### PR TITLE
Remove `GetNumNodes` trie functionality

### DIFF
--- a/common/interface.go
+++ b/common/interface.go
@@ -10,15 +10,6 @@ import (
 	"github.com/multiversx/mx-chain-go/trie/statistics"
 )
 
-// NumNodesDTO represents the DTO structure that will hold the number of nodes split by category and other
-// trie structure relevant data such as maximum number of trie levels including the roothash node and all leaves
-type NumNodesDTO struct {
-	Leaves     int
-	Extensions int
-	Branches   int
-	MaxLevel   int
-}
-
 // TrieIteratorChannels defines the channels that are being used when iterating the trie nodes
 type TrieIteratorChannels struct {
 	LeavesChan chan core.KeyValueHolder
@@ -40,7 +31,6 @@ type Trie interface {
 	GetOldRoot() []byte
 	GetSerializedNodes([]byte, uint64) ([][]byte, uint64, error)
 	GetSerializedNode([]byte) ([]byte, error)
-	GetNumNodes() NumNodesDTO
 	GetAllLeavesOnChannel(allLeavesChan *TrieIteratorChannels, ctx context.Context, rootHash []byte, keyBuilder KeyBuilder) error
 	GetAllHashes() ([][]byte, error)
 	GetProof(key []byte) ([][]byte, []byte, error)

--- a/integrationTests/state/stateTrieSync/stateTrieSync_test.go
+++ b/integrationTests/state/stateTrieSync/stateTrieSync_test.go
@@ -101,15 +101,6 @@ func testNodeRequestInterceptTrieNodesWithMessenger(t *testing.T, version int) {
 		_ = resolverTrie.Update([]byte(strconv.Itoa(i)), []byte(strconv.Itoa(i)))
 	}
 
-	nodes := resolverTrie.GetNumNodes()
-	log.Info("trie nodes",
-		"total", nodes.Branches+nodes.Extensions+nodes.Leaves,
-		"branches", nodes.Branches,
-		"extensions", nodes.Extensions,
-		"leaves", nodes.Leaves,
-		"max level", nodes.MaxLevel,
-	)
-
 	_ = resolverTrie.Commit()
 	rootHash, _ := resolverTrie.RootHash()
 
@@ -230,15 +221,6 @@ func testNodeRequestInterceptTrieNodesWithMessengerNotSyncingShouldErr(t *testin
 	for i := 0; i < numTrieLeaves; i++ {
 		_ = resolverTrie.Update([]byte(strconv.Itoa(i)), []byte(strconv.Itoa(i)))
 	}
-
-	nodes := resolverTrie.GetNumNodes()
-	log.Info("trie nodes",
-		"total", nodes.Branches+nodes.Extensions+nodes.Leaves,
-		"branches", nodes.Branches,
-		"extensions", nodes.Extensions,
-		"leaves", nodes.Leaves,
-		"max level", nodes.MaxLevel,
-	)
 
 	_ = resolverTrie.Commit()
 	rootHash, _ := resolverTrie.RootHash()

--- a/testscommon/trie/trieStub.go
+++ b/testscommon/trie/trieStub.go
@@ -27,7 +27,6 @@ type TrieStub struct {
 	VerifyProofCalled           func(rootHash []byte, key []byte, proof [][]byte) (bool, error)
 	GetStorageManagerCalled     func() common.StorageManager
 	GetSerializedNodeCalled     func(bytes []byte) ([]byte, error)
-	GetNumNodesCalled           func() common.NumNodesDTO
 	GetOldRootCalled            func() []byte
 	CloseCalled                 func() error
 }
@@ -183,15 +182,6 @@ func (ts *TrieStub) GetSerializedNode(bytes []byte) ([]byte, error) {
 	}
 
 	return nil, nil
-}
-
-// GetNumNodes -
-func (ts *TrieStub) GetNumNodes() common.NumNodesDTO {
-	if ts.GetNumNodesCalled != nil {
-		return ts.GetNumNodesCalled()
-	}
-
-	return common.NumNodesDTO{}
 }
 
 // GetOldRoot -

--- a/trie/branchNode.go
+++ b/trie/branchNode.go
@@ -855,34 +855,6 @@ func (bn *branchNode) getAllHashes(db common.DBWriteCacher) ([][]byte, error) {
 	return hashes, nil
 }
 
-func (bn *branchNode) getNumNodes() common.NumNodesDTO {
-	if check.IfNil(bn) {
-		return common.NumNodesDTO{}
-	}
-
-	currentNumNodes := common.NumNodesDTO{
-		Branches: 1,
-	}
-
-	for _, n := range bn.children {
-		if check.IfNil(n) {
-			continue
-		}
-
-		childNumNodes := n.getNumNodes()
-		currentNumNodes.Branches += childNumNodes.Branches
-		currentNumNodes.Leaves += childNumNodes.Leaves
-		currentNumNodes.Extensions += childNumNodes.Extensions
-		if childNumNodes.MaxLevel > currentNumNodes.MaxLevel {
-			currentNumNodes.MaxLevel = childNumNodes.MaxLevel
-		}
-	}
-
-	currentNumNodes.MaxLevel++
-
-	return currentNumNodes
-}
-
 func (bn *branchNode) getNextHashAndKey(key []byte) (bool, []byte, []byte) {
 	if len(key) == 0 || check.IfNil(bn) {
 		return false, nil, nil

--- a/trie/branchNode_test.go
+++ b/trie/branchNode_test.go
@@ -1319,15 +1319,6 @@ func TestBranchNode_getNextHashAndKeyNilNode(t *testing.T) {
 	assert.Nil(t, nextKey)
 }
 
-func TestBranchNode_GetNumNodesNilSelfShouldErr(t *testing.T) {
-	t.Parallel()
-
-	var bn *branchNode
-	numNodes := bn.getNumNodes()
-
-	assert.Equal(t, common.NumNodesDTO{}, numNodes)
-}
-
 func TestBranchNode_SizeInBytes(t *testing.T) {
 	t.Parallel()
 

--- a/trie/extensionNode.go
+++ b/trie/extensionNode.go
@@ -601,18 +601,6 @@ func (en *extensionNode) getChildren(db common.DBWriteCacher) ([]node, error) {
 	return nextNodes, nil
 }
 
-func (en *extensionNode) getNumNodes() common.NumNodesDTO {
-	if check.IfNil(en) {
-		return common.NumNodesDTO{}
-	}
-
-	childNumNodes := en.child.getNumNodes()
-	childNumNodes.Extensions++
-	childNumNodes.MaxLevel++
-
-	return childNumNodes
-}
-
 func (en *extensionNode) isValid() bool {
 	if len(en.EncodedChild) == 0 && en.child == nil {
 		return false

--- a/trie/extensionNode_test.go
+++ b/trie/extensionNode_test.go
@@ -987,15 +987,6 @@ func TestExtensionNode_getNextHashAndKeyNilNode(t *testing.T) {
 	assert.Nil(t, nextKey)
 }
 
-func TestExtensionNode_GetNumNodesNilSelfShouldErr(t *testing.T) {
-	t.Parallel()
-
-	var en *extensionNode
-	numNodes := en.getNumNodes()
-
-	assert.Equal(t, common.NumNodesDTO{}, numNodes)
-}
-
 func TestExtensionNode_SizeInBytes(t *testing.T) {
 	t.Parallel()
 

--- a/trie/interface.go
+++ b/trie/interface.go
@@ -42,7 +42,6 @@ type node interface {
 	getAllLeavesOnChannel(chan core.KeyValueHolder, common.KeyBuilder, common.DBWriteCacher, marshal.Marshalizer, chan struct{}, context.Context) error
 	getAllHashes(db common.DBWriteCacher) ([][]byte, error)
 	getNextHashAndKey([]byte) (bool, []byte, []byte)
-	getNumNodes() common.NumNodesDTO
 	getValue() []byte
 
 	commitDirty(level byte, maxTrieLevelInMemory uint, originDb common.DBWriteCacher, targetDb common.DBWriteCacher) error

--- a/trie/leafNode.go
+++ b/trie/leafNode.go
@@ -413,13 +413,6 @@ func (ln *leafNode) getChildren(_ common.DBWriteCacher) ([]node, error) {
 	return nil, nil
 }
 
-func (ln *leafNode) getNumNodes() common.NumNodesDTO {
-	return common.NumNodesDTO{
-		Leaves:   1,
-		MaxLevel: 1,
-	}
-}
-
 func (ln *leafNode) isValid() bool {
 	return len(ln.Value) > 0
 }

--- a/trie/patriciaMerkleTrie.go
+++ b/trie/patriciaMerkleTrie.go
@@ -604,19 +604,6 @@ func (tr *patriciaMerkleTrie) VerifyProof(rootHash []byte, key []byte, proof [][
 	return false, nil
 }
 
-// GetNumNodes will return the trie nodes statistics DTO
-func (tr *patriciaMerkleTrie) GetNumNodes() common.NumNodesDTO {
-	tr.mutOperation.Lock()
-	defer tr.mutOperation.Unlock()
-
-	n := tr.root
-	if check.IfNil(n) {
-		return common.NumNodesDTO{}
-	}
-
-	return n.getNumNodes()
-}
-
 // GetStorageManager returns the storage manager for the trie
 func (tr *patriciaMerkleTrie) GetStorageManager() common.StorageManager {
 	tr.mutOperation.Lock()

--- a/trie/patriciaMerkleTrie_test.go
+++ b/trie/patriciaMerkleTrie_test.go
@@ -883,15 +883,6 @@ func dumpTrieContents(tr common.Trie, values [][]byte) {
 	}
 }
 
-func TestPatriciaMerkleTrie_GetNumNodesNilRootShouldReturnEmpty(t *testing.T) {
-	t.Parallel()
-
-	tr := emptyTrie()
-
-	numNodes := tr.GetNumNodes()
-	assert.Equal(t, common.NumNodesDTO{}, numNodes)
-}
-
 func TestPatriciaMerkleTrie_GetTrieStats(t *testing.T) {
 	t.Parallel()
 
@@ -919,21 +910,6 @@ func TestPatriciaMerkleTrie_GetTrieStats(t *testing.T) {
 	assert.Equal(t, uint64(3), stats.NumLeafNodes)
 	assert.Equal(t, uint64(6), stats.TotalNumNodes)
 	assert.Equal(t, uint32(3), stats.MaxTrieDepth)
-}
-
-func TestPatriciaMerkleTrie_GetNumNodes(t *testing.T) {
-	t.Parallel()
-
-	tr := emptyTrie()
-	_ = tr.Update([]byte("eod"), []byte("reindeer"))
-	_ = tr.Update([]byte("god"), []byte("puppy"))
-	_ = tr.Update([]byte("eggod"), []byte("cat"))
-
-	numNodes := tr.GetNumNodes()
-	assert.Equal(t, 5, numNodes.MaxLevel)
-	assert.Equal(t, 3, numNodes.Leaves)
-	assert.Equal(t, 2, numNodes.Extensions)
-	assert.Equal(t, 2, numNodes.Branches)
 }
 
 func TestPatriciaMerkleTrie_GetOldRoot(t *testing.T) {


### PR DESCRIPTION
## Reasoning behind the pull request
The GetNumNodes functionality had some edge cases. This functionality was **solely used in tests** so it can be safely removed. 
  
## Proposed changes
- removed GetNumNodes trie unused functionality

## Testing procedure
- standard system-test

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
