### PR TITLE
Extend transaction structure new fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/gops v0.3.18
 	github.com/gorilla/websocket v1.5.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/multiversx/mx-chain-core-go v1.1.30
+	github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130112045-8282a4bbbcfb
 	github.com/multiversx/mx-chain-crypto-go v1.2.5
 	github.com/multiversx/mx-chain-es-indexer-go v1.3.8
 	github.com/multiversx/mx-chain-logger-go v1.0.11

--- a/go.sum
+++ b/go.sum
@@ -595,8 +595,9 @@ github.com/multiformats/go-varint v0.0.6 h1:gk85QWKxh3TazbLxED/NlDVv8+q+ReFJk7Y2
 github.com/multiformats/go-varint v0.0.6/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUYwbO0993uPI=
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
-github.com/multiversx/mx-chain-core-go v1.1.30 h1:BtURR4I6HU1OnSbxcPMTQSQXNqtOuH3RW6bg5N7FSM0=
 github.com/multiversx/mx-chain-core-go v1.1.30/go.mod h1:8gGEQv6BWuuJwhd25qqhCOZbBSv9mk+hLeKvinSaSMk=
+github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130112045-8282a4bbbcfb h1:CSTS/pPfPS6utt473/9zWJraL/onUwwmZMZWY7QAG0w=
+github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130112045-8282a4bbbcfb/go.mod h1:8gGEQv6BWuuJwhd25qqhCOZbBSv9mk+hLeKvinSaSMk=
 github.com/multiversx/mx-chain-crypto-go v1.2.5 h1:tuq3BUNMhKud5DQbZi9DiVAAHUXypizy8zPH0NpTGZk=
 github.com/multiversx/mx-chain-crypto-go v1.2.5/go.mod h1:teqhNyWEqfMPgNn8sgWXlgtJ1a36jGCnhs/tRpXW6r4=
 github.com/multiversx/mx-chain-es-indexer-go v1.3.8 h1:OvdOoBUQKkTaZsFPiBp1WCvDRN9ReQJUfy9Ac06rguM=

--- a/node/external/timemachine/fee/feeComputer.go
+++ b/node/external/timemachine/fee/feeComputer.go
@@ -56,6 +56,39 @@ func NewFeeComputer(args ArgsNewFeeComputer) (*feeComputer, error) {
 	return computer, nil
 }
 
+// ComputeGasUsedAndFeeBasedOnRefundValue computes gas used and fee based on the refund value, at a given epoch
+func (computer *feeComputer) ComputeGasUsedAndFeeBasedOnRefundValue(tx *transaction.ApiTransactionResult, refundValue *big.Int) (uint64, *big.Int) {
+	instance, err := computer.getOrCreateInstance(tx.Epoch)
+	if err != nil {
+		log.Error("ComputeTransactionFee(): unexpected error when creating an economicsData instance", "epoch", tx.Epoch, "error", err)
+		return 0, big.NewInt(0)
+	}
+
+	return instance.ComputeGasUsedAndFeeBasedOnRefundValue(tx.Tx, refundValue)
+}
+
+// ComputeTxFeeBasedOnGasUsed computes fee based on gas used, at a given epoch
+func (computer *feeComputer) ComputeTxFeeBasedOnGasUsed(tx *transaction.ApiTransactionResult, gasUsed uint64) *big.Int {
+	instance, err := computer.getOrCreateInstance(tx.Epoch)
+	if err != nil {
+		log.Error("ComputeTransactionFee(): unexpected error when creating an economicsData instance", "epoch", tx.Epoch, "error", err)
+		return big.NewInt(0)
+	}
+
+	return instance.ComputeTxFeeBasedOnGasUsed(tx.Tx, gasUsed)
+}
+
+// ComputeGasLimit computes a transaction gas limit, at a given epoch
+func (computer *feeComputer) ComputeGasLimit(tx *transaction.ApiTransactionResult) uint64 {
+	instance, err := computer.getOrCreateInstance(tx.Epoch)
+	if err != nil {
+		log.Error("ComputeTransactionFee(): unexpected error when creating an economicsData instance", "epoch", tx.Epoch, "error", err)
+		return 0
+	}
+
+	return instance.ComputeGasLimit(tx.Tx)
+}
+
 // ComputeTransactionFee computes a transaction fee, at a given epoch
 func (computer *feeComputer) ComputeTransactionFee(tx *transaction.ApiTransactionResult) *big.Int {
 	instance, err := computer.getOrCreateInstance(tx.Epoch)

--- a/node/external/timemachine/fee/feeComputer.go
+++ b/node/external/timemachine/fee/feeComputer.go
@@ -60,7 +60,7 @@ func NewFeeComputer(args ArgsNewFeeComputer) (*feeComputer, error) {
 func (computer *feeComputer) ComputeGasUsedAndFeeBasedOnRefundValue(tx *transaction.ApiTransactionResult, refundValue *big.Int) (uint64, *big.Int) {
 	instance, err := computer.getOrCreateInstance(tx.Epoch)
 	if err != nil {
-		log.Error("ComputeTransactionFee(): unexpected error when creating an economicsData instance", "epoch", tx.Epoch, "error", err)
+		log.Error("ComputeGasUsedAndFeeBasedOnRefundValue(): unexpected error when creating an economicsData instance", "epoch", tx.Epoch, "error", err)
 		return 0, big.NewInt(0)
 	}
 
@@ -71,7 +71,7 @@ func (computer *feeComputer) ComputeGasUsedAndFeeBasedOnRefundValue(tx *transact
 func (computer *feeComputer) ComputeTxFeeBasedOnGasUsed(tx *transaction.ApiTransactionResult, gasUsed uint64) *big.Int {
 	instance, err := computer.getOrCreateInstance(tx.Epoch)
 	if err != nil {
-		log.Error("ComputeTransactionFee(): unexpected error when creating an economicsData instance", "epoch", tx.Epoch, "error", err)
+		log.Error("ComputeTxFeeBasedOnGasUsed(): unexpected error when creating an economicsData instance", "epoch", tx.Epoch, "error", err)
 		return big.NewInt(0)
 	}
 
@@ -82,7 +82,7 @@ func (computer *feeComputer) ComputeTxFeeBasedOnGasUsed(tx *transaction.ApiTrans
 func (computer *feeComputer) ComputeGasLimit(tx *transaction.ApiTransactionResult) uint64 {
 	instance, err := computer.getOrCreateInstance(tx.Epoch)
 	if err != nil {
-		log.Error("ComputeTransactionFee(): unexpected error when creating an economicsData instance", "epoch", tx.Epoch, "error", err)
+		log.Error("ComputeGasLimit(): unexpected error when creating an economicsData instance", "epoch", tx.Epoch, "error", err)
 		return 0
 	}
 

--- a/node/external/timemachine/fee/interface.go
+++ b/node/external/timemachine/fee/interface.go
@@ -8,4 +8,7 @@ import (
 
 type economicsDataWithComputeFee interface {
 	ComputeTxFee(tx data.TransactionWithFeeHandler) *big.Int
+	ComputeGasUsedAndFeeBasedOnRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int) (uint64, *big.Int)
+	ComputeTxFeeBasedOnGasUsed(tx data.TransactionWithFeeHandler, gasUsed uint64) *big.Int
+	ComputeGasLimit(tx data.TransactionWithFeeHandler) uint64
 }

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -41,6 +41,7 @@ type apiTransactionProcessor struct {
 	txUnmarshaller              *txUnmarshaller
 	transactionResultsProcessor *apiTransactionResultsProcessor
 	refundDetector              *refundDetector
+	gasUsedAndFeeProcessor      *gasUsedAndFeeProcessor
 }
 
 // NewAPITransactionProcessor will create a new instance of apiTransactionProcessor
@@ -63,6 +64,7 @@ func NewAPITransactionProcessor(args *ArgAPITransactionProcessor) (*apiTransacti
 	)
 
 	refundDetector := newRefundDetector()
+	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(args.FeeComputer)
 
 	return &apiTransactionProcessor{
 		roundDuration:               args.RoundDuration,
@@ -79,6 +81,7 @@ func NewAPITransactionProcessor(args *ArgAPITransactionProcessor) (*apiTransacti
 		txUnmarshaller:              txUnmarshalerAndPreparer,
 		transactionResultsProcessor: txResultsProc,
 		refundDetector:              refundDetector,
+		gasUsedAndFeeProcessor:      gasUsedAndFeeProc,
 	}, nil
 }
 
@@ -97,6 +100,7 @@ func (atp *apiTransactionProcessor) GetTransaction(txHash string, withResults bo
 
 	tx.Hash = txHash
 	atp.PopulateComputedFields(tx)
+	atp.gasUsedAndFeeProcessor.computeAndAttachGasUsedAndFee(tx)
 
 	return tx, nil
 }

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -484,6 +484,7 @@ func TestNode_GetTransactionWithResultsFromStorage(t *testing.T) {
 		},
 		InitiallyPaidFee: "1000",
 		Receivers:        []string{},
+		Fee:              "0",
 	}
 
 	apiTx, err := apiTransactionProc.GetTransaction(txHash, true)

--- a/node/external/transactionAPI/gasUsedAndFeeProcessor.go
+++ b/node/external/transactionAPI/gasUsedAndFeeProcessor.go
@@ -61,7 +61,7 @@ func (gfp *gasUsedAndFeeProcessor) prepareTxWithResultsBasedOnLogs(
 			continue
 		}
 		if core.SignalErrorOperation == event.Identifier {
-			fee := gfp.txFeeCalculator.ComputeTxFeeBasedOnGasUsed(tx, tx.Tx.GetGasLimit())
+			fee := gfp.txFeeCalculator.ComputeTxFeeBasedOnGasUsed(tx, tx.GasLimit)
 			tx.GasUsed = tx.GasLimit
 			tx.Fee = fee.String()
 		}

--- a/node/external/transactionAPI/gasUsedAndFeeProcessor.go
+++ b/node/external/transactionAPI/gasUsedAndFeeProcessor.go
@@ -1,0 +1,69 @@
+package transactionAPI
+
+import (
+	"math/big"
+
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/data/transaction"
+)
+
+type gasUsedAndFeeProcessor struct {
+	txFeeCalculator feeComputer
+}
+
+func newGasUsedAndFeeProcessor(txFeeCalculator feeComputer) *gasUsedAndFeeProcessor {
+	return &gasUsedAndFeeProcessor{
+		txFeeCalculator: txFeeCalculator,
+	}
+}
+
+func (gfp *gasUsedAndFeeProcessor) computeAndAttachGasUsedAndFee(tx *transaction.ApiTransactionResult) {
+	gasUsed := gfp.txFeeCalculator.ComputeGasLimit(tx)
+	fee := gfp.txFeeCalculator.ComputeTxFeeBasedOnGasUsed(tx, gasUsed)
+
+	tx.GasUsed = gasUsed
+	tx.Fee = fee.String()
+
+	if tx.IsRelayed {
+		tx.GasUsed = tx.GasLimit
+		tx.Fee = tx.InitiallyPaidFee
+	}
+
+	hasRefund := false
+	for _, scr := range tx.SmartContractResults {
+		if scr.IsRefund {
+			gasUsed, fee = gfp.txFeeCalculator.ComputeGasUsedAndFeeBasedOnRefundValue(tx, scr.Value)
+
+			tx.GasUsed = gasUsed
+			tx.Fee = fee.String()
+			hasRefund = true
+			break
+		}
+	}
+
+	gfp.prepareTxWithResultsBasedOnLogs(tx, hasRefund)
+}
+
+func (gfp *gasUsedAndFeeProcessor) prepareTxWithResultsBasedOnLogs(
+	tx *transaction.ApiTransactionResult,
+	hasRefund bool,
+) {
+	if tx.Logs == nil {
+		return
+	}
+
+	for _, event := range tx.Logs.Events {
+		if core.WriteLogIdentifier == event.Identifier && !hasRefund {
+			gasUsed, fee := gfp.txFeeCalculator.ComputeGasUsedAndFeeBasedOnRefundValue(tx, big.NewInt(0))
+			tx.GasUsed = gasUsed
+			tx.Fee = fee.String()
+
+			continue
+		}
+		if core.SignalErrorOperation == event.Identifier {
+			fee := gfp.txFeeCalculator.ComputeTxFeeBasedOnGasUsed(tx, tx.Tx.GetGasLimit())
+			tx.GasUsed = tx.GasLimit
+			tx.Fee = fee.String()
+		}
+	}
+}

--- a/node/external/transactionAPI/gasUsedAndFeeProcessor_test.go
+++ b/node/external/transactionAPI/gasUsedAndFeeProcessor_test.go
@@ -1,1 +1,168 @@
 package transactionAPI
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/core/pubkeyConverter"
+	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-go/node/external/timemachine/fee"
+	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/stretchr/testify/require"
+)
+
+var pubKeyConverter, _ = pubkeyConverter.NewBech32PubkeyConverter(32, log)
+
+func TestComputeTransactionGasUsedAndFeeMoveBalance(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	feeComp, _ := fee.NewFeeComputer(fee.ArgsNewFeeComputer{
+		BuiltInFunctionsCostHandler: &testscommon.BuiltInCostHandlerStub{},
+		EconomicsConfig:             testscommon.GetEconomicsConfig(),
+	})
+	computer := fee.NewTestFeeComputer(feeComp)
+
+	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(computer)
+
+	sender := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
+	receiver := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
+
+	moveBalanceTx := &transaction.ApiTransactionResult{
+		Tx: &transaction.Transaction{
+			GasLimit: 80_000,
+			GasPrice: 1000000000,
+			SndAddr:  silentDecodeAddress(sender),
+			RcvAddr:  silentDecodeAddress(receiver),
+		},
+	}
+
+	gasUsedAndFeeProc.computeAndAttachGasUsedAndFee(moveBalanceTx)
+	require.Equal(uint64(50_000), moveBalanceTx.GasUsed)
+	require.Equal("50000000000000", moveBalanceTx.Fee)
+}
+
+func TestComputeTransactionGasUsedAndFeeLogWithError(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	feeComp, _ := fee.NewFeeComputer(fee.ArgsNewFeeComputer{
+		BuiltInFunctionsCostHandler: &testscommon.BuiltInCostHandlerStub{},
+		EconomicsConfig:             testscommon.GetEconomicsConfig(),
+	})
+	computer := fee.NewTestFeeComputer(feeComp)
+
+	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(computer)
+
+	sender := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
+	receiver := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
+
+	txWithSignalErrorLog := &transaction.ApiTransactionResult{
+		Tx: &transaction.Transaction{
+			GasLimit: 80_000,
+			GasPrice: 1000000000,
+			SndAddr:  silentDecodeAddress(sender),
+			RcvAddr:  silentDecodeAddress(receiver),
+		},
+		GasLimit: 80_000,
+		Logs: &transaction.ApiLogs{
+			Events: []*transaction.Events{
+				{
+					Identifier: core.SignalErrorOperation,
+				},
+			},
+		},
+	}
+
+	gasUsedAndFeeProc.computeAndAttachGasUsedAndFee(txWithSignalErrorLog)
+	require.Equal(uint64(80_000), txWithSignalErrorLog.GasUsed)
+	require.Equal("50300000000000", txWithSignalErrorLog.Fee)
+}
+
+func silentDecodeAddress(address string) []byte {
+	decoded, _ := pubKeyConverter.Decode(address)
+	return decoded
+}
+
+func TestComputeTransactionGasUsedAndFeeRelayedTxWithWriteLog(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	feeComp, _ := fee.NewFeeComputer(fee.ArgsNewFeeComputer{
+		BuiltInFunctionsCostHandler: &testscommon.BuiltInCostHandlerStub{},
+		EconomicsConfig:             testscommon.GetEconomicsConfig(),
+	})
+	computer := fee.NewTestFeeComputer(feeComp)
+
+	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(computer)
+
+	sender := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
+	receiver := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
+
+	relayedTxWithWriteLog := &transaction.ApiTransactionResult{
+		Tx: &transaction.Transaction{
+			GasLimit: 200_000,
+			GasPrice: 1000000000,
+			SndAddr:  silentDecodeAddress(sender),
+			RcvAddr:  silentDecodeAddress(receiver),
+			Data:     []byte("relayedTx@"),
+		},
+		GasLimit: 200_000,
+		Logs: &transaction.ApiLogs{
+			Events: []*transaction.Events{
+				{
+					Identifier: core.WriteLogIdentifier,
+				},
+			},
+		},
+		IsRelayed: true,
+	}
+
+	gasUsedAndFeeProc.computeAndAttachGasUsedAndFee(relayedTxWithWriteLog)
+	require.Equal(uint64(200_000), relayedTxWithWriteLog.GasUsed)
+	require.Equal("66350000000000", relayedTxWithWriteLog.Fee)
+}
+
+func TestComputeTransactionGasUsedAndFeeTransactionWithScrWithRefund(t *testing.T) {
+	require := require.New(t)
+	feeComp, _ := fee.NewFeeComputer(fee.ArgsNewFeeComputer{
+		BuiltInFunctionsCostHandler: &testscommon.BuiltInCostHandlerStub{},
+		EconomicsConfig:             testscommon.GetEconomicsConfig(),
+	})
+	computer := fee.NewTestFeeComputer(feeComp)
+
+	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(computer)
+
+	sender := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
+	receiver := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
+
+	txWithSRefundSCR := &transaction.ApiTransactionResult{
+		Tx: &transaction.Transaction{
+			GasLimit: 10_000_000,
+			GasPrice: 1000000000,
+			SndAddr:  silentDecodeAddress(sender),
+			RcvAddr:  silentDecodeAddress(receiver),
+			Data:     []byte("relayedTx@"),
+		},
+		GasLimit: 10_000_000,
+		SmartContractResults: []*transaction.ApiSmartContractResult{
+			{
+				Value:    big.NewInt(66350000000000),
+				IsRefund: true,
+			},
+		},
+		Logs: &transaction.ApiLogs{
+			Events: []*transaction.Events{
+				{
+					Identifier: core.WriteLogIdentifier,
+				},
+			},
+		},
+		IsRelayed: true,
+	}
+
+	gasUsedAndFeeProc.computeAndAttachGasUsedAndFee(txWithSRefundSCR)
+	require.Equal(uint64(3_365_000), txWithSRefundSCR.GasUsed)
+	require.Equal("98000000000000", txWithSRefundSCR.Fee)
+}

--- a/node/external/transactionAPI/gasUsedAndFeeProcessor_test.go
+++ b/node/external/transactionAPI/gasUsedAndFeeProcessor_test.go
@@ -1,0 +1,1 @@
+package transactionAPI

--- a/node/external/transactionAPI/interface.go
+++ b/node/external/transactionAPI/interface.go
@@ -8,7 +8,15 @@ import (
 )
 
 type feeComputer interface {
+	ComputeGasUsedAndFeeBasedOnRefundValue(tx *transaction.ApiTransactionResult, refundValue *big.Int) (uint64, *big.Int)
+	ComputeTxFeeBasedOnGasUsed(tx *transaction.ApiTransactionResult, gasUsed uint64) *big.Int
+	ComputeGasLimit(tx *transaction.ApiTransactionResult) uint64
 	ComputeTransactionFee(tx *transaction.ApiTransactionResult) *big.Int
+	IsInterfaceNil() bool
+}
+
+// FeesProcessorHandler defines the interface for the transaction fees processor
+type FeesProcessorHandler interface {
 	IsInterfaceNil() bool
 }
 

--- a/testscommon/feeComputerStub.go
+++ b/testscommon/feeComputerStub.go
@@ -8,7 +8,10 @@ import (
 
 // FeeComputerStub -
 type FeeComputerStub struct {
-	ComputeTransactionFeeCalled func(tx *transaction.ApiTransactionResult) *big.Int
+	ComputeTransactionFeeCalled                  func(tx *transaction.ApiTransactionResult) *big.Int
+	ComputeGasUsedAndFeeBasedOnRefundValueCalled func(tx *transaction.ApiTransactionResult, refundValue *big.Int) (uint64, *big.Int)
+	ComputeTxFeeBasedOnGasUsedCalled             func(tx *transaction.ApiTransactionResult, gasUsed uint64) *big.Int
+	ComputeGasLimitCalled                        func(tx *transaction.ApiTransactionResult) uint64
 }
 
 // ComputeTransactionFee -
@@ -18,6 +21,32 @@ func (stub *FeeComputerStub) ComputeTransactionFee(tx *transaction.ApiTransactio
 	}
 
 	return big.NewInt(0)
+}
+
+// ComputeGasUsedAndFeeBasedOnRefundValue -
+func (stub *FeeComputerStub) ComputeGasUsedAndFeeBasedOnRefundValue(tx *transaction.ApiTransactionResult, refundValue *big.Int) (uint64, *big.Int) {
+	if stub.ComputeGasUsedAndFeeBasedOnRefundValueCalled != nil {
+		return stub.ComputeGasUsedAndFeeBasedOnRefundValueCalled(tx, refundValue)
+	}
+	return 0, big.NewInt(0)
+}
+
+// ComputeTxFeeBasedOnGasUsed -
+func (stub *FeeComputerStub) ComputeTxFeeBasedOnGasUsed(tx *transaction.ApiTransactionResult, gasUsed uint64) *big.Int {
+	if stub.ComputeTxFeeBasedOnGasUsedCalled != nil {
+		return stub.ComputeTxFeeBasedOnGasUsedCalled(tx, gasUsed)
+	}
+
+	return big.NewInt(0)
+}
+
+// ComputeGasLimit -
+func (stub *FeeComputerStub) ComputeGasLimit(tx *transaction.ApiTransactionResult) uint64 {
+	if stub.ComputeGasLimitCalled != nil {
+		return stub.ComputeGasLimitCalled(tx)
+	}
+
+	return 0
 }
 
 // IsInterfaceNil returns true if there is no value under the interface


### PR DESCRIPTION
## Reasoning behind the pull request
- Add information about the gas used and the fee of a transaction
  
## Proposed changes
- Extended the `Transaction` structure that is returned on the `/transaction` endpoint with 2 extra fields: `gasUsed` and `fee`
- Changed the version of `mx-chain-core-go` module.
- PR from `mx-chain-core-go` repository: https://github.com/multiversx/mx-chain-core-go/pull/159

## Testing procedure
- Execute some transactions and check the `gasUsed` and the `fee` field if are returned by the `transaction` endpoint of the node and proxy

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
