### PR TITLE
Add tx pool to firehose block

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/ElrondNetwork/elastic-indexer-go v1.3.3
-	github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221215140953-889ae4c74255
+	github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221221125809-662924974348
 	github.com/ElrondNetwork/elrond-go-crypto v1.2.2
 	github.com/ElrondNetwork/elrond-go-logger v1.0.10
 	github.com/ElrondNetwork/elrond-go-p2p v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/ElrondNetwork/concurrent-map v0.1.3/go.mod h1:3XwSwn4JHI0lrKxWLZvtp53
 github.com/ElrondNetwork/elastic-indexer-go v1.3.3 h1:RgJ043yt92PUWMbSAQHRrC+GiyNnFdwdM/kseHlpLoo=
 github.com/ElrondNetwork/elastic-indexer-go v1.3.3/go.mod h1:E3VO5712GkGSGYnOTJ+0wxW74JXgjV6XCRPlcHiTTK0=
 github.com/ElrondNetwork/elrond-go-core v1.1.26/go.mod h1:N/RI++YU2M6OlnD1GSZepc1wPhI84ykRDQ1IyD3B0wk=
-github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221215140953-889ae4c74255 h1:p/jhYM8rrA9mwiXPqlBDO9CDWpAvCjOuzk4Hvts1Qu0=
-github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221215140953-889ae4c74255/go.mod h1:N/RI++YU2M6OlnD1GSZepc1wPhI84ykRDQ1IyD3B0wk=
+github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221221125809-662924974348 h1:XKMtPmipsLjN0kMzzbJtcNQd9Z5p4OnT7rqRnMxpA8k=
+github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221221125809-662924974348/go.mod h1:N/RI++YU2M6OlnD1GSZepc1wPhI84ykRDQ1IyD3B0wk=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.2 h1:Q59dZUeyibuskq5vjgk3ng/87ifOcd9YZMTnlYJAuIU=
 github.com/ElrondNetwork/elrond-go-crypto v1.2.2/go.mod h1:MyQPKUKti7Axnx/eihhL0F2jLTalvSV/Ytv1mIxvYyM=
 github.com/ElrondNetwork/elrond-go-logger v1.0.10 h1:2xQOWZErcHW5sl9qSRO+7mGNw+QhFhqiUlLLtOgvuuk=

--- a/outport/firehose/errors.go
+++ b/outport/firehose/errors.go
@@ -17,3 +17,5 @@ var errCannotCastReward = errors.New("cannot cast reward transaction")
 var errCannotCastReceipt = errors.New("cannot cast receipt transaction")
 
 var errCannotCastEvent = errors.New("cannot cast event")
+
+var errNilTxPool = errors.New("received nil transaction pool")

--- a/outport/firehose/errors.go
+++ b/outport/firehose/errors.go
@@ -12,7 +12,7 @@ var errCannotCastTransaction = errors.New("cannot cast transaction")
 
 var errCannotCastSCR = errors.New("cannot cast smart contract result")
 
-var errCannotCastRewards = errors.New("cannot cast reward transaction")
+var errCannotCastReward = errors.New("cannot cast reward transaction")
 
 var errCannotCastReceipt = errors.New("cannot cast receipt transaction")
 

--- a/outport/firehose/errors.go
+++ b/outport/firehose/errors.go
@@ -7,3 +7,13 @@ var errNilWriter = errors.New("nil writer provided")
 var errNilHeader = errors.New("received nil header")
 
 var errInvalidHeaderType = errors.New("received invalid/unknown header type")
+
+var errCannotCastTransaction = errors.New("cannot cast transaction")
+
+var errCannotCastSCR = errors.New("cannot cast smart contract result")
+
+var errCannotCastRewards = errors.New("cannot cast reward transaction")
+
+var errCannotCastReceipt = errors.New("cannot cast receipt transaction")
+
+var errCannotCastEvent = errors.New("cannot cast event")

--- a/outport/firehose/firehoseIndexer.go
+++ b/outport/firehose/firehoseIndexer.go
@@ -11,9 +11,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/firehose"
 	outportcore "github.com/ElrondNetwork/elrond-go-core/data/outport"
-	"github.com/ElrondNetwork/elrond-go-core/data/receipt"
-	"github.com/ElrondNetwork/elrond-go-core/data/rewardTx"
-	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/outport"
@@ -26,15 +23,6 @@ const (
 	beginBlockPrefix = "BLOCK_BEGIN"
 	endBlockPrefix   = "BLOCK_END"
 )
-
-type txPool struct {
-	transactions        map[string]*firehose.TxWithFee
-	smartContractResult map[string]*firehose.SCRWithFee
-	rewards             map[string]*rewardTx.RewardTx
-	receipts            map[string]*receipt.Receipt
-	invalidTxs          map[string]*firehose.TxWithFee
-	logs                []*transaction.Log
-}
 
 type firehoseIndexer struct {
 	writer     io.Writer

--- a/outport/firehose/firehoseIndexer.go
+++ b/outport/firehose/firehoseIndexer.go
@@ -65,7 +65,7 @@ func (fi *firehoseIndexer) SaveBlock(args *outportcore.ArgsSaveBlockData) error 
 
 	pool, err := getTxPool(args.TransactionsPool)
 	if err != nil {
-		return err
+		return fmt.Errorf("getTxPool error: %w, header hash %s", err, hex.EncodeToString(args.HeaderHash))
 	}
 
 	firehoseBlock := &firehose.FirehoseBlock{

--- a/outport/firehose/firehoseIndexerTxPool.go
+++ b/outport/firehose/firehoseIndexerTxPool.go
@@ -23,7 +23,7 @@ type txPool struct {
 
 func getTxPool(transactionsPool *outportcore.Pool) (*txPool, error) {
 	if transactionsPool == nil {
-		return &txPool{}, nil
+		return nil, errNilTxPool
 	}
 
 	txs, err := getTxs(transactionsPool.Txs)

--- a/outport/firehose/firehoseIndexerTxPool.go
+++ b/outport/firehose/firehoseIndexerTxPool.go
@@ -61,7 +61,7 @@ func getTxPool(transactionsPool *outportcore.Pool) (*txPool, error) {
 	}, nil
 }
 
-func getFirehoseFreeInfo(txHandler data.TransactionHandlerWithGasUsedAndFee) *firehose.FeeInfo {
+func getFirehoseFeeInfo(txHandler data.TransactionHandlerWithGasUsedAndFee) *firehose.FeeInfo {
 	return &firehose.FeeInfo{
 		GasUsed:        txHandler.GetGasUsed(),
 		Fee:            txHandler.GetFee(),
@@ -80,7 +80,7 @@ func getTxs(txs map[string]data.TransactionHandlerWithGasUsedAndFee) (map[string
 
 		ret[txHash] = &firehose.TxWithFee{
 			Transaction: tx,
-			FeeInfo:     getFirehoseFreeInfo(txHandler),
+			FeeInfo:     getFirehoseFeeInfo(txHandler),
 		}
 	}
 
@@ -98,7 +98,7 @@ func getScrs(scrs map[string]data.TransactionHandlerWithGasUsedAndFee) (map[stri
 
 		ret[scrHash] = &firehose.SCRWithFee{
 			SmartContractResult: tx,
-			FeeInfo:             getFirehoseFreeInfo(txHandler),
+			FeeInfo:             getFirehoseFeeInfo(txHandler),
 		}
 	}
 

--- a/outport/firehose/firehoseIndexerTxPool.go
+++ b/outport/firehose/firehoseIndexerTxPool.go
@@ -1,0 +1,155 @@
+package firehose
+
+import (
+	"fmt"
+
+	"github.com/ElrondNetwork/elrond-go-core/data"
+	"github.com/ElrondNetwork/elrond-go-core/data/firehose"
+	outportcore "github.com/ElrondNetwork/elrond-go-core/data/outport"
+	"github.com/ElrondNetwork/elrond-go-core/data/receipt"
+	"github.com/ElrondNetwork/elrond-go-core/data/rewardTx"
+	"github.com/ElrondNetwork/elrond-go-core/data/smartContractResult"
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
+)
+
+func getTxPool(transactionsPool *outportcore.Pool) (*txPool, error) {
+	if transactionsPool == nil {
+		return &txPool{}, nil
+	}
+
+	txs, err := getTxs(transactionsPool.Txs)
+	if err != nil {
+		return nil, err
+	}
+	scrs, err := getScrs(transactionsPool.Scrs)
+	if err != nil {
+		return nil, err
+	}
+	rewards, err := getRewards(transactionsPool.Rewards)
+	if err != nil {
+		return nil, err
+	}
+	receipts, err := getReceipts(transactionsPool.Receipts)
+	if err != nil {
+		return nil, err
+	}
+	logs, err := getLogs(transactionsPool.Logs)
+	if err != nil {
+		return nil, err
+	}
+	invalidTxs, err := getTxs(transactionsPool.Invalid)
+	if err != nil {
+		return nil, err
+	}
+
+	return &txPool{
+		transactions:        txs,
+		smartContractResult: scrs,
+		rewards:             rewards,
+		receipts:            receipts,
+		invalidTxs:          invalidTxs,
+		logs:                logs,
+	}, nil
+}
+
+func getTxs(txs map[string]data.TransactionHandlerWithGasUsedAndFee) (map[string]*firehose.TxWithFee, error) {
+	ret := make(map[string]*firehose.TxWithFee, len(txs))
+
+	for txHash, txHandler := range txs {
+		tx, castOk := txHandler.GetTxHandler().(*transaction.Transaction)
+		if !castOk {
+			return nil, fmt.Errorf("%w, hash: %s", errCannotCastTransaction, txHash)
+		}
+
+		ret[txHash] = &firehose.TxWithFee{
+			Transaction: tx,
+			FeeInfo:     getFirehoseFreeInfo(txHandler),
+		}
+	}
+
+	return ret, nil
+}
+
+func getScrs(scrs map[string]data.TransactionHandlerWithGasUsedAndFee) (map[string]*firehose.SCRWithFee, error) {
+	ret := make(map[string]*firehose.SCRWithFee, len(scrs))
+
+	for scrHash, txHandler := range scrs {
+		tx, castOk := txHandler.GetTxHandler().(*smartContractResult.SmartContractResult)
+		if !castOk {
+			return nil, fmt.Errorf("%w, hash: %s", errCannotCastSCR, scrHash)
+		}
+
+		ret[scrHash] = &firehose.SCRWithFee{
+			SmartContractResult: tx,
+			FeeInfo:             getFirehoseFreeInfo(txHandler),
+		}
+	}
+
+	return ret, nil
+}
+
+func getRewards(rewards map[string]data.TransactionHandlerWithGasUsedAndFee) (map[string]*rewardTx.RewardTx, error) {
+	ret := make(map[string]*rewardTx.RewardTx, len(rewards))
+	for hash, txHandler := range rewards {
+		tx, castOk := txHandler.GetTxHandler().(*rewardTx.RewardTx)
+		if !castOk {
+			return nil, fmt.Errorf("%w, hash: %s", errCannotCastRewards, hash)
+		}
+
+		ret[hash] = tx
+	}
+	return ret, nil
+}
+
+func getReceipts(receipts map[string]data.TransactionHandlerWithGasUsedAndFee) (map[string]*receipt.Receipt, error) {
+	ret := make(map[string]*receipt.Receipt, len(receipts))
+	for hash, receiptHandler := range receipts {
+		tx, castOk := receiptHandler.GetTxHandler().(*receipt.Receipt)
+		if !castOk {
+			return nil, fmt.Errorf("%w, hash: %s", errCannotCastReceipt, hash)
+		}
+
+		ret[hash] = tx
+	}
+	return ret, nil
+}
+
+func getLogs(logs []*data.LogData) ([]*transaction.Log, error) {
+	ret := make([]*transaction.Log, len(logs))
+	for idx, logHandler := range logs {
+		eventHandlers := logHandler.GetLogEvents()
+		events, err := getEvents(eventHandlers)
+		if err != nil {
+			return nil, fmt.Errorf("%w, hash: %s", err, logHandler.TxHash)
+		}
+
+		ret[idx] = &transaction.Log{
+			Address: logHandler.GetAddress(),
+			Events:  events,
+		}
+	}
+	return ret, nil
+}
+
+func getEvents(eventHandlers []data.EventHandler) ([]*transaction.Event, error) {
+	events := make([]*transaction.Event, len(eventHandlers))
+
+	for idx, eventHandler := range eventHandlers {
+		event, castOk := eventHandler.(*transaction.Event)
+		if !castOk {
+			return nil, errCannotCastEvent
+		}
+
+		events[idx] = event
+	}
+
+	return events, nil
+}
+
+func getFirehoseFreeInfo(txHandler data.TransactionHandlerWithGasUsedAndFee) *firehose.FeeInfo {
+	return &firehose.FeeInfo{
+		GasUsed:        txHandler.GetGasUsed(),
+		Fee:            txHandler.GetFee(),
+		InitialPaidFee: txHandler.GetInitialPaidFee(),
+	}
+}

--- a/outport/firehose/firehoseIndexerTxPool_test.go
+++ b/outport/firehose/firehoseIndexerTxPool_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
@@ -19,6 +20,22 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/stretchr/testify/require"
 )
+
+func TestFirehoseIndexer_SaveBlockNilTxPool(t *testing.T) {
+	t.Parallel()
+
+	fi, _ := NewFirehoseIndexer(&testscommon.IoWriterStub{})
+
+	headerHash := []byte("hash")
+	argsSaveBlock := &outportcore.ArgsSaveBlockData{
+		HeaderHash:       headerHash,
+		Header:           &block.Header{},
+		TransactionsPool: nil,
+	}
+	err := fi.SaveBlock(argsSaveBlock)
+	require.True(t, strings.Contains(err.Error(), errNilTxPool.Error()))
+	require.True(t, strings.Contains(err.Error(), hex.EncodeToString(headerHash)))
+}
 
 func TestFirehoseIndexer_SaveBlockTxPool(t *testing.T) {
 	t.Parallel()

--- a/outport/firehose/firehoseIndexerTxPool_test.go
+++ b/outport/firehose/firehoseIndexerTxPool_test.go
@@ -1,0 +1,123 @@
+package firehose
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/data"
+	"github.com/ElrondNetwork/elrond-go-core/data/block"
+	"github.com/ElrondNetwork/elrond-go-core/data/firehose"
+	outportcore "github.com/ElrondNetwork/elrond-go-core/data/outport"
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFirehoseIndexer_SaveBlockTxPool(t *testing.T) {
+	t.Parallel()
+
+	protoMarshaller := &marshal.GogoProtoMarshalizer{}
+
+	shardHeaderV1 := &block.Header{
+		Nonce:     2,
+		PrevHash:  []byte("prevHashV1"),
+		TimeStamp: 200,
+	}
+	marshalledHeader, err := protoMarshaller.Marshal(shardHeaderV1)
+	require.Nil(t, err)
+
+	headerHashShardV1 := []byte("headerHashShardV1")
+
+	txs := []*outportcore.TransactionHandlerWithGasAndFee{
+		{
+			FeeInfo: outportcore.FeeInfo{
+				GasUsed:        100,
+				Fee:            big.NewInt(100),
+				InitialPaidFee: big.NewInt(200),
+			},
+			TransactionHandler: &transaction.Transaction{
+				Nonce: 1,
+				Data:  []byte("data1"),
+			},
+		},
+		{
+			FeeInfo: outportcore.FeeInfo{
+				GasUsed:        220,
+				Fee:            big.NewInt(340),
+				InitialPaidFee: big.NewInt(500),
+			},
+			TransactionHandler: &transaction.Transaction{
+				Nonce: 2,
+				Data:  []byte("data2"),
+			},
+		},
+	}
+	argsSaveBlock := &outportcore.ArgsSaveBlockData{
+		HeaderHash: headerHashShardV1,
+		Header:     shardHeaderV1,
+		TransactionsPool: &outportcore.Pool{
+			Txs: map[string]data.TransactionHandlerWithGasUsedAndFee{
+				"txHash1": txs[0],
+				"txHash2": txs[1],
+			},
+			Scrs:     nil,
+			Rewards:  nil,
+			Invalid:  nil,
+			Receipts: nil,
+			Logs:     nil,
+		},
+	}
+
+	firehoseBlock := &firehose.FirehoseBlock{
+		HeaderHash:  headerHashShardV1,
+		HeaderType:  string(core.ShardHeaderV1),
+		HeaderBytes: marshalledHeader,
+		Transactions: map[string]*firehose.TxWithFee{
+			"txHash1": {
+				Transaction: txs[0].TransactionHandler.(*transaction.Transaction),
+				FeeInfo: &firehose.FeeInfo{
+					GasUsed:        txs[0].GasUsed,
+					Fee:            txs[0].Fee,
+					InitialPaidFee: txs[0].InitialPaidFee,
+				},
+			},
+			"txHash2": {
+				Transaction: txs[1].TransactionHandler.(*transaction.Transaction),
+				FeeInfo: &firehose.FeeInfo{
+					GasUsed:        txs[1].GasUsed,
+					Fee:            txs[1].Fee,
+					InitialPaidFee: txs[1].InitialPaidFee,
+				},
+			},
+		},
+	}
+	marshalledFirehoseBlock, err := protoMarshaller.Marshal(firehoseBlock)
+	require.Nil(t, err)
+
+	ioWriterCalledCt := 0
+	ioWriter := &testscommon.IoWriterStub{
+		WriteCalled: func(p []byte) (n int, err error) {
+			ioWriterCalledCt++
+			switch ioWriterCalledCt {
+			case 1:
+				require.Equal(t, []byte("FIRE BLOCK_BEGIN 2\n"), p)
+			case 2:
+
+				require.Equal(t, []byte(fmt.Sprintf("FIRE BLOCK_END 2 %s 200 %x\n",
+					hex.EncodeToString(shardHeaderV1.PrevHash),
+					marshalledFirehoseBlock)), p)
+			default:
+				require.Fail(t, "should not write again")
+			}
+			return 0, nil
+		},
+	}
+
+	fi, _ := NewFirehoseIndexer(ioWriter)
+	err = fi.SaveBlock(argsSaveBlock)
+	require.Nil(t, err)
+}

--- a/outport/firehose/firehoseIndexer_test.go
+++ b/outport/firehose/firehoseIndexer_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFirehoseIndexer_SaveBlock(t *testing.T) {
+func TestFirehoseIndexer_SaveBlockHeader(t *testing.T) {
 	t.Parallel()
 
 	protoMarshaller := &marshal.GogoProtoMarshalizer{}

--- a/outport/firehose/firehoseIndexer_test.go
+++ b/outport/firehose/firehoseIndexer_test.go
@@ -14,6 +14,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewFirehoseIndexer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil io writer, should return error", func(t *testing.T) {
+		t.Parallel()
+
+		fi, err := NewFirehoseIndexer(nil)
+		require.Nil(t, fi)
+		require.Equal(t, errNilWriter, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		fi, err := NewFirehoseIndexer(&testscommon.IoWriterStub{})
+		require.Nil(t, err)
+		require.NotNil(t, fi)
+	})
+}
+
 func TestFirehoseIndexer_SaveBlockHeader(t *testing.T) {
 	t.Parallel()
 
@@ -62,7 +82,6 @@ func TestFirehoseIndexer_SaveBlockHeader(t *testing.T) {
 				case 1:
 					require.Equal(t, []byte("FIRE BLOCK_BEGIN 1\n"), p)
 				case 2:
-
 					require.Equal(t, []byte(fmt.Sprintf("FIRE BLOCK_END 1 %s 100 %x\n",
 						hex.EncodeToString(metaBlockHeader.PrevHash),
 						marshalledFirehoseBlock)), p)
@@ -74,7 +93,11 @@ func TestFirehoseIndexer_SaveBlockHeader(t *testing.T) {
 		}
 
 		fi, _ := NewFirehoseIndexer(ioWriter)
-		err = fi.SaveBlock(&outportcore.ArgsSaveBlockData{HeaderHash: headerHashMeta, Header: metaBlockHeader})
+		err = fi.SaveBlock(&outportcore.ArgsSaveBlockData{
+			HeaderHash:       headerHashMeta,
+			Header:           metaBlockHeader,
+			TransactionsPool: &outportcore.Pool{},
+		})
 		require.Nil(t, err)
 	})
 
@@ -106,7 +129,6 @@ func TestFirehoseIndexer_SaveBlockHeader(t *testing.T) {
 				case 1:
 					require.Equal(t, []byte("FIRE BLOCK_BEGIN 2\n"), p)
 				case 2:
-
 					require.Equal(t, []byte(fmt.Sprintf("FIRE BLOCK_END 2 %s 200 %x\n",
 						hex.EncodeToString(shardHeaderV1.PrevHash),
 						marshalledFirehoseBlock)), p)
@@ -118,7 +140,11 @@ func TestFirehoseIndexer_SaveBlockHeader(t *testing.T) {
 		}
 
 		fi, _ := NewFirehoseIndexer(ioWriter)
-		err = fi.SaveBlock(&outportcore.ArgsSaveBlockData{HeaderHash: headerHashShardV1, Header: shardHeaderV1})
+		err = fi.SaveBlock(&outportcore.ArgsSaveBlockData{
+			HeaderHash:       headerHashShardV1,
+			Header:           shardHeaderV1,
+			TransactionsPool: &outportcore.Pool{},
+		})
 		require.Nil(t, err)
 	})
 
@@ -152,7 +178,6 @@ func TestFirehoseIndexer_SaveBlockHeader(t *testing.T) {
 				case 1:
 					require.Equal(t, []byte("FIRE BLOCK_BEGIN 3\n"), p)
 				case 2:
-
 					require.Equal(t, []byte(fmt.Sprintf("FIRE BLOCK_END 3 %s 300 %x\n",
 						hex.EncodeToString(shardHeaderV2.Header.PrevHash),
 						marshalledFirehoseBlock)), p)
@@ -164,7 +189,11 @@ func TestFirehoseIndexer_SaveBlockHeader(t *testing.T) {
 		}
 
 		fi, _ := NewFirehoseIndexer(ioWriter)
-		err = fi.SaveBlock(&outportcore.ArgsSaveBlockData{HeaderHash: headerHashShardV2, Header: shardHeaderV2})
+		err = fi.SaveBlock(&outportcore.ArgsSaveBlockData{
+			HeaderHash:       headerHashShardV2,
+			Header:           shardHeaderV2,
+			TransactionsPool: &outportcore.Pool{},
+		})
 		require.Nil(t, err)
 	})
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- Include tx pool in firehose block

## Proposed changes
- Add support to parse tx pool and convert each interface to its proto message

## Testing procedure
- Local testnet + firehose ingestion process + tools to check firehose ingested blocks

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/ElrondNetwork/elrond-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
