### PR TITLE
Fix inconsistent computation of "initiallyPaidFee" on concurrent requests

### DIFF
--- a/node/external/timemachine/fee/feeComputer_test.go
+++ b/node/external/timemachine/fee/feeComputer_test.go
@@ -3,6 +3,7 @@ package fee
 import (
 	"encoding/hex"
 	"math/big"
+	"sync"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
@@ -10,6 +11,7 @@ import (
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -179,5 +181,38 @@ func checkComputedFee(t *testing.T, expectedFee string, computer *feeComputer, e
 	}
 
 	fee := computer.ComputeTransactionFee(tx)
-	require.Equal(t, expectedFee, fee.String())
+	assert.Equal(t, expectedFee, fee.String())
+}
+
+func TestFeeComputer_InHighConcurrency(t *testing.T) {
+	arguments := ArgsNewFeeComputer{
+		BuiltInFunctionsCostHandler: &testscommon.BuiltInCostHandlerStub{},
+		EconomicsConfig:             testscommon.GetEconomicsConfig(),
+		EnableEpochsConfig: config.EnableEpochs{
+			PenalizedTooMuchGasEnableEpoch: 124,
+			GasPriceModifierEnableEpoch:    180,
+		},
+	}
+
+	computer, _ := NewFeeComputer(arguments)
+
+	n := 1000
+	wg := sync.WaitGroup{}
+	wg.Add(n * 2)
+
+	for i := 0; i < n; i++ {
+		go func() {
+			checkComputedFee(t, "50000000000000", computer, 0, 80000, 1000000000, "", nil)
+			wg.Done()
+		}()
+	}
+
+	for i := 0; i < n; i++ {
+		go func() {
+			checkComputedFee(t, "80000000000000", computer, 125, 80000, 1000000000, "", nil)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
 }

--- a/node/external/timemachine/fee/memoryFootprint/memory_test.go
+++ b/node/external/timemachine/fee/memoryFootprint/memory_test.go
@@ -15,7 +15,7 @@ import (
 // keep this test in a separate package as to not be influenced by other the tests from the same package
 func TestFeeComputer_MemoryFootprint(t *testing.T) {
 	numEpochs := 10000
-	maxFootprintNumBytes := 20_000_000
+	maxFootprintNumBytes := 30_000_000
 
 	journal := &memoryFootprintJournal{}
 	journal.before = getMemStats()

--- a/node/external/timemachine/fee/memoryFootprint/memory_test.go
+++ b/node/external/timemachine/fee/memoryFootprint/memory_test.go
@@ -15,7 +15,7 @@ import (
 // keep this test in a separate package as to not be influenced by other the tests from the same package
 func TestFeeComputer_MemoryFootprint(t *testing.T) {
 	numEpochs := 10000
-	maxFootprintNumBytes := 30_000_000
+	maxFootprintNumBytes := 48_000_000
 
 	journal := &memoryFootprintJournal{}
 	journal.before = getMemStats()


### PR DESCRIPTION
## Reasoning behind the pull request
- Concurrent requests for `GET transaction` - where transactions are in in epochs with different fee computation scheme - result in inconsistent computation of the API field `initiallyPaidFee`
- Regression introduced in https://github.com/multiversx/mx-chain-go/pull/4255.
  
## Proposed changes
- In API's fee computer, do not share `enableEpochsHandler` across different instances of `economicsData`.

## Testing procedure
- regular testing on internal testnets
- testing session on public testnet using rosetta-cli checker

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
