### PR TITLE
FIX: Remove warn

### DIFF
--- a/sharding/nodesCoordinator/indexHashedNodesCoordinator.go
+++ b/sharding/nodesCoordinator/indexHashedNodesCoordinator.go
@@ -591,7 +591,7 @@ func (ihnc *indexHashedNodesCoordinator) EpochStartPrepare(metaHdr data.HeaderHa
 		return
 	}
 
-	metaBlock, castOk := metaHdr.(*block.MetaBlock)
+	_, castOk := metaHdr.(*block.MetaBlock)
 	if !castOk {
 		log.Error("could not process EpochStartPrepare on nodesCoordinator - not metaBlock")
 		return
@@ -618,15 +618,6 @@ func (ihnc *indexHashedNodesCoordinator) EpochStartPrepare(metaHdr data.HeaderHa
 	if err != nil {
 		log.Error("could not compute nodes config from list - do nothing on nodesCoordinator epochStartPrepare")
 		return
-	}
-
-	prevNumOfShards := uint32(len(metaBlock.ShardInfo))
-	if prevNumOfShards != newNodesConfig.nbShards {
-		log.Warn("number of shards does not match",
-			"previous epoch", ihnc.currentEpoch,
-			"previous number of shards", prevNumOfShards,
-			"new epoch", newEpoch,
-			"new number of shards", newNodesConfig.nbShards)
 	}
 
 	additionalLeavingMap, err := ihnc.nodesCoordinatorHelper.ComputeAdditionalLeaving(allValidatorInfo)


### PR DESCRIPTION
## Reasoning behind the pull request
- In the old version when there was a fix for `FixWaitingList` which was wrongfully using a `previousEpochConfig` for leaving nodes, there was a log.Warn in case of shard mismatch. The reason why this warn was not triggered when nodes were starting with previousConfig from epoch = 0 is because we never changed the number of shards. This warn was adapted to work with metablock start of epoch data which might not provide enough info and trigger unnecessary warnings.
## Proposed changes
- Remove warn

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
