### PR TITLE
Fix termui node URL

### DIFF
--- a/cmd/termui/provider/metricsProvider.go
+++ b/cmd/termui/provider/metricsProvider.go
@@ -124,8 +124,8 @@ func (smp *StatusMetricsProvider) setPresenterValue(key string, value interface{
 }
 
 func formatUrlAddress(address string) string {
-	httpPrefix := "https://"
-	if !strings.HasPrefix(address, httpPrefix) {
+	httpPrefix := "http://"
+	if !strings.HasPrefix(address, "http") {
 		address = httpPrefix + address
 	}
 


### PR DESCRIPTION
## Reasoning behind the pull request
- nodes without `https` would have not worked for termui
  
## Proposed changes
- allow both `http` and `https`

## Testing procedure
- start a termui instance built from the `rc/v1.4.0` branch - should **not** load upper data (node name, pub key, and so on)
- start a termui instance built from this branch -  - **should** load upper data (node name, pub key, and so on)

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
