### PR TITLE
added new cross height metrics

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -198,6 +198,9 @@ const MetricConsensusRoundState = "erd_consensus_round_state"
 // MetricCrossCheckBlockHeight is the metric that store cross block height
 const MetricCrossCheckBlockHeight = "erd_cross_check_block_height"
 
+// MetricCrossCheckBlockHeightMeta is the metric that store metachain cross block height
+const MetricCrossCheckBlockHeightMeta = "erd_cross_check_block_height_meta"
+
 // MetricNumProcessedTxs is the metric that stores the number of transactions processed
 const MetricNumProcessedTxs = "erd_num_transactions_processed"
 

--- a/node/metrics/metrics.go
+++ b/node/metrics/metrics.go
@@ -233,8 +233,12 @@ func InitMetrics(
 	appStatusHandler.SetStringValue(common.MetricAppVersion, version)
 	appStatusHandler.SetUInt64Value(common.MetricRoundsPerEpoch, uint64(roundsPerEpoch))
 	appStatusHandler.SetStringValue(common.MetricCrossCheckBlockHeight, "0")
+	for i := uint32(0); i < shardCoordinator.NumberOfShards(); i++ {
+		key := fmt.Sprintf("%s_%d", common.MetricCrossCheckBlockHeight, i)
+		appStatusHandler.SetUInt64Value(key, 0)
+	}
+	appStatusHandler.SetUInt64Value(common.MetricCrossCheckBlockHeightMeta, 0)
 	appStatusHandler.SetUInt64Value(common.MetricIsSyncing, isSyncing)
-	// TODO: add all other rewards parameters
 	appStatusHandler.SetStringValue(common.MetricLeaderPercentage, fmt.Sprintf("%f", leaderPercentage))
 	appStatusHandler.SetUInt64Value(common.MetricDenomination, uint64(economicsConfig.GlobalSettings.Denomination))
 

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -216,6 +216,10 @@ func (mp *metaProcessor) RequestMissingFinalityAttestingShardHeaders() uint32 {
 	return mp.requestMissingFinalityAttestingShardHeaders()
 }
 
+func (mp *metaProcessor) SaveMetricCrossCheckBlockHeight() {
+	mp.saveMetricCrossCheckBlockHeight()
+}
+
 func (bp *baseProcessor) NotarizedHdrs() map[uint32][]data.HeaderHandler {
 	lastCrossNotarizedHeaders := make(map[uint32][]data.HeaderHandler)
 	for shardID := uint32(0); shardID < bp.shardCoordinator.NumberOfShards(); shardID++ {

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -1619,6 +1619,9 @@ func (mp *metaProcessor) saveMetricCrossCheckBlockHeight() {
 		}
 
 		crossCheckBlockHeight += fmt.Sprintf("%d: %d, ", i, heightValue)
+
+		shardedCrossChecksKey := fmt.Sprintf("%s_%d", common.MetricCrossCheckBlockHeight, i)
+		mp.appStatusHandler.SetUInt64Value(shardedCrossChecksKey, heightValue)
 	}
 
 	mp.appStatusHandler.SetStringValue(common.MetricCrossCheckBlockHeight, crossCheckBlockHeight)

--- a/process/block/metablock_test.go
+++ b/process/block/metablock_test.go
@@ -3665,3 +3665,45 @@ func TestMetaProcessor_getAllMarshalledTxs(t *testing.T) {
 	assert.Equal(t, []byte("h"), allMarshalledTxs["validatorInfo"][1])
 	assert.Equal(t, []byte("i"), allMarshalledTxs["validatorInfo"][2])
 }
+
+func TestMetaProcessor_CrossChecksBlockHeightsMetrics(t *testing.T) {
+	t.Parallel()
+
+	requireInstance := require.New(t)
+
+	savedMetrics := make(map[string]interface{})
+	arguments := createMockMetaArguments(createMockComponentHolders())
+	arguments.StatusCoreComponents = &factory.StatusCoreComponentsStub{
+		AppStatusHandlerField: &statusHandlerMock.AppStatusHandlerStub{
+			SetUInt64ValueHandler: func(key string, value uint64) {
+				savedMetrics[key] = value
+			},
+			SetStringValueHandler: func(key string, value string) {
+				savedMetrics[key] = value
+			},
+		},
+	}
+	arguments.BootstrapComponents = &mock.BootstrapComponentsMock{
+		Coordinator:          mock.NewMultiShardsCoordinatorMock(3),
+		HdrIntegrityVerifier: &mock.HeaderIntegrityVerifierStub{},
+		VersionedHdrFactory: &testscommon.VersionedHeaderFactoryStub{
+			CreateCalled: func(epoch uint32) data.HeaderHandler {
+				return &block.MetaBlock{}
+			},
+		},
+	}
+
+	mp, _ := blproc.NewMetaProcessor(arguments)
+
+	mp.UpdateShardsHeadersNonce(0, 37)
+	mp.UpdateShardsHeadersNonce(1, 38)
+	mp.UpdateShardsHeadersNonce(2, 39)
+
+	mp.SaveMetricCrossCheckBlockHeight()
+
+	requireInstance.NotEmpty(savedMetrics)
+	requireInstance.Equal("0: 37, 1: 38, 2: 39, ", savedMetrics["erd_cross_check_block_height"])
+	requireInstance.Equal(uint64(37), savedMetrics["erd_cross_check_block_height_0"])
+	requireInstance.Equal(uint64(38), savedMetrics["erd_cross_check_block_height_1"])
+	requireInstance.Equal(uint64(39), savedMetrics["erd_cross_check_block_height_2"])
+}

--- a/process/block/metrics.go
+++ b/process/block/metrics.go
@@ -95,6 +95,7 @@ func saveMetricsForCommittedShardBlock(
 	appStatusHandler.SetStringValue(common.MetricCurrentBlockHash, currentBlockHash)
 	appStatusHandler.SetUInt64Value(common.MetricHighestFinalBlock, highestFinalBlockNonce)
 	appStatusHandler.SetStringValue(common.MetricCrossCheckBlockHeight, fmt.Sprintf("meta %d", metaBlock.GetNonce()))
+	appStatusHandler.SetUInt64Value(common.MetricCrossCheckBlockHeightMeta, metaBlock.GetNonce())
 }
 
 func incrementCountAcceptedBlocks(


### PR DESCRIPTION
## Reasoning behind the pull request
- previously, the metric that indicated the cross checks block heights between meta and shards was a string, making it hard for monitoring solutions
  
## Proposed changes
- added new metrics for each shard, as numeric values

## Testing procedure
1). **Shard node**:
1.1).  query `<node>:<port>/node/status` and validate for these metrics (X != 0):
- `erd_cross_check_block_height` has something like `meta X` 
- `erd_cross_check_block_height_0` is 0
- `erd_cross_check_block_height_1` is 0
- `erd_cross_check_block_height_2` is 0
- `erd_cross_check_block_height_meta` is X

1.2). query query `<node>:<port>/node/metrics` and search for the same metrics as the above

2). **Metachain node**:
2.1).  query `<node>:<port>/node/status` and validate for these metrics (X,Y,Z != 0):
- `erd_cross_check_block_height` has something like `0: X, 1: Y, 2: Z, ` 
- `erd_cross_check_block_height_0` is X
- `erd_cross_check_block_height_1` is Y
- `erd_cross_check_block_height_2` is Z
- `erd_cross_check_block_height_meta` is 0

2.2). query query `<node>:<port>/node/metrics` and search for the same metrics as the above

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
