### PR TITLE
fix leader fees for last block in epoch

### DIFF
--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -239,6 +239,9 @@
     # AlwaysSaveTokenMetaDataEnableEpoch represents the epoch when the token metadata is always saved
     AlwaysSaveTokenMetaDataEnableEpoch = 2
 
+    # LeaderFeesForLastEpochBlockEnableEpoch represents the epoch when the leader fees for the last epoch block are enabled
+    LeaderFeesForLastEpochBlockEnableEpoch = 2  # takes effect in epoch 3
+
     # BLSMultiSignerEnableEpoch represents the activation epoch for different types of BLS multi-signers
     BLSMultiSignerEnableEpoch = [
         { EnableEpoch = 0, Type = "no-KOSK"},

--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -240,7 +240,7 @@
     AlwaysSaveTokenMetaDataEnableEpoch = 2
 
     # LeaderFeesForLastEpochBlockEnableEpoch represents the epoch when the leader fees for the last epoch block are enabled
-    LeaderFeesForLastEpochBlockEnableEpoch = 2  # takes effect in epoch 3
+    LeaderFeesForLastEpochBlockEnableEpoch = 2
 
     # BLSMultiSignerEnableEpoch represents the activation epoch for different types of BLS multi-signers
     BLSMultiSignerEnableEpoch = [

--- a/common/enablers/enableEpochsHandler.go
+++ b/common/enablers/enableEpochsHandler.go
@@ -117,6 +117,7 @@ func (handler *enableEpochsHandler) EpochConfirmed(epoch uint32, _ uint64) {
 	handler.setFlagValue(epoch >= handler.enableEpochsConfig.MaxBlockchainHookCountersEnableEpoch, handler.maxBlockchainHookCountersFlag, "maxBlockchainHookCountersFlag")
 	handler.setFlagValue(epoch >= handler.enableEpochsConfig.WipeSingleNFTLiquidityDecreaseEnableEpoch, handler.wipeSingleNFTLiquidityDecreaseFlag, "wipeSingleNFTLiquidityDecreaseFlag")
 	handler.setFlagValue(epoch >= handler.enableEpochsConfig.AlwaysSaveTokenMetaDataEnableEpoch, handler.alwaysSaveTokenMetaDataFlag, "alwaysSaveTokenMetaDataFlag")
+	handler.setFlagValue(epoch >= handler.enableEpochsConfig.LeaderFeesForLastEpochBlockEnableEpoch, handler.leaderFeesForLastEpochBlockFlag, "leaderFeesForLastEpochBlockFlag")
 }
 
 func (handler *enableEpochsHandler) setFlagValue(value bool, flag *atomic.Flag, flagName string) {
@@ -212,6 +213,10 @@ func (handler *enableEpochsHandler) MiniBlockPartialExecutionEnableEpoch() uint3
 // RefactorPeersMiniBlocksEnableEpoch returns the epoch when refactor of peers mini blocks becomes active
 func (handler *enableEpochsHandler) RefactorPeersMiniBlocksEnableEpoch() uint32 {
 	return handler.enableEpochsConfig.RefactorPeersMiniBlocksEnableEpoch
+}
+
+func (handler *enableEpochsHandler) LeaderFeesForLastEpochBlockEnableEpoch() uint32 {
+	return handler.enableEpochsConfig.LeaderFeesForLastEpochBlockEnableEpoch
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/common/enablers/enableEpochsHandler_test.go
+++ b/common/enablers/enableEpochsHandler_test.go
@@ -90,6 +90,7 @@ func createEnableEpochsConfig() config.EnableEpochs {
 		MaxBlockchainHookCountersEnableEpoch:              74,
 		WipeSingleNFTLiquidityDecreaseEnableEpoch:         75,
 		AlwaysSaveTokenMetaDataEnableEpoch:                76,
+		LeaderFeesForLastEpochBlockEnableEpoch:            77,
 	}
 }
 

--- a/common/enablers/epochFlags.go
+++ b/common/enablers/epochFlags.go
@@ -89,6 +89,7 @@ type epochFlagsHolder struct {
 	maxBlockchainHookCountersFlag               *atomic.Flag
 	wipeSingleNFTLiquidityDecreaseFlag          *atomic.Flag
 	alwaysSaveTokenMetaDataFlag                 *atomic.Flag
+	leaderFeesForLastEpochBlockFlag             *atomic.Flag
 }
 
 func newEpochFlagsHolder() *epochFlagsHolder {
@@ -177,6 +178,7 @@ func newEpochFlagsHolder() *epochFlagsHolder {
 		maxBlockchainHookCountersFlag:               &atomic.Flag{},
 		wipeSingleNFTLiquidityDecreaseFlag:          &atomic.Flag{},
 		alwaysSaveTokenMetaDataFlag:                 &atomic.Flag{},
+		leaderFeesForLastEpochBlockFlag:             &atomic.Flag{},
 	}
 }
 
@@ -651,4 +653,8 @@ func (holder *epochFlagsHolder) IsWipeSingleNFTLiquidityDecreaseEnabled() bool {
 // IsAlwaysSaveTokenMetaDataEnabled returns true if alwaysSaveTokenMetaDataFlag is enabled
 func (holder *epochFlagsHolder) IsAlwaysSaveTokenMetaDataEnabled() bool {
 	return holder.alwaysSaveTokenMetaDataFlag.IsSet()
+}
+
+func (holder *epochFlagsHolder) IsLeaderFeesForLastEpochBlockEnabled() bool {
+	return holder.leaderFeesForLastEpochBlockFlag.IsSet()
 }

--- a/common/interface.go
+++ b/common/interface.go
@@ -336,6 +336,7 @@ type EnableEpochsHandler interface {
 	IsMaxBlockchainHookCountersFlagEnabled() bool
 	IsWipeSingleNFTLiquidityDecreaseEnabled() bool
 	IsAlwaysSaveTokenMetaDataEnabled() bool
+	IsLeaderFeesForLastEpochBlockEnabled() bool
 
 	IsInterfaceNil() bool
 }

--- a/config/epochConfig.go
+++ b/config/epochConfig.go
@@ -92,6 +92,7 @@ type EnableEpochs struct {
 	MaxBlockchainHookCountersEnableEpoch              uint32
 	WipeSingleNFTLiquidityDecreaseEnableEpoch         uint32
 	AlwaysSaveTokenMetaDataEnableEpoch                uint32
+	LeaderFeesForLastEpochBlockEnableEpoch            uint32
 	BLSMultiSignerEnableEpoch                         []MultiSignerConfig
 }
 

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -678,6 +678,9 @@ func TestEnableEpochConfig(t *testing.T) {
     # AlwaysSaveTokenMetaDataEnableEpoch represents the epoch when the token metadata is always saved
     AlwaysSaveTokenMetaDataEnableEpoch = 61
 
+	# LeaderFeesForLastEpochBlockEnableEpoch represents the epoch when the leader fees for the last epoch block are enabled
+	LeaderFeesForLastEpochBlockEnableEpoch = 62
+
     # MaxNodesChangeEnableEpoch holds configuration for changing the maximum number of nodes and the enabling epoch
     MaxNodesChangeEnableEpoch = [
         { EpochEnable = 44, MaxNumNodes = 2169, NodesToShufflePerShard = 80 },
@@ -771,6 +774,7 @@ func TestEnableEpochConfig(t *testing.T) {
 			MaxBlockchainHookCountersEnableEpoch:        59,
 			WipeSingleNFTLiquidityDecreaseEnableEpoch:   60,
 			AlwaysSaveTokenMetaDataEnableEpoch:          61,
+			LeaderFeesForLastEpochBlockEnableEpoch:      62,
 			BLSMultiSignerEnableEpoch: []MultiSignerConfig{
 				{
 					EnableEpoch: 0,

--- a/integrationTests/testProcessorNodeWithMultisigner.go
+++ b/integrationTests/testProcessorNodeWithMultisigner.go
@@ -230,10 +230,11 @@ func CreateNodesWithNodesCoordinatorFactory(
 	}
 
 	epochsConfig := config.EnableEpochs{
-		StakingV2EnableEpoch:                 UnreachableEpoch,
-		ScheduledMiniBlocksEnableEpoch:       UnreachableEpoch,
-		MiniBlockPartialExecutionEnableEpoch: UnreachableEpoch,
-		RefactorPeersMiniBlocksEnableEpoch:   UnreachableEpoch,
+		StakingV2EnableEpoch:                   UnreachableEpoch,
+		ScheduledMiniBlocksEnableEpoch:         UnreachableEpoch,
+		MiniBlockPartialExecutionEnableEpoch:   UnreachableEpoch,
+		RefactorPeersMiniBlocksEnableEpoch:     UnreachableEpoch,
+		LeaderFeesForLastEpochBlockEnableEpoch: UnreachableEpoch,
 	}
 
 	nodesMap := make(map[uint32][]*TestProcessorNode)
@@ -467,9 +468,10 @@ func CreateNodesWithNodesCoordinatorAndHeaderSigVerifier(
 				NodeShardId:          shardId,
 				TxSignPrivKeyShardId: txSignPrivKeyShardId,
 				EpochsConfig: &config.EnableEpochs{
-					StakingV2EnableEpoch:                 UnreachableEpoch,
-					ScheduledMiniBlocksEnableEpoch:       UnreachableEpoch,
-					MiniBlockPartialExecutionEnableEpoch: UnreachableEpoch,
+					StakingV2EnableEpoch:                   UnreachableEpoch,
+					ScheduledMiniBlocksEnableEpoch:         UnreachableEpoch,
+					MiniBlockPartialExecutionEnableEpoch:   UnreachableEpoch,
+					LeaderFeesForLastEpochBlockEnableEpoch: UnreachableEpoch,
 				},
 				NodeKeys:                cp.Keys[shardId][i],
 				NodesSetup:              nodesSetup,
@@ -591,9 +593,10 @@ func CreateNodesWithNodesCoordinatorKeygenAndSingleSigner(
 				NodeShardId:          shardId,
 				TxSignPrivKeyShardId: txSignPrivKeyShardId,
 				EpochsConfig: &config.EnableEpochs{
-					StakingV2EnableEpoch:                 UnreachableEpoch,
-					ScheduledMiniBlocksEnableEpoch:       UnreachableEpoch,
-					MiniBlockPartialExecutionEnableEpoch: UnreachableEpoch,
+					StakingV2EnableEpoch:                   UnreachableEpoch,
+					ScheduledMiniBlocksEnableEpoch:         UnreachableEpoch,
+					MiniBlockPartialExecutionEnableEpoch:   UnreachableEpoch,
+					LeaderFeesForLastEpochBlockEnableEpoch: UnreachableEpoch,
 				},
 				NodeKeys:                cp.Keys[shardId][i],
 				NodesSetup:              nodesSetup,

--- a/sharding/mock/enableEpochsHandlerMock.go
+++ b/sharding/mock/enableEpochsHandlerMock.go
@@ -561,6 +561,11 @@ func (mock *EnableEpochsHandlerMock) IsAlwaysSaveTokenMetaDataEnabled() bool {
 	return false
 }
 
+// IsLeaderFeesForLastEpochBlockEnabled -
+func (mock *EnableEpochsHandlerMock) IsLeaderFeesForLastEpochBlockEnabled() bool {
+	return false
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (mock *EnableEpochsHandlerMock) IsInterfaceNil() bool {
 	return mock == nil

--- a/testscommon/enableEpochsHandlerStub.go
+++ b/testscommon/enableEpochsHandlerStub.go
@@ -116,6 +116,7 @@ type EnableEpochsHandlerStub struct {
 	IsMaxBlockchainHookCountersFlagEnabledField                  bool
 	IsWipeSingleNFTLiquidityDecreaseEnabledField                 bool
 	IsAlwaysSaveTokenMetaDataEnabledField                        bool
+	IsLeaderFeesForLastEpochBlockEnabledField                    bool
 }
 
 // ResetPenalizedTooMuchGasFlag -
@@ -1003,6 +1004,14 @@ func (stub *EnableEpochsHandlerStub) IsAlwaysSaveTokenMetaDataEnabled() bool {
 	defer stub.RUnlock()
 
 	return stub.IsAlwaysSaveTokenMetaDataEnabledField
+}
+
+// IsLeaderFeesForLastEpochBlockEnabled -
+func (stub *EnableEpochsHandlerStub) IsLeaderFeesForLastEpochBlockEnabled() bool {
+	stub.RLock()
+	defer stub.RUnlock()
+
+	return stub.IsLeaderFeesForLastEpochBlockEnabledField
 }
 
 // IsInterfaceNil -


### PR DESCRIPTION
## Reasoning behind the pull request
The leader fees for the meta-chain block are added in validator statistics with a one block delay which cause at the end of epoch negative dust when the last metachain block before a change of epoch had  transactions.
  
## Proposed changes
- register the leader fees for the meta-chain block in the validator statistics for that specific meta-block
- the change needs activation epoch, as it is not backwards compatible 

## Testing procedure
- generate transactions for meta-chain e.g ESDT issue/ Delegation/Stake and check the added logs that the leader fees are considered for the current block validator statistics instead of the following block
- run an import-db on metachain to validate that the change is backwards compatible.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
