### PR TITLE
remove StartInEpoch integration test db

### DIFF
--- a/integrationTests/multiShard/endOfEpoch/startInEpoch/startInEpoch_test.go
+++ b/integrationTests/multiShard/endOfEpoch/startInEpoch/startInEpoch_test.go
@@ -181,6 +181,9 @@ func testNodeStartsInEpoch(t *testing.T, shardID uint32, expectedHighestRound ui
 	defer func() {
 		errRemoveDir := os.RemoveAll("Epoch_0")
 		assert.NoError(t, errRemoveDir)
+
+		errRemoveDir = os.RemoveAll("Static")
+		assert.NoError(t, errRemoveDir)
 	}()
 
 	genesisShardCoordinator, _ := sharding.NewMultiShardCoordinator(nodesConfig.NumberOfShards(), 0)


### PR DESCRIPTION
## Reasoning behind the pull request
- After the integration tests in `StartInEpoch` were run, the `Static` db was not removed
  
## Proposed changes
- Remove the `Static` db after the tests are finished 

## Testing procedure
- No testing needed, no changes were made in productive code.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
