### PR TITLE
Fix gas used and fee

### DIFF
--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -64,7 +64,7 @@ func NewAPITransactionProcessor(args *ArgAPITransactionProcessor) (*apiTransacti
 	)
 
 	refundDetector := newRefundDetector()
-	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(args.FeeComputer)
+	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(args.FeeComputer, args.AddressPubKeyConverter)
 
 	return &apiTransactionProcessor{
 		roundDuration:               args.RoundDuration,
@@ -100,7 +100,10 @@ func (atp *apiTransactionProcessor) GetTransaction(txHash string, withResults bo
 
 	tx.Hash = txHash
 	atp.PopulateComputedFields(tx)
-	atp.gasUsedAndFeeProcessor.computeAndAttachGasUsedAndFee(tx)
+
+	if withResults {
+		atp.gasUsedAndFeeProcessor.computeAndAttachGasUsedAndFee(tx)
+	}
 
 	return tx, nil
 }

--- a/node/external/transactionAPI/gasUsedAndFeeProcessor.go
+++ b/node/external/transactionAPI/gasUsedAndFeeProcessor.go
@@ -8,12 +8,14 @@ import (
 )
 
 type gasUsedAndFeeProcessor struct {
-	feeComputer feeComputer
+	feeComputer     feeComputer
+	pubKeyConverter core.PubkeyConverter
 }
 
-func newGasUsedAndFeeProcessor(txFeeCalculator feeComputer) *gasUsedAndFeeProcessor {
+func newGasUsedAndFeeProcessor(txFeeCalculator feeComputer, pubKeyConverter core.PubkeyConverter) *gasUsedAndFeeProcessor {
 	return &gasUsedAndFeeProcessor{
-		feeComputer: txFeeCalculator,
+		feeComputer:     txFeeCalculator,
+		pubKeyConverter: pubKeyConverter,
 	}
 }
 
@@ -24,7 +26,7 @@ func (gfp *gasUsedAndFeeProcessor) computeAndAttachGasUsedAndFee(tx *transaction
 	tx.GasUsed = gasUsed
 	tx.Fee = fee.String()
 
-	if tx.IsRelayed {
+	if tx.IsRelayed || gfp.isESDTOperationWithSCCall(tx) {
 		tx.GasUsed = tx.GasLimit
 		tx.Fee = tx.InitiallyPaidFee
 	}
@@ -73,4 +75,34 @@ func (gfp *gasUsedAndFeeProcessor) setGasUsedAndFeeBaseOnRefundValue(tx *transac
 	gasUsed, fee := gfp.feeComputer.ComputeGasUsedAndFeeBasedOnRefundValue(tx, refund)
 	tx.GasUsed = gasUsed
 	tx.Fee = fee.String()
+}
+
+func (gfp *gasUsedAndFeeProcessor) isESDTOperationWithSCCall(tx *transaction.ApiTransactionResult) bool {
+	isESDTTransferOperation := tx.Operation == core.BuiltInFunctionESDTTransfer ||
+		tx.Operation == core.BuiltInFunctionESDTNFTTransfer || tx.Operation == core.BuiltInFunctionMultiESDTNFTTransfer
+
+	receiverIsSC := core.IsSmartContractAddress(tx.Tx.GetRcvAddr())
+	hasFunction := tx.Function != ""
+	if !hasFunction {
+		return false
+	}
+
+	if tx.Sender != tx.Receiver {
+		return isESDTTransferOperation && receiverIsSC && hasFunction
+	}
+
+	if len(tx.Receivers) == 0 {
+		return false
+	}
+
+	receiver := tx.Receivers[0]
+	decodedReceiver, err := gfp.pubKeyConverter.Decode(receiver)
+	if err != nil {
+		log.Warn("gpf.isESDTOperationWithSCCall cannot decode receiver address", "error", err.Error())
+		return false
+	}
+
+	receiverIsSC = core.IsSmartContractAddress(decodedReceiver)
+
+	return isESDTTransferOperation && receiverIsSC && hasFunction
 }

--- a/node/external/transactionAPI/gasUsedAndFeeProcessor.go
+++ b/node/external/transactionAPI/gasUsedAndFeeProcessor.go
@@ -81,14 +81,14 @@ func (gfp *gasUsedAndFeeProcessor) isESDTOperationWithSCCall(tx *transaction.Api
 	isESDTTransferOperation := tx.Operation == core.BuiltInFunctionESDTTransfer ||
 		tx.Operation == core.BuiltInFunctionESDTNFTTransfer || tx.Operation == core.BuiltInFunctionMultiESDTNFTTransfer
 
-	receiverIsSC := core.IsSmartContractAddress(tx.Tx.GetRcvAddr())
+	isReceiverSC := core.IsSmartContractAddress(tx.Tx.GetRcvAddr())
 	hasFunction := tx.Function != ""
 	if !hasFunction {
 		return false
 	}
 
 	if tx.Sender != tx.Receiver {
-		return isESDTTransferOperation && receiverIsSC && hasFunction
+		return isESDTTransferOperation && isReceiverSC && hasFunction
 	}
 
 	if len(tx.Receivers) == 0 {
@@ -98,11 +98,11 @@ func (gfp *gasUsedAndFeeProcessor) isESDTOperationWithSCCall(tx *transaction.Api
 	receiver := tx.Receivers[0]
 	decodedReceiver, err := gfp.pubKeyConverter.Decode(receiver)
 	if err != nil {
-		log.Warn("gpf.isESDTOperationWithSCCall cannot decode receiver address", "error", err.Error())
+		log.Warn("gasUsedAndFeeProcessor.isESDTOperationWithSCCall cannot decode receiver address", "error", err.Error())
 		return false
 	}
 
-	receiverIsSC = core.IsSmartContractAddress(decodedReceiver)
+	isReceiverSC = core.IsSmartContractAddress(decodedReceiver)
 
-	return isESDTTransferOperation && receiverIsSC && hasFunction
+	return isESDTTransferOperation && isReceiverSC && hasFunction
 }

--- a/node/external/transactionAPI/gasUsedAndFeeProcessor_test.go
+++ b/node/external/transactionAPI/gasUsedAndFeeProcessor_test.go
@@ -24,7 +24,7 @@ func TestComputeTransactionGasUsedAndFeeMoveBalance(t *testing.T) {
 	})
 	computer := fee.NewTestFeeComputer(feeComp)
 
-	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(computer)
+	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(computer, pubKeyConverter)
 
 	sender := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
 	receiver := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
@@ -53,7 +53,7 @@ func TestComputeTransactionGasUsedAndFeeLogWithError(t *testing.T) {
 	})
 	computer := fee.NewTestFeeComputer(feeComp)
 
-	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(computer)
+	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(computer, pubKeyConverter)
 
 	sender := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
 	receiver := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
@@ -95,7 +95,7 @@ func TestComputeTransactionGasUsedAndFeeRelayedTxWithWriteLog(t *testing.T) {
 	})
 	computer := fee.NewTestFeeComputer(feeComp)
 
-	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(computer)
+	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(computer, pubKeyConverter)
 
 	sender := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
 	receiver := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
@@ -132,7 +132,7 @@ func TestComputeTransactionGasUsedAndFeeTransactionWithScrWithRefund(t *testing.
 	})
 	computer := fee.NewTestFeeComputer(feeComp)
 
-	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(computer)
+	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(computer, pubKeyConverter)
 
 	sender := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
 	receiver := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
@@ -165,4 +165,37 @@ func TestComputeTransactionGasUsedAndFeeTransactionWithScrWithRefund(t *testing.
 	gasUsedAndFeeProc.computeAndAttachGasUsedAndFee(txWithSRefundSCR)
 	require.Equal(uint64(3_365_000), txWithSRefundSCR.GasUsed)
 	require.Equal("98000000000000", txWithSRefundSCR.Fee)
+}
+
+func TestNFTTransferWithScCall(t *testing.T) {
+	require := require.New(t)
+	feeComp, _ := fee.NewFeeComputer(fee.ArgsNewFeeComputer{
+		BuiltInFunctionsCostHandler: &testscommon.BuiltInCostHandlerStub{},
+		EconomicsConfig:             testscommon.GetEconomicsConfig(),
+	})
+	computer := fee.NewTestFeeComputer(feeComp)
+
+	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(computer, pubKeyConverter)
+
+	sender := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
+	receiver := "erd1wc3uh22g2aved3qeehkz9kzgrjwxhg9mkkxp2ee7jj7ph34p2csq0n2y5x"
+
+	tx := &transaction.ApiTransactionResult{
+		Tx: &transaction.Transaction{
+			GasLimit: 55_000_000,
+			GasPrice: 1000000000,
+			SndAddr:  silentDecodeAddress(sender),
+			RcvAddr:  silentDecodeAddress(receiver),
+			Data:     []byte("ESDTNFTTransfer@434f572d636434363364@080c@01@00000000000000000500d3b28828d62052124f07dcd50ed31b0825f60eee1526@616363657074476c6f62616c4f66666572@c3e5q"),
+		},
+		GasLimit:  55_000_000,
+		Receivers: []string{"erd1qqqqqqqqqqqqqpgq6wegs2xkypfpync8mn2sa5cmpqjlvrhwz5nqgepyg8"},
+		Function:  "acceptGlobalOffer",
+		Operation: "ESDTNFTTransfer",
+	}
+	tx.InitiallyPaidFee = feeComp.ComputeTransactionFee(tx).String()
+
+	gasUsedAndFeeProc.computeAndAttachGasUsedAndFee(tx)
+	require.Equal(uint64(55_000_000), tx.GasUsed)
+	require.Equal("822250000000000", tx.Fee)
 }

--- a/outport/process/factory/check_test.go
+++ b/outport/process/factory/check_test.go
@@ -17,7 +17,7 @@ import (
 func createArgOutportDataProviderFactory() ArgOutportDataProviderFactory {
 	return ArgOutportDataProviderFactory{
 		HasDrivers:             false,
-		AddressConverter:       &testscommon.PubkeyConverterMock{},
+		AddressConverter:       testscommon.NewPubkeyConverterMock(32),
 		AccountsDB:             &state.AccountsStub{},
 		Marshaller:             &testscommon.MarshalizerMock{},
 		EsdtDataStorageHandler: &testscommon.EsdtStorageHandlerStub{},

--- a/outport/process/factory/outportDataProviderFactory.go
+++ b/outport/process/factory/outportDataProviderFactory.go
@@ -64,6 +64,7 @@ func CreateOutportDataProvider(arg ArgOutportDataProviderFactory) (outport.DataP
 		TransactionsStorer: arg.TransactionsStorer,
 		ShardCoordinator:   arg.ShardCoordinator,
 		TxFeeCalculator:    arg.EconomicsData,
+		PubKeyConverter:    arg.AddressConverter,
 	})
 	if err != nil {
 		return nil, err

--- a/outport/process/transactionsfee/interface.go
+++ b/outport/process/transactionsfee/interface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	datafield "github.com/multiversx/mx-chain-vm-common-go/parsers/dataField"
 )
 
 // FeesProcessorHandler defines the interface for the transaction fees processor
@@ -17,4 +18,8 @@ type FeesProcessorHandler interface {
 
 type transactionGetter interface {
 	GetTxByHash(txHash []byte) (*transaction.Transaction, error)
+}
+
+type dataFieldParser interface {
+	Parse(dataField []byte, sender, receiver []byte, numOfShards uint32) *datafield.ResponseParseData
 }

--- a/outport/process/transactionsfee/transactionChecker.go
+++ b/outport/process/transactionsfee/transactionChecker.go
@@ -18,23 +18,23 @@ func (tep *transactionsFeeProcessor) isESDTOperationWithSCCall(tx data.Transacti
 	isESDTTransferOperation := res.Operation == core.BuiltInFunctionESDTTransfer ||
 		res.Operation == core.BuiltInFunctionESDTNFTTransfer || res.Operation == core.BuiltInFunctionMultiESDTNFTTransfer
 
-	receiverIsSC := core.IsSmartContractAddress(tx.GetRcvAddr())
+	isReceiverSC := core.IsSmartContractAddress(tx.GetRcvAddr())
 	hasFunction := res.Function != ""
 	if !hasFunction {
 		return false
 	}
 
 	if !bytes.Equal(tx.GetSndAddr(), tx.GetRcvAddr()) {
-		return isESDTTransferOperation && receiverIsSC && hasFunction
+		return isESDTTransferOperation && isReceiverSC && hasFunction
 	}
 
 	if len(res.Receivers) == 0 {
 		return false
 	}
 
-	receiverIsSC = core.IsSmartContractAddress(res.Receivers[0])
+	isReceiverSC = core.IsSmartContractAddress(res.Receivers[0])
 
-	return isESDTTransferOperation && receiverIsSC && hasFunction
+	return isESDTTransferOperation && isReceiverSC && hasFunction
 }
 
 func isSCRForSenderWithRefund(scr *smartContractResult.SmartContractResult, txHash []byte, tx data.TransactionHandlerWithGasUsedAndFee) bool {

--- a/outport/process/transactionsfee/transactionsFeeProcessor.go
+++ b/outport/process/transactionsfee/transactionsFeeProcessor.go
@@ -10,7 +10,11 @@ import (
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/sharding"
 	"github.com/multiversx/mx-chain-go/storage"
+	logger "github.com/multiversx/mx-chain-logger-go"
+	datafield "github.com/multiversx/mx-chain-vm-common-go/parsers/dataField"
 )
+
+var log = logger.GetOrCreate("outport/process/transactionsfee")
 
 // ArgTransactionsFeeProcessor holds the arguments needed for creating a new instance of transactionsFeeProcessor
 type ArgTransactionsFeeProcessor struct {
@@ -18,12 +22,14 @@ type ArgTransactionsFeeProcessor struct {
 	TransactionsStorer storage.Storer
 	ShardCoordinator   sharding.Coordinator
 	TxFeeCalculator    FeesProcessorHandler
+	PubKeyConverter    core.PubkeyConverter
 }
 
 type transactionsFeeProcessor struct {
 	txGetter         transactionGetter
 	txFeeCalculator  FeesProcessorHandler
 	shardCoordinator sharding.Coordinator
+	dataFieldParser  dataFieldParser
 }
 
 // NewTransactionsFeeProcessor will create a new instance of transactionsFeeProcessor
@@ -33,10 +39,19 @@ func NewTransactionsFeeProcessor(arg ArgTransactionsFeeProcessor) (*transactions
 		return nil, err
 	}
 
+	parser, err := datafield.NewOperationDataFieldParser(&datafield.ArgsOperationDataFieldParser{
+		AddressLength: arg.PubKeyConverter.Len(),
+		Marshalizer:   arg.Marshaller,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	return &transactionsFeeProcessor{
 		txFeeCalculator:  arg.TxFeeCalculator,
 		shardCoordinator: arg.ShardCoordinator,
 		txGetter:         newTxGetter(arg.TransactionsStorer, arg.Marshaller),
+		dataFieldParser:  parser,
 	}, nil
 }
 
@@ -52,6 +67,9 @@ func checkArg(arg ArgTransactionsFeeProcessor) error {
 	}
 	if check.IfNil(arg.Marshaller) {
 		return ErrNilMarshaller
+	}
+	if check.IfNil(arg.PubKeyConverter) {
+		return core.ErrNilPubkeyConverter
 	}
 
 	return nil
@@ -86,7 +104,7 @@ func (tep *transactionsFeeProcessor) prepareNormalTxs(transactionsAndScrs *trans
 		txWithResult.SetFee(fee)
 		txWithResult.SetInitialPaidFee(initialPaidFee)
 
-		if isRelayedTx(txWithResult) {
+		if isRelayedTx(txWithResult) || tep.isESDTOperationWithSCCall(txWithResult) {
 			txWithResult.SetGasUsed(txWithResult.GetGasLimit())
 			txWithResult.SetFee(initialPaidFee)
 		}

--- a/outport/process/transactionsfee/transactionsFeeProcessor_test.go
+++ b/outport/process/transactionsfee/transactionsFeeProcessor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/core/pubkeyConverter"
 	coreData "github.com/multiversx/mx-chain-core-go/data"
 	outportcore "github.com/multiversx/mx-chain-core-go/data/outport"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
@@ -15,12 +16,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var pubKeyConverter, _ = pubkeyConverter.NewBech32PubkeyConverter(32, log)
+
 func prepareMockArg() ArgTransactionsFeeProcessor {
 	return ArgTransactionsFeeProcessor{
 		Marshaller:         testscommon.MarshalizerMock{},
 		TransactionsStorer: genericMocks.NewStorerMock(),
 		ShardCoordinator:   &testscommon.ShardsCoordinatorMock{},
 		TxFeeCalculator:    &mock.EconomicsHandlerMock{},
+		PubKeyConverter:    pubKeyConverter,
 	}
 }
 
@@ -297,4 +301,41 @@ func TestPutFeeAndGasUsedWrongRelayedTx(t *testing.T) {
 	require.Equal(t, big.NewInt(6103405000000000), initialTx.GetFee())
 	require.Equal(t, uint64(550000000), initialTx.GetGasUsed())
 	require.Equal(t, "6103405000000000", initialTx.GetInitialPaidFee().String())
+}
+
+func TestPutFeeAndGasUsedESDTWithScCall(t *testing.T) {
+	t.Parallel()
+
+	txHash := []byte("tx")
+	tx := outportcore.NewTransactionHandlerWithGasAndFee(&transaction.Transaction{
+		Nonce:    1011,
+		SndAddr:  silentDecodeAddress("erd1dglncxk6sl9a3xumj78n6z2xux4ghp5c92cstv5zsn56tjgtdwpsk46qrs"),
+		RcvAddr:  silentDecodeAddress("erd1dglncxk6sl9a3xumj78n6z2xux4ghp5c92cstv5zsn56tjgtdwpsk46qrs"),
+		GasLimit: 55_000_000,
+		GasPrice: 1000000000,
+		Data:     []byte("ESDTNFTTransfer@434f572d636434363364@080c@01@00000000000000000500d3b28828d62052124f07dcd50ed31b0825f60eee1526@616363657074476c6f62616c4f66666572@c3e5"),
+		Value:    big.NewInt(0),
+	}, 0, big.NewInt(0))
+
+	pool := &outportcore.Pool{
+		Txs: map[string]coreData.TransactionHandlerWithGasUsedAndFee{
+			string(txHash): tx,
+		},
+	}
+
+	arg := prepareMockArg()
+	txsFeeProc, err := NewTransactionsFeeProcessor(arg)
+	require.NotNil(t, txsFeeProc)
+	require.Nil(t, err)
+
+	err = txsFeeProc.PutFeeAndGasUsed(pool)
+	require.Nil(t, err)
+	require.Equal(t, big.NewInt(820765000000000), tx.GetFee())
+	require.Equal(t, uint64(55_000_000), tx.GetGasUsed())
+	require.Equal(t, "820765000000000", tx.GetInitialPaidFee().String())
+}
+
+func silentDecodeAddress(address string) []byte {
+	decoded, _ := pubKeyConverter.Decode(address)
+	return decoded
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- Bug-fix the problem of how is calculated the `gasUsed` and `fee` fields for the transaction structure that is returned by the `/transction/${txHash}` endpoint and for the `outport` package
  
## Proposed changes
- In case of an ESDT Transfer ( fungible token transfer, nft transfer, or multi transfer) with smart contract calls the fee field will be set with initialPaidFee and the gasUsed field will be set with gasLimit of the transaction. This solution will solve the case when we have this kind of transaction and it fails (in that case these fields were incorrect).

## Testing procedure
- For a failed transaction with an ESDT transfer and SC call check if the `gasUsed` and `fee` fields are calculated correctly.


## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
