### PR TITLE
Protection check for stakingV4 configs

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -97,6 +97,12 @@ func startNodeRunner(c *cli.Context, log logger.Logger, version string) error {
 		return errCfg
 	}
 
+	// check config here
+	errCheckEpochsCfg := sanityCheckEnableEpochsStakingV4(cfgs, log)
+	if errCheckEpochsCfg != nil {
+		return errCfg
+	}
+
 	errCfgOverride := overridableConfig.OverrideConfigValues(cfgs.PreferencesConfig.Preferences.OverridableConfigTomlValues, cfgs)
 	if errCfgOverride != nil {
 		return errCfgOverride
@@ -246,6 +252,59 @@ func readConfigs(ctx *cli.Context, log logger.Logger) (*config.Configs, error) {
 		EpochConfig:              epochConfig,
 		RoundConfig:              roundConfig,
 	}, nil
+}
+
+func sanityCheckEnableEpochsStakingV4(cfg *config.Configs, log logger.Logger) error {
+	enableEpochsCfg := cfg.EpochConfig.EnableEpochs
+	stakingV4StepsInOrder := (enableEpochsCfg.StakingV4Step1EnableEpoch < enableEpochsCfg.StakingV4Step2EnableEpoch) &&
+		(enableEpochsCfg.StakingV4Step2EnableEpoch < enableEpochsCfg.StakingV4Step3EnableEpoch)
+
+	if !stakingV4StepsInOrder {
+		return fmt.Errorf("staking v4 enable epochs are not in ascending order" +
+			"; expected StakingV4Step1EnableEpoch < StakingV4Step2EnableEpoch < StakingV4Step3EnableEpoch")
+	}
+
+	stakingV4StepsInExpectedOrder := (enableEpochsCfg.StakingV4Step1EnableEpoch == enableEpochsCfg.StakingV4Step2EnableEpoch-1) &&
+		(enableEpochsCfg.StakingV4Step2EnableEpoch == enableEpochsCfg.StakingV4Step3EnableEpoch-1)
+	if !stakingV4StepsInExpectedOrder {
+		log.Warn("staking v4 enable epoch steps should be in cardinal order " +
+			"(e.g.: StakingV4Step1EnableEpoch = 2, StakingV4Step2EnableEpoch = 3, StakingV4Step3EnableEpoch = 4)" +
+			"; can leave them as they are for playground purposes" +
+			", but DO NOT use them in production, since system's behavior is undefined")
+	}
+
+	maxNodesConfigAdaptedForStakingV4 := false
+	for idx, maxNodesChangeCfg := range enableEpochsCfg.MaxNodesChangeEnableEpoch {
+		if maxNodesChangeCfg.EpochEnable == enableEpochsCfg.StakingV4Step2EnableEpoch {
+			maxNodesConfigAdaptedForStakingV4 = true
+
+			if idx == 0 {
+				log.Warn(fmt.Sprintf("found config change in MaxNodesChangeEnableEpoch for StakingV4Step3EnableEpoch = %d, ", enableEpochsCfg.StakingV4Step3EnableEpoch) +
+					"but no previous config change entry in MaxNodesChangeEnableEpoch")
+			} else {
+				prevMaxNodesChange := enableEpochsCfg.MaxNodesChangeEnableEpoch[idx-1]
+				if prevMaxNodesChange.NodesToShufflePerShard != maxNodesChangeCfg.NodesToShufflePerShard {
+					log.Warn("previous MaxNodesChangeEnableEpoch.NodesToShufflePerShard != MaxNodesChangeEnableEpoch.NodesToShufflePerShard with EnableEpoch = StakingV4Step3EnableEpoch" +
+						"; can leave them as they are for playground purposes, but DO NOT use them in production, since this will influence rewards")
+				}
+
+				numShards := cfg.GeneralConfig.GeneralSettings.GenesisMaxNumberOfShards
+				expectedMaxNumNodes := prevMaxNodesChange.MaxNumNodes - (numShards + 1) - prevMaxNodesChange.NodesToShufflePerShard
+				if expectedMaxNumNodes != maxNodesChangeCfg.MaxNumNodes {
+					return fmt.Errorf(fmt.Sprintf("expcted MaxNodesChangeEnableEpoch.MaxNumNodes for StakingV4Step3EnableEpoch = %d, but got %d",
+						expectedMaxNumNodes, maxNodesChangeCfg.MaxNumNodes))
+				}
+			}
+
+			break
+		}
+	}
+
+	if !maxNodesConfigAdaptedForStakingV4 {
+		return fmt.Errorf("no MaxNodesChangeEnableEpoch config found for EpochEnable = StakingV4Step3EnableEpoch(%d)", enableEpochsCfg.StakingV4Step3EnableEpoch)
+	}
+
+	return nil
 }
 
 func attachFileLogger(log logger.Logger, flagsConfig *config.ContextFlagsConfig) (factory.FileLoggingHandler, error) {

--- a/config/configChecker.go
+++ b/config/configChecker.go
@@ -2,55 +2,41 @@ package config
 
 import (
 	"fmt"
-
-	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
-var log = logger.GetOrCreate("configChecker")
-
+// SanityCheckEnableEpochsStakingV4 checks if the enable epoch configs for stakingV4 are set correctly
 func SanityCheckEnableEpochsStakingV4(cfg *Configs) error {
 	enableEpochsCfg := cfg.EpochConfig.EnableEpochs
-	err := checkStakingV4EpochsOrder(enableEpochsCfg)
-	if err != nil {
-		return err
+	if !areStakingV4StepsInOrder(enableEpochsCfg) {
+		return errStakingV4StepsNotInOrder
 	}
 
 	numOfShards := cfg.GeneralConfig.GeneralSettings.GenesisMaxNumberOfShards
 	return checkStakingV4MaxNodesChangeCfg(enableEpochsCfg, numOfShards)
 }
 
-func checkStakingV4EpochsOrder(enableEpochsCfg EnableEpochs) error {
-	stakingV4StepsInOrder := (enableEpochsCfg.StakingV4Step1EnableEpoch < enableEpochsCfg.StakingV4Step2EnableEpoch) &&
-		(enableEpochsCfg.StakingV4Step2EnableEpoch < enableEpochsCfg.StakingV4Step3EnableEpoch)
-
-	if !stakingV4StepsInOrder {
-		return errStakingV4StepsNotInOrder
-	}
-
-	stakingV4StepsInExpectedOrder := (enableEpochsCfg.StakingV4Step1EnableEpoch == enableEpochsCfg.StakingV4Step2EnableEpoch-1) &&
+func areStakingV4StepsInOrder(enableEpochsCfg EnableEpochs) bool {
+	return (enableEpochsCfg.StakingV4Step1EnableEpoch == enableEpochsCfg.StakingV4Step2EnableEpoch-1) &&
 		(enableEpochsCfg.StakingV4Step2EnableEpoch == enableEpochsCfg.StakingV4Step3EnableEpoch-1)
-	if !stakingV4StepsInExpectedOrder {
-		log.Warn("staking v4 enable epoch steps should be in cardinal order " +
-			"(e.g.: StakingV4Step1EnableEpoch = 2, StakingV4Step2EnableEpoch = 3, StakingV4Step3EnableEpoch = 4)" +
-			"; can leave them as they are for playground purposes" +
-			", but DO NOT use them in production, since system's behavior is undefined")
-	}
-
-	return nil
 }
 
 func checkStakingV4MaxNodesChangeCfg(enableEpochsCfg EnableEpochs, numOfShards uint32) error {
+	maxNodesChangeCfg := enableEpochsCfg.MaxNodesChangeEnableEpoch
+	if len(maxNodesChangeCfg) <= 1 {
+		return errNotEnoughMaxNodesChanges
+	}
+
 	maxNodesConfigAdaptedForStakingV4 := false
 
-	for idx, currMaxNodesChangeCfg := range enableEpochsCfg.MaxNodesChangeEnableEpoch {
+	for idx, currMaxNodesChangeCfg := range maxNodesChangeCfg {
 		if currMaxNodesChangeCfg.EpochEnable == enableEpochsCfg.StakingV4Step3EnableEpoch {
-
 			maxNodesConfigAdaptedForStakingV4 = true
+
 			if idx == 0 {
-				log.Warn(fmt.Sprintf("found config change in MaxNodesChangeEnableEpoch for StakingV4Step3EnableEpoch = %d, ", enableEpochsCfg.StakingV4Step3EnableEpoch) +
-					"but no previous config change entry in MaxNodesChangeEnableEpoch, DO NOT use this config in production")
+				return fmt.Errorf("found config change in MaxNodesChangeEnableEpoch for StakingV4Step3EnableEpoch = %d, but %w ",
+					enableEpochsCfg.StakingV4Step3EnableEpoch, errNoMaxNodesConfigBeforeStakingV4)
 			} else {
-				prevMaxNodesChange := enableEpochsCfg.MaxNodesChangeEnableEpoch[idx-1]
+				prevMaxNodesChange := maxNodesChangeCfg[idx-1]
 				err := checkMaxNodesChangedCorrectly(prevMaxNodesChange, currMaxNodesChangeCfg, numOfShards)
 				if err != nil {
 					return err
@@ -70,9 +56,7 @@ func checkStakingV4MaxNodesChangeCfg(enableEpochsCfg EnableEpochs, numOfShards u
 
 func checkMaxNodesChangedCorrectly(prevMaxNodesChange MaxNodesChangeConfig, currMaxNodesChange MaxNodesChangeConfig, numOfShards uint32) error {
 	if prevMaxNodesChange.NodesToShufflePerShard != currMaxNodesChange.NodesToShufflePerShard {
-		log.Warn("previous MaxNodesChangeEnableEpoch.NodesToShufflePerShard != MaxNodesChangeEnableEpoch.NodesToShufflePerShard" +
-			" with EnableEpoch = StakingV4Step3EnableEpoch; can leave them as they are for playground purposes," +
-			" but DO NOT use them in production, since this will influence rewards")
+		return errMismatchNodesToShuffle
 	}
 
 	totalShuffled := (numOfShards + 1) * prevMaxNodesChange.NodesToShufflePerShard

--- a/config/configChecker.go
+++ b/config/configChecker.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"fmt"
+
+	logger "github.com/multiversx/mx-chain-logger-go"
+)
+
+var log = logger.GetOrCreate("configChecker")
+
+func SanityCheckEnableEpochsStakingV4(cfg *Configs) error {
+	enableEpochsCfg := cfg.EpochConfig.EnableEpochs
+	err := checkStakingV4EpochsOrder(enableEpochsCfg)
+	if err != nil {
+		return err
+	}
+
+	numOfShards := cfg.GeneralConfig.GeneralSettings.GenesisMaxNumberOfShards
+	return checkStakingV4MaxNodesChangeCfg(enableEpochsCfg, numOfShards)
+}
+
+func checkStakingV4EpochsOrder(enableEpochsCfg EnableEpochs) error {
+	stakingV4StepsInOrder := (enableEpochsCfg.StakingV4Step1EnableEpoch < enableEpochsCfg.StakingV4Step2EnableEpoch) &&
+		(enableEpochsCfg.StakingV4Step2EnableEpoch < enableEpochsCfg.StakingV4Step3EnableEpoch)
+
+	if !stakingV4StepsInOrder {
+		return fmt.Errorf("staking v4 enable epochs are not in ascending order" +
+			"; expected StakingV4Step1EnableEpoch < StakingV4Step2EnableEpoch < StakingV4Step3EnableEpoch")
+	}
+
+	stakingV4StepsInExpectedOrder := (enableEpochsCfg.StakingV4Step1EnableEpoch == enableEpochsCfg.StakingV4Step2EnableEpoch-1) &&
+		(enableEpochsCfg.StakingV4Step2EnableEpoch == enableEpochsCfg.StakingV4Step3EnableEpoch-1)
+	if !stakingV4StepsInExpectedOrder {
+		log.Warn("staking v4 enable epoch steps should be in cardinal order " +
+			"(e.g.: StakingV4Step1EnableEpoch = 2, StakingV4Step2EnableEpoch = 3, StakingV4Step3EnableEpoch = 4)" +
+			"; can leave them as they are for playground purposes" +
+			", but DO NOT use them in production, since system's behavior is undefined")
+	}
+
+	return nil
+}
+
+func checkStakingV4MaxNodesChangeCfg(enableEpochsCfg EnableEpochs, numOfShards uint32) error {
+	maxNodesConfigAdaptedForStakingV4 := false
+
+	for idx, currMaxNodesChangeCfg := range enableEpochsCfg.MaxNodesChangeEnableEpoch {
+		if currMaxNodesChangeCfg.EpochEnable == enableEpochsCfg.StakingV4Step3EnableEpoch {
+
+			maxNodesConfigAdaptedForStakingV4 = true
+			if idx == 0 {
+				log.Warn(fmt.Sprintf("found config change in MaxNodesChangeEnableEpoch for StakingV4Step3EnableEpoch = %d, ", enableEpochsCfg.StakingV4Step3EnableEpoch) +
+					"but no previous config change entry in MaxNodesChangeEnableEpoch")
+			} else {
+				prevMaxNodesChange := enableEpochsCfg.MaxNodesChangeEnableEpoch[idx-1]
+				err := checkMaxNodesChangedCorrectly(prevMaxNodesChange, currMaxNodesChangeCfg, numOfShards)
+				if err != nil {
+					return err
+				}
+			}
+
+			break
+		}
+	}
+
+	if !maxNodesConfigAdaptedForStakingV4 {
+		return fmt.Errorf("no MaxNodesChangeEnableEpoch config found for EpochEnable = StakingV4Step3EnableEpoch(%d)", enableEpochsCfg.StakingV4Step3EnableEpoch)
+	}
+
+	return nil
+}
+
+func checkMaxNodesChangedCorrectly(prevMaxNodesChange MaxNodesChangeConfig, currMaxNodesChange MaxNodesChangeConfig, numOfShards uint32) error {
+	if prevMaxNodesChange.NodesToShufflePerShard != currMaxNodesChange.NodesToShufflePerShard {
+		log.Warn("previous MaxNodesChangeEnableEpoch.NodesToShufflePerShard != MaxNodesChangeEnableEpoch.NodesToShufflePerShard" +
+			" with EnableEpoch = StakingV4Step3EnableEpoch; can leave them as they are for playground purposes," +
+			" but DO NOT use them in production, since this will influence rewards")
+	}
+
+	expectedMaxNumNodes := prevMaxNodesChange.MaxNumNodes - (numOfShards + 1) - prevMaxNodesChange.NodesToShufflePerShard
+	if expectedMaxNumNodes != currMaxNodesChange.MaxNumNodes {
+		return fmt.Errorf(fmt.Sprintf("expcted MaxNodesChangeEnableEpoch.MaxNumNodes for StakingV4Step3EnableEpoch = %d, but got %d",
+			expectedMaxNumNodes, currMaxNodesChange.MaxNumNodes))
+	}
+
+	return nil
+}

--- a/config/configChecker_test.go
+++ b/config/configChecker_test.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func generateCorrectConfig() *Configs {
+	return &Configs{
+		EpochConfig: &EpochConfig{
+			EnableEpochs: EnableEpochs{
+				StakingV4Step1EnableEpoch: 4,
+				StakingV4Step2EnableEpoch: 5,
+				StakingV4Step3EnableEpoch: 6,
+				MaxNodesChangeEnableEpoch: []MaxNodesChangeConfig{
+					{
+						EpochEnable:            0,
+						MaxNumNodes:            36,
+						NodesToShufflePerShard: 4,
+					},
+					{
+						EpochEnable:            1,
+						MaxNumNodes:            56,
+						NodesToShufflePerShard: 2,
+					},
+					{
+						EpochEnable:            6,
+						MaxNumNodes:            48,
+						NodesToShufflePerShard: 2,
+					},
+				},
+			},
+		},
+		GeneralConfig: &Config{
+			GeneralSettings: GeneralSettingsConfig{
+				GenesisMaxNumberOfShards: 3,
+			},
+		},
+	}
+}
+
+func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
+	t.Parallel()
+
+	t.Run("correct config, should work", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := generateCorrectConfig()
+		err := SanityCheckEnableEpochsStakingV4(cfg)
+		require.Nil(t, err)
+	})
+
+	t.Run("staking v4 steps not in ascending order, should return error", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := generateCorrectConfig()
+		cfg.EpochConfig.EnableEpochs.StakingV4Step1EnableEpoch = 5
+		cfg.EpochConfig.EnableEpochs.StakingV4Step2EnableEpoch = 5
+		err := SanityCheckEnableEpochsStakingV4(cfg)
+		require.Equal(t, errStakingV4StepsNotInOrder, err)
+
+		cfg = generateCorrectConfig()
+		cfg.EpochConfig.EnableEpochs.StakingV4Step2EnableEpoch = 5
+		cfg.EpochConfig.EnableEpochs.StakingV4Step3EnableEpoch = 4
+		err = SanityCheckEnableEpochsStakingV4(cfg)
+		require.Equal(t, errStakingV4StepsNotInOrder, err)
+	})
+
+	t.Run("staking v4 steps not in ascending order, should work", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := generateCorrectConfig()
+		cfg.EpochConfig.EnableEpochs.StakingV4Step1EnableEpoch = 1
+		cfg.EpochConfig.EnableEpochs.StakingV4Step2EnableEpoch = 3
+		cfg.EpochConfig.EnableEpochs.StakingV4Step3EnableEpoch = 6
+
+		err := SanityCheckEnableEpochsStakingV4(cfg)
+		require.Nil(t, err)
+	})
+
+	t.Run("no previous config for max nodes change, should work", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := generateCorrectConfig()
+		cfg.EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch = []MaxNodesChangeConfig{
+			{
+				EpochEnable:            6,
+				MaxNumNodes:            48,
+				NodesToShufflePerShard: 2,
+			},
+		}
+
+		err := SanityCheckEnableEpochsStakingV4(cfg)
+		require.Nil(t, err)
+	})
+
+	t.Run("no max nodes config change for StakingV4Step3EnableEpoch, should return error", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := generateCorrectConfig()
+		cfg.EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch = []MaxNodesChangeConfig{
+			{
+				EpochEnable:            444,
+				MaxNumNodes:            48,
+				NodesToShufflePerShard: 2,
+			},
+		}
+
+		err := SanityCheckEnableEpochsStakingV4(cfg)
+		require.NotNil(t, err)
+		require.True(t, strings.Contains(err.Error(), errNoMaxNodesConfigChangeForStakingV4.Error()))
+		require.True(t, strings.Contains(err.Error(), "6"))
+	})
+
+	t.Run("stakingV4 config for max nodes changed with different nodes to shuffle, should work", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := generateCorrectConfig()
+		cfg.EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch[1].NodesToShufflePerShard = 2
+		cfg.EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch[2].NodesToShufflePerShard = 4
+
+		err := SanityCheckEnableEpochsStakingV4(cfg)
+		require.Nil(t, err)
+	})
+
+	t.Run("stakingV4 config for max nodes changed with wrong max num nodes, should return error", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := generateCorrectConfig()
+		cfg.EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch[2].MaxNumNodes = 56
+
+		err := SanityCheckEnableEpochsStakingV4(cfg)
+		require.NotNil(t, err)
+		require.True(t, strings.Contains(err.Error(), "expected"))
+		require.True(t, strings.Contains(err.Error(), "48"))
+		require.True(t, strings.Contains(err.Error(), "got"))
+		require.True(t, strings.Contains(err.Error(), "56"))
+	})
+}

--- a/config/configChecker_test.go
+++ b/config/configChecker_test.go
@@ -68,15 +68,27 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 		require.Equal(t, errStakingV4StepsNotInOrder, err)
 	})
 
-	t.Run("staking v4 steps not in ascending order, should work", func(t *testing.T) {
+	t.Run("staking v4 steps not in cardinal order, should work", func(t *testing.T) {
 		t.Parallel()
 
 		cfg := generateCorrectConfig()
+
 		cfg.EpochConfig.EnableEpochs.StakingV4Step1EnableEpoch = 1
 		cfg.EpochConfig.EnableEpochs.StakingV4Step2EnableEpoch = 3
 		cfg.EpochConfig.EnableEpochs.StakingV4Step3EnableEpoch = 6
-
 		err := SanityCheckEnableEpochsStakingV4(cfg)
+		require.Nil(t, err)
+
+		cfg.EpochConfig.EnableEpochs.StakingV4Step1EnableEpoch = 1
+		cfg.EpochConfig.EnableEpochs.StakingV4Step2EnableEpoch = 2
+		cfg.EpochConfig.EnableEpochs.StakingV4Step3EnableEpoch = 6
+		err = SanityCheckEnableEpochsStakingV4(cfg)
+		require.Nil(t, err)
+
+		cfg.EpochConfig.EnableEpochs.StakingV4Step1EnableEpoch = 1
+		cfg.EpochConfig.EnableEpochs.StakingV4Step2EnableEpoch = 5
+		cfg.EpochConfig.EnableEpochs.StakingV4Step3EnableEpoch = 6
+		err = SanityCheckEnableEpochsStakingV4(cfg)
 		require.Nil(t, err)
 	})
 

--- a/config/errors.go
+++ b/config/errors.go
@@ -1,0 +1,7 @@
+package config
+
+import "errors"
+
+var errStakingV4StepsNotInOrder = errors.New("staking v4 enable epochs are not in ascending order; expected StakingV4Step1EnableEpoch < StakingV4Step2EnableEpoch < StakingV4Step3EnableEpoch")
+
+var errNoMaxNodesConfigChangeForStakingV4 = errors.New("no MaxNodesChangeEnableEpoch config found for EpochEnable = StakingV4Step3EnableEpoch")

--- a/config/errors.go
+++ b/config/errors.go
@@ -2,6 +2,12 @@ package config
 
 import "errors"
 
-var errStakingV4StepsNotInOrder = errors.New("staking v4 enable epochs are not in ascending order; expected StakingV4Step1EnableEpoch < StakingV4Step2EnableEpoch < StakingV4Step3EnableEpoch")
+var errStakingV4StepsNotInOrder = errors.New("staking v4 enable epoch steps should be in cardinal order(e.g.: StakingV4Step1EnableEpoch = 2, StakingV4Step2EnableEpoch = 3, StakingV4Step3EnableEpoch = 4)")
+
+var errNotEnoughMaxNodesChanges = errors.New("not enough entries in MaxNodesChangeEnableEpoch config; expected one entry before stakingV4 and another one starting StakingV4Step3EnableEpoch")
+
+var errNoMaxNodesConfigBeforeStakingV4 = errors.New("no previous config change entry in MaxNodesChangeEnableEpoch before entry with EpochEnable = StakingV4Step3EnableEpoch")
+
+var errMismatchNodesToShuffle = errors.New("previous MaxNodesChangeEnableEpoch.NodesToShufflePerShard != MaxNodesChangeEnableEpoch.NodesToShufflePerShard with EnableEpoch = StakingV4Step3EnableEpoch")
 
 var errNoMaxNodesConfigChangeForStakingV4 = errors.New("no MaxNodesChangeEnableEpoch config found for EpochEnable = StakingV4Step3EnableEpoch")


### PR DESCRIPTION
## Reasoning behind the pull request
- In case of a wrong epoch configuration for staking v4, there was no protocol sanity check to signal it

## Proposed changes
- Added a config checker for stakingV4, which checks:
1. StakingV4 steps are in order
2. MaxNodesChangeEnableEpoch are changed correctly.
- For "soft configuration mistakes", a **warn** is thrown 

## Testing procedure
- Local testnet scripts

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
