### PR TITLE
fix path for generating proto schema

### DIFF
--- a/testscommon/state/userAccountStub.go
+++ b/testscommon/state/userAccountStub.go
@@ -1,4 +1,4 @@
-//go:generate protoc -I=proto -I=$GOPATH/src -I=$GOPATH/src/github.com/multiversx/protobuf/protobuf  --gogoslick_out=. proto/accountWrapperMock.proto
+//go:generate protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/multiversx/protobuf/protobuf  --gogoslick_out=. accountWrapperMock.proto
 package state
 
 import (


### PR DESCRIPTION
## Reasoning behind the pull request
- generating schema from proto not working due to invalid path
  
## Proposed changes
- fix included path in generator

## Testing procedure
- generate schemas, no error should be reported

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
