### PR TITLE
Schedule processing control over the process status handler component

### DIFF
--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -83,6 +83,7 @@ type baseProcessor struct {
 	genesisNonce            uint64
 	mutProcessDebugger      sync.RWMutex
 	processDebugger         process.Debugger
+	processStatusHandler    common.ProcessStatusHandler
 
 	versionedHeaderFactory       nodeFactory.VersionedHeaderFactory
 	headerIntegrityVerifier      process.HeaderIntegrityVerifier
@@ -1852,10 +1853,12 @@ func (bp *baseProcessor) Close() error {
 // ProcessScheduledBlock processes a scheduled block
 func (bp *baseProcessor) ProcessScheduledBlock(headerHandler data.HeaderHandler, bodyHandler data.BodyHandler, haveTime func() time.Duration) error {
 	var err error
+	bp.processStatusHandler.SetBusy("shardProcessor.ProcessScheduledBlock")
 	defer func() {
 		if err != nil {
 			bp.RevertCurrentBlock()
 		}
+		bp.processStatusHandler.SetIdle()
 	}()
 
 	scheduledMiniBlocksFromMe, err := getScheduledMiniBlocksFromMe(headerHandler, bodyHandler)

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -1853,7 +1853,7 @@ func (bp *baseProcessor) Close() error {
 // ProcessScheduledBlock processes a scheduled block
 func (bp *baseProcessor) ProcessScheduledBlock(headerHandler data.HeaderHandler, bodyHandler data.BodyHandler, haveTime func() time.Duration) error {
 	var err error
-	bp.processStatusHandler.SetBusy("shardProcessor.ProcessScheduledBlock")
+	bp.processStatusHandler.SetBusy("baseProcessor.ProcessScheduledBlock")
 	defer func() {
 		if err != nil {
 			bp.RevertCurrentBlock()

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -42,7 +42,6 @@ type metaProcessor struct {
 	shardBlockFinality           uint32
 	chRcvAllHdrs                 chan bool
 	headersCounter               *headersCounter
-	processStatusHandler         common.ProcessStatusHandler
 }
 
 // NewMetaProcessor creates a new metaProcessor object
@@ -133,6 +132,7 @@ func NewMetaProcessor(arguments ArgMetaProcessor) (*metaProcessor, error) {
 		receiptsRepository:            arguments.ReceiptsRepository,
 		processDebugger:               processDebugger,
 		outportDataProvider:           arguments.OutportDataProvider,
+		processStatusHandler:          arguments.CoreComponents.ProcessStatusHandler(),
 	}
 
 	mp := metaProcessor{
@@ -146,7 +146,6 @@ func NewMetaProcessor(arguments ArgMetaProcessor) (*metaProcessor, error) {
 		validatorStatisticsProcessor: arguments.ValidatorStatisticsProcessor,
 		validatorInfoCreator:         arguments.EpochValidatorInfoCreator,
 		epochSystemSCProcessor:       arguments.EpochSystemSCProcessor,
-		processStatusHandler:         arguments.CoreComponents.ProcessStatusHandler(),
 	}
 
 	mp.txCounter, err = NewTransactionCounter(mp.hasher, mp.marshalizer)

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -45,9 +45,8 @@ type createAndProcessMiniBlocksDestMeInfo struct {
 // shardProcessor implements shardProcessor interface, and actually it tries to execute block
 type shardProcessor struct {
 	*baseProcessor
-	metaBlockFinality    uint32
-	chRcvAllMetaHdrs     chan bool
-	processStatusHandler common.ProcessStatusHandler
+	metaBlockFinality uint32
+	chRcvAllMetaHdrs  chan bool
 }
 
 // NewShardProcessor creates a new shardProcessor object
@@ -118,11 +117,11 @@ func NewShardProcessor(arguments ArgShardProcessor) (*shardProcessor, error) {
 		receiptsRepository:            arguments.ReceiptsRepository,
 		processDebugger:               processDebugger,
 		outportDataProvider:           arguments.OutportDataProvider,
+		processStatusHandler:          arguments.CoreComponents.ProcessStatusHandler(),
 	}
 
 	sp := shardProcessor{
-		baseProcessor:        base,
-		processStatusHandler: arguments.CoreComponents.ProcessStatusHandler(),
+		baseProcessor: base,
 	}
 
 	sp.txCounter, err = NewTransactionCounter(sp.hasher, sp.marshalizer)

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -286,19 +286,18 @@ func TestShardProcess_CreateNewBlockHeaderProcessHeaderExpectCheckRoundCalled(t 
 
 	processHandler := arguments.CoreComponents.ProcessStatusHandler()
 	mockProcessHandler := processHandler.(*testscommon.ProcessStatusHandlerStub)
-	statusBusySet := false
-	statusIdleSet := false
+	busyIdleCalled := make([]string, 0)
 	mockProcessHandler.SetIdleCalled = func() {
-		statusIdleSet = true
+		busyIdleCalled = append(busyIdleCalled, idleIdentifier)
 	}
 	mockProcessHandler.SetBusyCalled = func(reason string) {
-		statusBusySet = true
+		busyIdleCalled = append(busyIdleCalled, busyIdentifier)
 	}
 
 	err = shardProcessor.ProcessBlock(headerHandler, bodyHandler, func() time.Duration { return time.Second })
 	require.Nil(t, err)
 	require.Equal(t, int64(2), checkRoundCt.Get())
-	assert.True(t, statusIdleSet && statusBusySet)
+	assert.Equal(t, []string{busyIdentifier, idleIdentifier}, busyIdleCalled) // the order is important
 }
 
 func TestShardProcessor_ProcessWithDirtyAccountShouldErr(t *testing.T) {
@@ -1922,13 +1921,12 @@ func TestShardProcessor_CommitBlockStorageFailsForHeaderShouldErr(t *testing.T) 
 
 	processHandler := arguments.CoreComponents.ProcessStatusHandler()
 	mockProcessHandler := processHandler.(*testscommon.ProcessStatusHandlerStub)
-	statusBusySet := false
-	statusIdleSet := false
+	busyIdleCalled := make([]string, 0)
 	mockProcessHandler.SetIdleCalled = func() {
-		statusIdleSet = true
+		busyIdleCalled = append(busyIdleCalled, idleIdentifier)
 	}
 	mockProcessHandler.SetBusyCalled = func(reason string) {
-		statusBusySet = true
+		busyIdleCalled = append(busyIdleCalled, busyIdentifier)
 	}
 	expectedFirstNonce := core.OptionalUint64{
 		HasValue: false,
@@ -1939,7 +1937,7 @@ func TestShardProcessor_CommitBlockStorageFailsForHeaderShouldErr(t *testing.T) 
 	wg.Wait()
 	assert.True(t, atomic.LoadUint32(&putCalledNr) > 0)
 	assert.Nil(t, err)
-	assert.True(t, statusBusySet && statusIdleSet)
+	assert.Equal(t, []string{busyIdentifier, idleIdentifier}, busyIdleCalled) // the order is important
 
 	expectedFirstNonce.HasValue = true
 	expectedFirstNonce.Value = hdr.Nonce

--- a/trie/branchNode.go
+++ b/trie/branchNode.go
@@ -298,7 +298,7 @@ func (bn *branchNode) commitCheckpoint(
 	idleProvider IdleNodeProvider,
 	depthLevel int,
 ) error {
-	if shouldStopIfContextDone(ctx, idleProvider) {
+	if shouldStopIfContextDoneBlockingIfBusy(ctx, idleProvider) {
 		return errors.ErrContextClosing
 	}
 
@@ -346,7 +346,7 @@ func (bn *branchNode) commitSnapshot(
 	idleProvider IdleNodeProvider,
 	depthLevel int,
 ) error {
-	if shouldStopIfContextDone(ctx, idleProvider) {
+	if shouldStopIfContextDoneBlockingIfBusy(ctx, idleProvider) {
 		return errors.ErrContextClosing
 	}
 

--- a/trie/extensionNode.go
+++ b/trie/extensionNode.go
@@ -210,7 +210,7 @@ func (en *extensionNode) commitCheckpoint(
 	idleProvider IdleNodeProvider,
 	depthLevel int,
 ) error {
-	if shouldStopIfContextDone(ctx, idleProvider) {
+	if shouldStopIfContextDoneBlockingIfBusy(ctx, idleProvider) {
 		return errors.ErrContextClosing
 	}
 
@@ -252,7 +252,7 @@ func (en *extensionNode) commitSnapshot(
 	idleProvider IdleNodeProvider,
 	depthLevel int,
 ) error {
-	if shouldStopIfContextDone(ctx, idleProvider) {
+	if shouldStopIfContextDoneBlockingIfBusy(ctx, idleProvider) {
 		return errors.ErrContextClosing
 	}
 

--- a/trie/leafNode.go
+++ b/trie/leafNode.go
@@ -138,7 +138,7 @@ func (ln *leafNode) commitCheckpoint(
 	idleProvider IdleNodeProvider,
 	depthLevel int,
 ) error {
-	if shouldStopIfContextDone(ctx, idleProvider) {
+	if shouldStopIfContextDoneBlockingIfBusy(ctx, idleProvider) {
 		return errors.ErrContextClosing
 	}
 
@@ -183,7 +183,7 @@ func (ln *leafNode) commitSnapshot(
 	idleProvider IdleNodeProvider,
 	depthLevel int,
 ) error {
-	if shouldStopIfContextDone(ctx, idleProvider) {
+	if shouldStopIfContextDoneBlockingIfBusy(ctx, idleProvider) {
 		return errors.ErrContextClosing
 	}
 

--- a/trie/node.go
+++ b/trie/node.go
@@ -241,7 +241,7 @@ func prefixLen(a, b []byte) int {
 	return i
 }
 
-func shouldStopIfContextDone(ctx context.Context, idleProvider IdleNodeProvider) bool {
+func shouldStopIfContextDoneBlockingIfBusy(ctx context.Context, idleProvider IdleNodeProvider) bool {
 	for {
 		select {
 		case <-ctx.Done():

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -164,11 +164,11 @@ func TestNode_getNodeFromDBAndDecodeBranchNode(t *testing.T) {
 	encNode = append(encNode, branch)
 	nodeHash := bn.hasher.Compute(string(encNode))
 
-	node, err := getNodeFromDBAndDecode(nodeHash, db, bn.marsh, bn.hasher)
+	nodeInstance, err := getNodeFromDBAndDecode(nodeHash, db, bn.marsh, bn.hasher)
 	assert.Nil(t, err)
 
 	h1, _ := encodeNodeAndGetHash(collapsedBn)
-	h2, _ := encodeNodeAndGetHash(node)
+	h2, _ := encodeNodeAndGetHash(nodeInstance)
 	assert.Equal(t, h1, h2)
 }
 
@@ -183,11 +183,11 @@ func TestNode_getNodeFromDBAndDecodeExtensionNode(t *testing.T) {
 	encNode = append(encNode, extension)
 	nodeHash := en.hasher.Compute(string(encNode))
 
-	node, err := getNodeFromDBAndDecode(nodeHash, db, en.marsh, en.hasher)
+	nodeInstance, err := getNodeFromDBAndDecode(nodeHash, db, en.marsh, en.hasher)
 	assert.Nil(t, err)
 
 	h1, _ := encodeNodeAndGetHash(collapsedEn)
-	h2, _ := encodeNodeAndGetHash(node)
+	h2, _ := encodeNodeAndGetHash(nodeInstance)
 	assert.Equal(t, h1, h2)
 }
 
@@ -202,12 +202,12 @@ func TestNode_getNodeFromDBAndDecodeLeafNode(t *testing.T) {
 	encNode = append(encNode, leaf)
 	nodeHash := ln.hasher.Compute(string(encNode))
 
-	node, err := getNodeFromDBAndDecode(nodeHash, db, ln.marsh, ln.hasher)
+	nodeInstance, err := getNodeFromDBAndDecode(nodeHash, db, ln.marsh, ln.hasher)
 	assert.Nil(t, err)
 
 	ln = getLn(ln.marsh, ln.hasher)
 	ln.dirty = false
-	assert.Equal(t, ln, node)
+	assert.Equal(t, ln, nodeInstance)
 }
 
 func TestNode_resolveIfCollapsedBranchNode(t *testing.T) {
@@ -250,9 +250,9 @@ func TestNode_resolveIfCollapsedLeafNode(t *testing.T) {
 func TestNode_resolveIfCollapsedNilNode(t *testing.T) {
 	t.Parallel()
 
-	var node *extensionNode
+	var nodeInstance *extensionNode
 
-	err := resolveIfCollapsed(node, 0, nil)
+	err := resolveIfCollapsed(nodeInstance, 0, nil)
 	assert.Equal(t, ErrNilExtensionNode, err)
 }
 
@@ -284,8 +284,8 @@ func TestNode_hasValidHash(t *testing.T) {
 func TestNode_hasValidHashNilNode(t *testing.T) {
 	t.Parallel()
 
-	var node *branchNode
-	ok, err := hasValidHash(node)
+	var nodeInstance *branchNode
+	ok, err := hasValidHash(nodeInstance)
 	assert.Equal(t, ErrNilBranchNode, err)
 	assert.False(t, ok)
 }
@@ -297,11 +297,11 @@ func TestNode_decodeNodeBranchNode(t *testing.T) {
 	encNode, _ := collapsedBn.marsh.Marshal(collapsedBn)
 	encNode = append(encNode, branch)
 
-	node, err := decodeNode(encNode, collapsedBn.marsh, collapsedBn.hasher)
+	nodeInstance, err := decodeNode(encNode, collapsedBn.marsh, collapsedBn.hasher)
 	assert.Nil(t, err)
 
 	h1, _ := encodeNodeAndGetHash(collapsedBn)
-	h2, _ := encodeNodeAndGetHash(node)
+	h2, _ := encodeNodeAndGetHash(nodeInstance)
 	assert.Equal(t, h1, h2)
 }
 
@@ -312,11 +312,11 @@ func TestNode_decodeNodeExtensionNode(t *testing.T) {
 	encNode, _ := collapsedEn.marsh.Marshal(collapsedEn)
 	encNode = append(encNode, extension)
 
-	node, err := decodeNode(encNode, collapsedEn.marsh, collapsedEn.hasher)
+	nodeInstance, err := decodeNode(encNode, collapsedEn.marsh, collapsedEn.hasher)
 	assert.Nil(t, err)
 
 	h1, _ := encodeNodeAndGetHash(collapsedEn)
-	h2, _ := encodeNodeAndGetHash(node)
+	h2, _ := encodeNodeAndGetHash(nodeInstance)
 	assert.Equal(t, h1, h2)
 }
 
@@ -327,12 +327,12 @@ func TestNode_decodeNodeLeafNode(t *testing.T) {
 	encNode, _ := ln.marsh.Marshal(ln)
 	encNode = append(encNode, leaf)
 
-	node, err := decodeNode(encNode, ln.marsh, ln.hasher)
+	nodeInstance, err := decodeNode(encNode, ln.marsh, ln.hasher)
 	assert.Nil(t, err)
 	ln.dirty = false
 
 	h1, _ := encodeNodeAndGetHash(ln)
-	h2, _ := encodeNodeAndGetHash(node)
+	h2, _ := encodeNodeAndGetHash(nodeInstance)
 	assert.Equal(t, h1, h2)
 }
 
@@ -345,8 +345,8 @@ func TestNode_decodeNodeInvalidNode(t *testing.T) {
 	encNode, _ := ln.marsh.Marshal(ln)
 	encNode = append(encNode, invalidNode)
 
-	node, err := decodeNode(encNode, ln.marsh, ln.hasher)
-	assert.Nil(t, node)
+	nodeInstance, err := decodeNode(encNode, ln.marsh, ln.hasher)
+	assert.Nil(t, nodeInstance)
 	assert.Equal(t, ErrInvalidNode, err)
 }
 
@@ -356,8 +356,8 @@ func TestNode_decodeNodeInvalidEncoding(t *testing.T) {
 	marsh, hasher := getTestMarshalizerAndHasher()
 	var encNode []byte
 
-	node, err := decodeNode(encNode, marsh, hasher)
-	assert.Nil(t, node)
+	nodeInstance, err := decodeNode(encNode, marsh, hasher)
+	assert.Nil(t, nodeInstance)
 	assert.Equal(t, ErrInvalidEncoding, err)
 }
 
@@ -576,16 +576,16 @@ func TestNode_NodeExtension(t *testing.T) {
 	assert.False(t, shouldTestNode(n, make([]byte, 0)))
 }
 
-func TestShouldStopIfContextDone(t *testing.T) {
+func TestShouldStopIfContextDoneBlockingIfBusy(t *testing.T) {
 	t.Parallel()
 
 	t.Run("context done", func(t *testing.T) {
 		t.Parallel()
 
 		ctx, cancelFunc := context.WithCancel(context.Background())
-		assert.False(t, shouldStopIfContextDone(ctx, &testscommon.ProcessStatusHandlerStub{}))
+		assert.False(t, shouldStopIfContextDoneBlockingIfBusy(ctx, &testscommon.ProcessStatusHandlerStub{}))
 		cancelFunc()
-		assert.True(t, shouldStopIfContextDone(ctx, &testscommon.ProcessStatusHandlerStub{}))
+		assert.True(t, shouldStopIfContextDoneBlockingIfBusy(ctx, &testscommon.ProcessStatusHandlerStub{}))
 	})
 	t.Run("wait until idle", func(t *testing.T) {
 		t.Parallel()
@@ -602,7 +602,7 @@ func TestShouldStopIfContextDone(t *testing.T) {
 
 		chResult := make(chan bool, 1)
 		go func() {
-			chResult <- shouldStopIfContextDone(ctx, idleProvider)
+			chResult <- shouldStopIfContextDoneBlockingIfBusy(ctx, idleProvider)
 		}()
 
 		select {
@@ -623,11 +623,11 @@ func TestShouldStopIfContextDone(t *testing.T) {
 	})
 }
 
-func Benchmark_ShouldStopIfContextDone(b *testing.B) {
+func Benchmark_ShouldStopIfContextDoneBlockingIfBusy(b *testing.B) {
 	ctx := context.Background()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = shouldStopIfContextDone(ctx, &testscommon.ProcessStatusHandlerStub{})
+		_ = shouldStopIfContextDoneBlockingIfBusy(ctx, &testscommon.ProcessStatusHandlerStub{})
 	}
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- while processing scheduled transactions, the process status handler component is not notified
  
## Proposed changes
- added processStatusHandler control while processing scheduled transactions

## Testing procedure
- standard system test with scheduled transactions, after the upgrade we should be able to find the following succession of events: 
```
   processStatusHandler.SetBusy reason = "shardProcessor.CreateBlock"
   processStatusHandler.SetIdle
*** or ***
   processStatusHandler.SetBusy reason = "baseProcessor.ProcessScheduledBlock"
   processStatusHandler.SetIdle
   

   processStatusHandler.SetBusy reason = "baseProcessor.ProcessScheduledBlock"
   processStatusHandler.SetIdle
   processStatusHandler.SetBusy reason = "shardProcessor.CommitBlock"
   processStatusHandler.SetIdle
```

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
