### PR TITLE
Use hex encoded hash in txs maps

### DIFF
--- a/outport/firehose/firehoseIndexerTxPool.go
+++ b/outport/firehose/firehoseIndexerTxPool.go
@@ -1,6 +1,7 @@
 package firehose
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	"github.com/multiversx/mx-chain-core-go/data"
@@ -78,7 +79,8 @@ func getTxs(txs map[string]data.TransactionHandlerWithGasUsedAndFee) (map[string
 			return nil, fmt.Errorf("%w, hash: %s", errCannotCastTransaction, txHash)
 		}
 
-		ret[txHash] = &firehose.TxInfo{
+		txHashHex := getHexEncodedHash(txHash)
+		ret[txHashHex] = &firehose.TxInfo{
 			Transaction:    tx,
 			FeeInfo:        getFirehoseFeeInfo(txHandler),
 			ExecutionOrder: uint32(txHandler.GetExecutionOrder()),
@@ -86,6 +88,11 @@ func getTxs(txs map[string]data.TransactionHandlerWithGasUsedAndFee) (map[string
 	}
 
 	return ret, nil
+}
+
+func getHexEncodedHash(txHash string) string {
+	txHashBytes := []byte(txHash)
+	return hex.EncodeToString(txHashBytes)
 }
 
 func getScrs(scrs map[string]data.TransactionHandlerWithGasUsedAndFee) (map[string]*firehose.SCRInfo, error) {
@@ -97,7 +104,8 @@ func getScrs(scrs map[string]data.TransactionHandlerWithGasUsedAndFee) (map[stri
 			return nil, fmt.Errorf("%w, hash: %s", errCannotCastSCR, scrHash)
 		}
 
-		ret[scrHash] = &firehose.SCRInfo{
+		scrHashHex := getHexEncodedHash(scrHash)
+		ret[scrHashHex] = &firehose.SCRInfo{
 			SmartContractResult: tx,
 			FeeInfo:             getFirehoseFeeInfo(txHandler),
 			ExecutionOrder:      uint32(txHandler.GetExecutionOrder()),
@@ -116,7 +124,8 @@ func getRewards(rewards map[string]data.TransactionHandlerWithGasUsedAndFee) (ma
 			return nil, fmt.Errorf("%w, hash: %s", errCannotCastReward, hash)
 		}
 
-		ret[hash] = &firehose.RewardInfo{
+		hexHex := getHexEncodedHash(hash)
+		ret[hexHex] = &firehose.RewardInfo{
 			Reward:         reward,
 			ExecutionOrder: uint32(txHandler.GetExecutionOrder()),
 		}
@@ -134,7 +143,8 @@ func getReceipts(receipts map[string]data.TransactionHandlerWithGasUsedAndFee) (
 			return nil, fmt.Errorf("%w, hash: %s", errCannotCastReceipt, hash)
 		}
 
-		ret[hash] = tx
+		hashHex := getHexEncodedHash(hash)
+		ret[hashHex] = tx
 	}
 
 	return ret, nil
@@ -150,7 +160,8 @@ func getLogs(logs []*data.LogData) (map[string]*transaction.Log, error) {
 			return nil, fmt.Errorf("%w, hash: %s", err, logHandler.TxHash)
 		}
 
-		ret[logHandler.TxHash] = &transaction.Log{
+		txHashHex := getHexEncodedHash(logHandler.TxHash)
+		ret[txHashHex] = &transaction.Log{
 			Address: logHandler.GetAddress(),
 			Events:  events,
 		}

--- a/outport/firehose/firehoseIndexerTxPool.go
+++ b/outport/firehose/firehoseIndexerTxPool.go
@@ -75,11 +75,11 @@ func getTxs(txs map[string]data.TransactionHandlerWithGasUsedAndFee) (map[string
 
 	for txHash, txHandler := range txs {
 		tx, castOk := txHandler.GetTxHandler().(*transaction.Transaction)
+		txHashHex := getHexEncodedHash(txHash)
 		if !castOk {
-			return nil, fmt.Errorf("%w, hash: %s", errCannotCastTransaction, txHash)
+			return nil, fmt.Errorf("%w, hash: %s", errCannotCastTransaction, txHashHex)
 		}
 
-		txHashHex := getHexEncodedHash(txHash)
 		ret[txHashHex] = &firehose.TxInfo{
 			Transaction:    tx,
 			FeeInfo:        getFirehoseFeeInfo(txHandler),
@@ -100,11 +100,11 @@ func getScrs(scrs map[string]data.TransactionHandlerWithGasUsedAndFee) (map[stri
 
 	for scrHash, txHandler := range scrs {
 		tx, castOk := txHandler.GetTxHandler().(*smartContractResult.SmartContractResult)
+		scrHashHex := getHexEncodedHash(scrHash)
 		if !castOk {
-			return nil, fmt.Errorf("%w, hash: %s", errCannotCastSCR, scrHash)
+			return nil, fmt.Errorf("%w, hash: %s", errCannotCastSCR, scrHashHex)
 		}
 
-		scrHashHex := getHexEncodedHash(scrHash)
 		ret[scrHashHex] = &firehose.SCRInfo{
 			SmartContractResult: tx,
 			FeeInfo:             getFirehoseFeeInfo(txHandler),
@@ -120,11 +120,11 @@ func getRewards(rewards map[string]data.TransactionHandlerWithGasUsedAndFee) (ma
 
 	for hash, txHandler := range rewards {
 		reward, castOk := txHandler.GetTxHandler().(*rewardTx.RewardTx)
+		hexHex := getHexEncodedHash(hash)
 		if !castOk {
-			return nil, fmt.Errorf("%w, hash: %s", errCannotCastReward, hash)
+			return nil, fmt.Errorf("%w, hash: %s", errCannotCastReward, hexHex)
 		}
 
-		hexHex := getHexEncodedHash(hash)
 		ret[hexHex] = &firehose.RewardInfo{
 			Reward:         reward,
 			ExecutionOrder: uint32(txHandler.GetExecutionOrder()),
@@ -139,11 +139,11 @@ func getReceipts(receipts map[string]data.TransactionHandlerWithGasUsedAndFee) (
 
 	for hash, receiptHandler := range receipts {
 		tx, castOk := receiptHandler.GetTxHandler().(*receipt.Receipt)
+		hashHex := getHexEncodedHash(hash)
 		if !castOk {
-			return nil, fmt.Errorf("%w, hash: %s", errCannotCastReceipt, hash)
+			return nil, fmt.Errorf("%w, hash: %s", errCannotCastReceipt, hashHex)
 		}
 
-		hashHex := getHexEncodedHash(hash)
 		ret[hashHex] = tx
 	}
 
@@ -156,11 +156,11 @@ func getLogs(logs []*data.LogData) (map[string]*transaction.Log, error) {
 	for _, logHandler := range logs {
 		eventHandlers := logHandler.GetLogEvents()
 		events, err := getEvents(eventHandlers)
+		txHashHex := getHexEncodedHash(logHandler.TxHash)
 		if err != nil {
-			return nil, fmt.Errorf("%w, hash: %s", err, logHandler.TxHash)
+			return nil, fmt.Errorf("%w, hash: %s", err, txHashHex)
 		}
 
-		txHashHex := getHexEncodedHash(logHandler.TxHash)
 		ret[txHashHex] = &transaction.Log{
 			Address: logHandler.GetAddress(),
 			Events:  events,

--- a/outport/firehose/firehoseIndexerTxPool_test.go
+++ b/outport/firehose/firehoseIndexerTxPool_test.go
@@ -181,7 +181,7 @@ func TestFirehoseIndexer_SaveBlockTxPool(t *testing.T) {
 		HeaderType:  string(core.ShardHeaderV1),
 		HeaderBytes: marshalledHeader,
 		Transactions: map[string]*firehose.TxInfo{
-			"txHash1": {
+			hex.EncodeToString([]byte("txHash1")): {
 				Transaction: txs[0].TransactionHandler.(*transaction.Transaction),
 				FeeInfo: &firehose.FeeInfo{
 					GasUsed:        txs[0].GasUsed,
@@ -190,7 +190,7 @@ func TestFirehoseIndexer_SaveBlockTxPool(t *testing.T) {
 				},
 				ExecutionOrder: 1,
 			},
-			"txHash2": {
+			hex.EncodeToString([]byte("txHash2")): {
 				Transaction: txs[1].TransactionHandler.(*transaction.Transaction),
 				FeeInfo: &firehose.FeeInfo{
 					GasUsed:        txs[1].GasUsed,
@@ -201,7 +201,7 @@ func TestFirehoseIndexer_SaveBlockTxPool(t *testing.T) {
 			},
 		},
 		SmartContractResults: map[string]*firehose.SCRInfo{
-			"txHash3": {
+			hex.EncodeToString([]byte("txHash3")): {
 				SmartContractResult: scrs[0].TransactionHandler.(*smartContractResult.SmartContractResult),
 				FeeInfo: &firehose.FeeInfo{
 					GasUsed:        scrs[0].GasUsed,
@@ -212,13 +212,13 @@ func TestFirehoseIndexer_SaveBlockTxPool(t *testing.T) {
 			},
 		},
 		Rewards: map[string]*firehose.RewardInfo{
-			"txHash4": {
+			hex.EncodeToString([]byte("txHash4")): {
 				Reward:         rewards[0].TransactionHandler.(*rewardTx.RewardTx),
 				ExecutionOrder: 4,
 			},
 		},
 		InvalidTxs: map[string]*firehose.TxInfo{
-			"txHash5": {
+			hex.EncodeToString([]byte("txHash5")): {
 				Transaction: invalidTxs[0].TransactionHandler.(*transaction.Transaction),
 				FeeInfo: &firehose.FeeInfo{
 					GasUsed:        invalidTxs[0].GasUsed,
@@ -229,11 +229,11 @@ func TestFirehoseIndexer_SaveBlockTxPool(t *testing.T) {
 			},
 		},
 		Receipts: map[string]*receipt.Receipt{
-			"txHash6": receipts[0].TransactionHandler.(*receipt.Receipt),
-			"txHash7": receipts[1].TransactionHandler.(*receipt.Receipt),
+			hex.EncodeToString([]byte("txHash6")): receipts[0].TransactionHandler.(*receipt.Receipt),
+			hex.EncodeToString([]byte("txHash7")): receipts[1].TransactionHandler.(*receipt.Receipt),
 		},
 		Logs: map[string]*transaction.Log{
-			"txHash8": logs[0].LogHandler.(*transaction.Log),
+			hex.EncodeToString([]byte("txHash8")): logs[0].LogHandler.(*transaction.Log),
 		},
 	}
 	marshalledFirehoseBlock, err := protoMarshaller.Marshal(firehoseBlock)


### PR DESCRIPTION
## Reasoning behind the pull request
- Tx pool contains a `map<string, tx>` fore each tx/scr/reward, etc. Each `string` **key**  in map is defined as `string([]byte(...))`, which result in non human readible strings when being indexed in firehose, such as: 

```
"Transactions": {
      "\ufffd\ufffd\u000eC\ufffd\ufffd\u001a\ufffd\ufffd\u000eZS!=\ufffd\ufffd\ufffdJ\ufffdaE\ufffd\ufffdE\\\ufffdm\ufffd\ufffd\ufffd\ufffd\ufffd": {
        "Transaction": {
          "nonce": 10,
```
  
## Proposed changes
- Refactor indexing process for each key string to be the hex encoded value of the hash. E.g.:

```
"Transactions": {
      "e8f86c78622c609913fd1a445d65a31dda2ae79ac73bc678c6069e7eacdaafc5": {
        "Transaction": {
          "nonce": 10,
```

## Testing procedure
- Firehose integration tests

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
