### PR TITLE
DB lookup extension enabled for observers running on local testnets

### DIFF
--- a/scripts/testnet/variables.sh
+++ b/scripts/testnet/variables.sh
@@ -159,7 +159,7 @@ let "total_observer_count = $SHARD_OBSERVERCOUNT * $SHARDCOUNT + $META_OBSERVERC
 export TOTAL_OBSERVERCOUNT=$total_observer_count
 
 # to enable the full archive feature on the observers, please use the --full-archive flag
-export EXTRA_OBSERVERS_FLAGS=""
+export EXTRA_OBSERVERS_FLAGS="-operation-mode db-lookup-extension"
 
 # Leave unchanged.
 let "total_node_count = $SHARD_VALIDATORCOUNT * $SHARDCOUNT + $META_VALIDATORCOUNT + $TOTAL_OBSERVERCOUNT"


### PR DESCRIPTION
## Reasoning behind the pull request
- when running the internal testnets, the observers were not running with the DB lookup extension. It is useful to have them running with the DB lookup extension for testing & debugging purposes  
  
## Proposed changes
- set default DbLookupExtensions.Enabled = true on observers that are running using the internal testnet scripts

## Testing procedure
- start a local system testnet, the observers should be started in db-lookup-extension mode:
Logs like this one will appear:
```
WARN [2023-01-30 12:15:19.361] [main]               [/0/0/]        the node is in DB lookup extension mode! Will auto-set some config values DbLookupExtensions.Enabled = true 
```

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
