### PR TITLE
add delay after UpdateRound in integration tests

### DIFF
--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -2401,6 +2401,9 @@ func UpdateRound(nodes []*TestProcessorNode, round uint64) {
 	for _, n := range nodes {
 		n.RoundHandler.IndexField = int64(round)
 	}
+
+	// this delay is needed in order for the round to be properly updated in the nodes
+	time.Sleep(10 * time.Millisecond)
 }
 
 // ProposeBlocks proposes blocks for a given number of rounds


### PR DESCRIPTION
## Reasoning behind the pull request
- There were some integration tests that were randomly failing
  
## Proposed changes
- Add a delay after UpdateRound() (from integration tests) is called, allowing the round to be properly updated in the nodes

## Testing procedure
- No testing needed, changes were made only in integration tests.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
