### PR TITLE
Relayed guard accounts semi integration tests

### DIFF
--- a/integrationTests/multiShard/relayedTx/common.go
+++ b/integrationTests/multiShard/relayedTx/common.go
@@ -11,7 +11,6 @@ import (
 	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/state"
-	"github.com/multiversx/mx-chain-go/testscommon/txDataBuilder"
 )
 
 // CreateGeneralSetupForRelayTxTest will create the general setup for relayed transactions
@@ -158,21 +157,13 @@ func createRelayedTxV2(
 	userTx *transaction.Transaction,
 	gasLimitForUserTx uint64,
 ) *transaction.Transaction {
-	dataBuilder := txDataBuilder.NewBuilder()
-	txData := dataBuilder.
-		Func(core.RelayedTransactionV2).
-		Bytes(userTx.RcvAddr).
-		Int64(int64(userTx.Nonce)).
-		Bytes(userTx.Data).
-		Bytes(userTx.Signature)
-
 	tx := &transaction.Transaction{
 		Nonce:    relayer.Nonce,
 		Value:    big.NewInt(0).Set(userTx.Value),
 		RcvAddr:  userTx.SndAddr,
 		SndAddr:  relayer.Address,
 		GasPrice: integrationTests.MinTxGasPrice,
-		Data:     txData.ToBytes(),
+		Data:     integrationTests.PrepareRelayedTxDataV2(userTx),
 		ChainID:  userTx.ChainID,
 		Version:  userTx.Version,
 	}

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -61,6 +61,7 @@ import (
 	testStorage "github.com/multiversx/mx-chain-go/testscommon/state"
 	"github.com/multiversx/mx-chain-go/testscommon/statusHandler"
 	statusHandlerMock "github.com/multiversx/mx-chain-go/testscommon/statusHandler"
+	"github.com/multiversx/mx-chain-go/testscommon/txDataBuilder"
 	"github.com/multiversx/mx-chain-go/trie"
 	"github.com/multiversx/mx-chain-go/trie/hashesHolder"
 	"github.com/multiversx/mx-chain-go/vm"
@@ -2538,4 +2539,23 @@ func SaveDelegationContractsList(nodes []*TestProcessorNode) {
 		_ = n.AccntState.SaveAccount(userAcc)
 		_, _ = n.AccntState.Commit()
 	}
+}
+
+// PrepareRelayedTxDataV1 repares the data for a relayed transaction V1
+func PrepareRelayedTxDataV1(innerTx *transaction.Transaction) []byte {
+	userTxBytes, _ := TestMarshalizer.Marshal(innerTx)
+	return []byte(core.RelayedTransaction + "@" + hex.EncodeToString(userTxBytes))
+}
+
+// PrepareRelayedTxDataV2 prepares the data for a relayed transaction V2
+func PrepareRelayedTxDataV2(innerTx *transaction.Transaction) []byte {
+	dataBuilder := txDataBuilder.NewBuilder()
+	txData := dataBuilder.
+		Func(core.RelayedTransactionV2).
+		Bytes(innerTx.RcvAddr).
+		Int64(int64(innerTx.Nonce)).
+		Bytes(innerTx.Data).
+		Bytes(innerTx.Signature)
+
+	return txData.ToBytes()
 }

--- a/integrationTests/vm/txsFee/asyncCall_test.go
+++ b/integrationTests/vm/txsFee/asyncCall_test.go
@@ -34,7 +34,6 @@ func TestAsyncCallShouldWork(t *testing.T) {
 	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, egldBalance)
 	_, _ = vm.CreateAccount(testContext.Accounts, senderAddr, 0, egldBalance)
 
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(50000)
 
@@ -93,7 +92,6 @@ func TestMinterContractWithAsyncCalls(t *testing.T) {
 	token := []byte("miiutoken")
 	roles := [][]byte{[]byte(core.ESDTRoleNFTCreate)}
 
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(500000)
 	pathToContract := "testdata/minter/minter.wasm"

--- a/integrationTests/vm/txsFee/asyncESDT_test.go
+++ b/integrationTests/vm/txsFee/asyncESDT_test.go
@@ -36,7 +36,6 @@ func TestAsyncESDTCallShouldWork(t *testing.T) {
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance)
 
 	// deploy 2 contracts
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(50000)
 
@@ -89,7 +88,6 @@ func TestAsyncESDTCallSecondScRefusesPayment(t *testing.T) {
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance)
 
 	// deploy 2 contracts
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(50000)
 
@@ -143,7 +141,6 @@ func TestAsyncESDTCallsOutOfGas(t *testing.T) {
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance)
 
 	// deploy 2 contracts
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(50000)
 
@@ -193,7 +190,6 @@ func TestAsyncMultiTransferOnCallback(t *testing.T) {
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, ownerAddr, big.NewInt(1000000000), sftTokenID, sftNonce, sftBalance)
 	utils.CheckESDTNFTBalance(t, testContext, ownerAddr, sftTokenID, sftNonce, sftBalance)
 
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(1000000)
 	txGasLimit := uint64(1000000)
@@ -287,7 +283,6 @@ func TestAsyncMultiTransferOnCallAndOnCallback(t *testing.T) {
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, ownerAddr, big.NewInt(1000000000), sftTokenID, sftNonce, sftBalance)
 	utils.CheckESDTNFTBalance(t, testContext, ownerAddr, sftTokenID, sftNonce, sftBalance)
 
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(1000000)
 	txGasLimit := uint64(1000000)
@@ -387,7 +382,6 @@ func TestSendNFTToContractWith0Function(t *testing.T) {
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, ownerAddr, big.NewInt(1000000000), sftTokenID, sftNonce, sftBalance)
 	utils.CheckESDTNFTBalance(t, testContext, ownerAddr, sftTokenID, sftNonce, sftBalance)
 
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(1000000)
 	txGasLimit := uint64(1000000)
@@ -437,7 +431,6 @@ func TestSendNFTToContractWith0FunctionNonPayable(t *testing.T) {
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, ownerAddr, big.NewInt(1000000000), sftTokenID, sftNonce, sftBalance)
 	utils.CheckESDTNFTBalance(t, testContext, ownerAddr, sftTokenID, sftNonce, sftBalance)
 
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(1000000)
 	txGasLimit := uint64(1000000)

--- a/integrationTests/vm/txsFee/backwardsCompatibility_test.go
+++ b/integrationTests/vm/txsFee/backwardsCompatibility_test.go
@@ -30,7 +30,6 @@ func TestMoveBalanceSelfShouldWorkAndConsumeTxFeeWhenAllFlagsAreDisabled(t *test
 	sndAddr := []byte("12345678901234567890123456789012")
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(10000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(100)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -72,7 +71,6 @@ func TestMoveBalanceAllFlagsDisabledLessBalanceThanGasLimitMulGasPrice(t *testin
 	sndAddr := []byte("12345678901234567890123456789012")
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(10000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(10000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -97,7 +95,6 @@ func TestMoveBalanceSelfShouldWorkAndConsumeTxFeeWhenSomeFlagsAreDisabled(t *tes
 	sndAddr := []byte("12345678901234567890123456789012")
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(10000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(100)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)

--- a/integrationTests/vm/txsFee/builtInFunctions_test.go
+++ b/integrationTests/vm/txsFee/builtInFunctions_test.go
@@ -36,7 +36,6 @@ func TestBuildInFunctionChangeOwnerCallShouldWork(t *testing.T) {
 	utils.CleanAccumulatedIntermediateTransactions(t, testContext)
 
 	newOwner := []byte("12345678901234567890123456789112")
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	txData := []byte(core.BuiltInFunctionChangeOwnerAddress + "@" + hex.EncodeToString(newOwner))
@@ -72,7 +71,6 @@ func TestBuildInFunctionChangeOwnerCallWrongOwnerShouldConsumeGas(t *testing.T) 
 
 	sndAddr := []byte("12345678901234567890123456789113")
 	newOwner := []byte("12345678901234567890123456789112")
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, big.NewInt(100000))
@@ -109,7 +107,6 @@ func TestBuildInFunctionChangeOwnerInvalidAddressShouldConsumeGas(t *testing.T) 
 	testContext.TxFeeHandler.CreateBlockStarted(getZeroGasAndFees())
 
 	newOwner := []byte("invalidAddress")
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	txData := []byte(core.BuiltInFunctionChangeOwnerAddress + "@" + hex.EncodeToString(newOwner))
@@ -143,7 +140,6 @@ func TestBuildInFunctionChangeOwnerCallInsufficientGasLimitShouldNotConsumeGas(t
 	testContext.TxFeeHandler.CreateBlockStarted(getZeroGasAndFees())
 
 	newOwner := []byte("12345678901234567890123456789112")
-	gasPrice := uint64(10)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, owner, 1, big.NewInt(10970))
 
@@ -181,7 +177,6 @@ func TestBuildInFunctionChangeOwnerOutOfGasShouldConsumeGas(t *testing.T) {
 	testContext.TxFeeHandler.CreateBlockStarted(getZeroGasAndFees())
 
 	newOwner := []byte("12345678901234567890123456789112")
-	gasPrice := uint64(10)
 
 	txData := []byte(core.BuiltInFunctionChangeOwnerAddress + "@" + hex.EncodeToString(newOwner))
 	gasLimit := uint64(len(txData) + 1)
@@ -226,7 +221,6 @@ func TestBuildInFunctionSaveKeyValue_WrongDestination(t *testing.T) {
 
 	txData := []byte(core.BuiltInFunctionSaveKeyValue + "@01@02")
 	gasLimit := uint64(len(txData) + 1)
-	gasPrice := uint64(10)
 
 	tx := vm.CreateTransaction(0, big.NewInt(0), sndAddr, destAddr, gasPrice, gasLimit, txData)
 	retCode, err := testContext.TxProcessor.ProcessTransaction(tx)
@@ -259,7 +253,6 @@ func TestBuildInFunctionSaveKeyValue_NotEnoughGasFor3rdSave(t *testing.T) {
 
 	txData := []byte(core.BuiltInFunctionSaveKeyValue + "@01000000@02000000@03000000@04000000@05000000@06000000")
 	gasLimit := uint64(len(txData) + 20)
-	gasPrice := uint64(10)
 
 	tx := vm.CreateTransaction(0, big.NewInt(0), sndAddr, sndAddr, gasPrice, gasLimit, txData)
 	retCode, err := testContext.TxProcessor.ProcessTransaction(tx)

--- a/integrationTests/vm/txsFee/dns_test.go
+++ b/integrationTests/vm/txsFee/dns_test.go
@@ -30,7 +30,6 @@ func TestDeployDNSContract_TestRegisterAndResolveAndSendTxWithSndAndRcvUserName(
 
 	sndAddr := []byte("12345678901234567890123456789112")
 	senderBalance := big.NewInt(10000000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(200000)
 
 	rcvAddr := []byte("12345678901234567890123456789113")

--- a/integrationTests/vm/txsFee/esdtLocalBurn_test.go
+++ b/integrationTests/vm/txsFee/esdtLocalBurn_test.go
@@ -26,7 +26,6 @@ func TestESDTLocalBurnShouldWork(t *testing.T) {
 	roles := [][]byte{[]byte(core.ESDTRoleLocalMint), []byte(core.ESDTRoleLocalBurn)}
 	utils.CreateAccountWithESDTBalanceAndRoles(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance, roles)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(40)
 	tx := utils.CreateESDTLocalBurnTx(0, sndAddr, sndAddr, token, big.NewInt(100), gasPrice, gasLimit)
 	retCode, err := testContext.TxProcessor.ProcessTransaction(tx)
@@ -57,7 +56,6 @@ func TestESDTLocalBurnMoreThanTotalBalanceShouldErr(t *testing.T) {
 	roles := [][]byte{[]byte(core.ESDTRoleLocalMint), []byte(core.ESDTRoleLocalBurn)}
 	utils.CreateAccountWithESDTBalanceAndRoles(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance, roles)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(60)
 	tx := utils.CreateESDTLocalBurnTx(0, sndAddr, sndAddr, token, big.NewInt(100000001), gasPrice, gasLimit)
 	retCode, err := testContext.TxProcessor.ProcessTransaction(tx)
@@ -87,7 +85,6 @@ func TestESDTLocalBurnNotAllowedShouldErr(t *testing.T) {
 	token := []byte("miiutoken")
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(40)
 	tx := utils.CreateESDTLocalBurnTx(0, sndAddr, sndAddr, token, big.NewInt(100), gasPrice, gasLimit)
 	retCode, err := testContext.TxProcessor.ProcessTransaction(tx)

--- a/integrationTests/vm/txsFee/esdtLocalMint_test.go
+++ b/integrationTests/vm/txsFee/esdtLocalMint_test.go
@@ -26,7 +26,6 @@ func TestESDTLocalMintShouldWork(t *testing.T) {
 	roles := [][]byte{[]byte(core.ESDTRoleLocalMint), []byte(core.ESDTRoleLocalBurn)}
 	utils.CreateAccountWithESDTBalanceAndRoles(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance, roles)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(40)
 	tx := utils.CreateESDTLocalMintTx(0, sndAddr, sndAddr, token, big.NewInt(100), gasPrice, gasLimit)
 	retCode, err := testContext.TxProcessor.ProcessTransaction(tx)
@@ -56,7 +55,6 @@ func TestESDTLocalMintNotAllowedShouldErr(t *testing.T) {
 	token := []byte("miiutoken")
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(40)
 	tx := utils.CreateESDTLocalMintTx(0, sndAddr, sndAddr, token, big.NewInt(100), gasPrice, gasLimit)
 	retCode, err := testContext.TxProcessor.ProcessTransaction(tx)

--- a/integrationTests/vm/txsFee/esdt_test.go
+++ b/integrationTests/vm/txsFee/esdt_test.go
@@ -30,7 +30,6 @@ func TestESDTTransferShouldWork(t *testing.T) {
 	token := []byte("miiutoken")
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(40)
 	tx := utils.CreateESDTTransferTx(0, sndAddr, rcvAddr, token, big.NewInt(100), gasPrice, gasLimit)
 	retCode, err := testContext.TxProcessor.ProcessTransaction(tx)
@@ -67,7 +66,6 @@ func TestESDTTransferShouldWorkToMuchGasShouldConsumeAllGas(t *testing.T) {
 	token := []byte("miiutoken")
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 	tx := utils.CreateESDTTransferTx(0, sndAddr, rcvAddr, token, big.NewInt(100), gasPrice, gasLimit)
 	retCode, err := testContext.TxProcessor.ProcessTransaction(tx)
@@ -104,7 +102,6 @@ func TestESDTTransferInvalidESDTValueShouldConsumeGas(t *testing.T) {
 	token := []byte("miiutoken")
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 	tx := utils.CreateESDTTransferTx(0, sndAddr, rcvAddr, token, big.NewInt(100000000+1), gasPrice, gasLimit)
 

--- a/integrationTests/vm/txsFee/guardAccount_test.go
+++ b/integrationTests/vm/txsFee/guardAccount_test.go
@@ -33,7 +33,6 @@ import (
 )
 
 const txWithOptionVersion = 2
-const gasPrice = uint64(10)
 const guardianSigVerificationGas = uint64(50000)
 const guardAccountGas = uint64(250000)
 const unGuardAccountGas = uint64(250000)

--- a/integrationTests/vm/txsFee/guardAccount_test.go
+++ b/integrationTests/vm/txsFee/guardAccount_test.go
@@ -16,15 +16,17 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/guardians"
+	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-go/common/forking"
 	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/guardian"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/testscommon"
-	"github.com/multiversx/mx-chain-go/testscommon/integrationtests"
+	testscommonIntegrationTests "github.com/multiversx/mx-chain-go/testscommon/integrationtests"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,8 +44,8 @@ var (
 	alice         = []byte("alice-12345678901234567890123456")
 	bob           = []byte("bob-1234567890123456789012345678")
 	charlie       = []byte("charlie-123456789012345678901234")
-	delta         = []byte("delta-12345678901234567890123456")
-	allAddresses  = [][]byte{alice, bob, charlie, delta}
+	david         = []byte("david-12345678901234567890123456")
+	allAddresses  = [][]byte{alice, bob, charlie, david}
 	uuid          = []byte("uuid")
 	transferValue = big.NewInt(2000000)
 	initialMint   = big.NewInt(1000000000000000000)
@@ -71,7 +73,7 @@ func createUnGuardedAccountStatus() guardAccountStatus {
 
 func prepareTestContextForGuardedAccounts(tb testing.TB) *vm.VMTestContext {
 	unreachableEpoch := uint32(999999)
-	db := integrationtests.CreateStorer(tb.TempDir())
+	db := testscommonIntegrationTests.CreateStorer(tb.TempDir())
 	gasScheduleDir := "../../../cmd/node/config/gasSchedules"
 
 	cfg := config.GasScheduleByEpochs{
@@ -422,7 +424,7 @@ func TestGuardAccount_SendingFundsWhileProtectedAndNotProtected(t *testing.T) {
 	testContext := prepareTestContextForGuardedAccounts(t)
 	defer testContext.Close()
 
-	// alice is the user, bob is the guardian, charlie is the receiver, delta is the wrong guardian
+	// alice is the user, bob is the guardian, charlie is the receiver, david is the wrong guardian
 	mintAddress(t, testContext, alice, initialMint)
 
 	expectedStatus := createUnGuardedAccountStatus()
@@ -511,8 +513,8 @@ func TestGuardAccount_SendingFundsWhileProtectedAndNotProtected(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, big.NewInt(transferValue.Int64()*4), getBalance(testContext, charlie))
 
-	// userAddress can not send funds while protected with a wrong guardian address (delta)
-	err = transferFundsCoSigned(testContext, alice, transferValue, charlie, delta)
+	// userAddress can not send funds while protected with a wrong guardian address (david)
+	err = transferFundsCoSigned(testContext, alice, transferValue, charlie, david)
 	require.ErrorIs(t, err, process.ErrTransactionNotExecutable)
 	require.Contains(t, err.Error(), "mismatch between transaction guardian and configured account guardian")
 	require.Equal(t, big.NewInt(transferValue.Int64()*4), getBalance(testContext, charlie))
@@ -525,13 +527,13 @@ func TestGuardAccount_SendingFundsWhileProtectedAndNotProtected(t *testing.T) {
 }
 
 // Scenario 1 description:
-// 1.  create & mint 4 addresses: alice, bob, charlie and delta
+// 1.  create & mint 4 addresses: alice, bob, charlie and david
 // 2.  alice sets bob as guardian (test if pending)
 // 3.  alice can not set bob as guardian again (test if pending & same activation epoch)
 //   3.1 alice can not set bob as guardian again even if one epoch past
 // 4.  alice activates the guardian (test if active)
 // 5.  alice sets charlie as pending guardian (test if pending & different activation epoch)
-//   5.1. alice wants to set delta as pending guardian (transaction is not executable, will not be included in a miniblock)
+//   5.1. alice wants to set david as pending guardian (transaction is not executable, will not be included in a miniblock)
 // 6.  alice sets charlie as guardian immediately through a cosigned transaction (test active & pending guardians)
 // 7.  alice immediately sets bob as guardian through a cosigned transaction (test active & pending guardians)
 // 8.  alice adds charlie as a pending guardian (test if pending & different activation epoch)
@@ -641,10 +643,10 @@ func TestGuardAccount_Scenario1(t *testing.T) {
 	}
 	testGuardianStatus(t, testContext, alice, expectedStatus)
 
-	// step 5.1 - alice tries to set delta as pending guardian, overwriting charlie
+	// step 5.1 - alice tries to set david as pending guardian, overwriting charlie
 	currentEpoch++
 	setNewEpochOnContext(testContext, currentEpoch)
-	returnCode, err = setGuardian(testContext, alice, delta, uuid)
+	returnCode, err = setGuardian(testContext, alice, david, uuid)
 	require.ErrorIs(t, err, process.ErrTransactionNotExecutable)
 	require.Equal(t, vmcommon.UserError, returnCode)
 	expectedStatus = guardAccountStatus{
@@ -795,7 +797,7 @@ func TestGuardAccount_Scenario1(t *testing.T) {
 	testGuardianStatus(t, testContext, alice, expectedStatus)
 
 	// 13. alice sends a guarded transaction, while account is guarded -> should work
-	err = transferFundsCoSigned(testContext, alice, transferValue, delta, charlie)
+	err = transferFundsCoSigned(testContext, alice, transferValue, david, charlie)
 	require.Nil(t, err)
 
 	// 14. alice un-guards the accounts immediately using a cosigned transaction and then sends a guarded transaction -> should error
@@ -812,9 +814,250 @@ func TestGuardAccount_Scenario1(t *testing.T) {
 		pending: nil,
 	}
 	testGuardianStatus(t, testContext, alice, expectedStatus)
-	err = transferFundsCoSigned(testContext, alice, transferValue, delta, charlie)
+	err = transferFundsCoSigned(testContext, alice, transferValue, david, charlie)
 	require.ErrorIs(t, err, process.ErrTransactionNotExecutable)
 	// 14.1 alice sends unguarded transaction -> should work
-	err = transferFunds(testContext, alice, transferValue, delta)
+	err = transferFunds(testContext, alice, transferValue, david)
 	require.Nil(t, err)
+}
+
+// 1. create & mint 4 addresses: alice, bob, charlie and david
+// 2. alice sets bob as guardian and the account becomes guarded
+// 3. test that charlie can send a relayed transaction v1 on the behalf of alice to david
+//   3.1 cosigned transaction should work
+//   3.2 single signed transaction should not work
+func TestGuardAccounts_RelayedTransactionV1(t *testing.T) {
+	testContext := prepareTestContextForGuardedAccounts(t)
+	defer testContext.Close()
+
+	// step 1 -  mint addresses
+	for _, address := range allAddresses {
+		mintAddress(t, testContext, address, initialMint)
+	}
+	expectedStatus := createUnGuardedAccountStatus()
+	for _, address := range allAddresses {
+		testGuardianStatus(t, testContext, address, expectedStatus)
+	}
+
+	currentEpoch := uint32(0)
+
+	// step 2 - alice sets bob as guardian
+	step2Epoch := currentEpoch
+	returnCode, err := setGuardian(testContext, alice, bob, uuid)
+	require.Nil(t, err)
+	require.Equal(t, vmcommon.Ok, returnCode)
+	currentEpoch += vm.EpochGuardianDelay
+	setNewEpochOnContext(testContext, currentEpoch)
+	returnCode, err = guardAccount(testContext, alice)
+	require.Nil(t, err)
+	require.Equal(t, vmcommon.Ok, returnCode)
+	expectedStatus = guardAccountStatus{
+		isGuarded: true,
+		active: &guardianInfo{
+			address: bob,
+			uuid:    uuid,
+			epoch:   step2Epoch + vm.EpochGuardianDelay,
+		},
+		pending: nil,
+	}
+	testGuardianStatus(t, testContext, alice, expectedStatus)
+
+	aliceCurrentBalance := getBalance(testContext, alice)
+
+	// step 3 - charlie sends a relayed transaction v1 on the behalf of alice
+	// 3.1 cosigned transaction should work
+	userTx := vm.CreateTransaction(
+		getNonce(testContext, alice),
+		transferValue,
+		alice,
+		david,
+		gasPrice,
+		transferGas+guardianSigVerificationGas,
+		make([]byte, 0))
+
+	userTx.GuardianAddr = bob
+	userTx.Options = userTx.Options | transaction.MaskGuardedTransaction
+	userTx.Version = txWithOptionVersion
+
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
+	rTxGasLimit := 1 + transferGas + guardianSigVerificationGas + uint64(len(rtxData))
+	rtx := vm.CreateTransaction(getNonce(testContext, charlie), big.NewInt(0), charlie, alice, gasPrice, rTxGasLimit, rtxData)
+	returnCode, err = testContext.TxProcessor.ProcessTransaction(rtx)
+	require.Nil(t, err)
+	require.Equal(t, vmcommon.Ok, returnCode)
+	// balance tests:
+	//  alice: aliceCurrentBalance - transferValue (no fee for relayed transaction)
+	//  bob: initialMint
+	//  charlie: initialMint - rtxGasLimit * gasPrice
+	//  david: initialMint + transferValue
+	aliceExpectedBalance := big.NewInt(0).Sub(aliceCurrentBalance, transferValue)
+	assert.Equal(t, aliceExpectedBalance, getBalance(testContext, alice))
+	bobExpectedBalance := big.NewInt(0).Set(initialMint)
+	assert.Equal(t, bobExpectedBalance, getBalance(testContext, bob))
+	charlieExpectedBalance := big.NewInt(0).Sub(initialMint, big.NewInt(int64(rTxGasLimit*gasPrice)))
+	assert.Equal(t, charlieExpectedBalance, getBalance(testContext, charlie))
+	davidExpectedBalance := big.NewInt(0).Add(initialMint, transferValue)
+	assert.Equal(t, davidExpectedBalance, getBalance(testContext, david))
+
+	aliceCurrentBalance = getBalance(testContext, alice)
+	charlieCurrentBalance := getBalance(testContext, charlie)
+	davidCurrentBalance := getBalance(testContext, david)
+	testContext.CleanIntermediateTransactions(t)
+
+	// 3.1 single signed transaction should not work
+	userTx = vm.CreateTransaction(
+		getNonce(testContext, alice),
+		transferValue,
+		alice,
+		david,
+		gasPrice,
+		transferGas+guardianSigVerificationGas,
+		make([]byte, 0))
+
+	userTx.Version = txWithOptionVersion
+
+	rtxData = integrationTests.PrepareRelayedTxDataV1(userTx)
+	rTxGasLimit = 1 + transferGas + guardianSigVerificationGas + uint64(len(rtxData))
+	rtx = vm.CreateTransaction(getNonce(testContext, charlie), big.NewInt(0), charlie, alice, gasPrice, rTxGasLimit, rtxData)
+	returnCode, err = testContext.TxProcessor.ProcessTransaction(rtx)
+	require.Nil(t, err)
+	require.Equal(t, vmcommon.UserError, returnCode)
+	intermediateTxs := testContext.GetIntermediateTransactions(t)
+	require.Equal(t, 1, len(intermediateTxs))
+	scr := intermediateTxs[0].(*smartContractResult.SmartContractResult)
+	// expectedReturnMessage is hardcoded for backwards compatibility reasons
+	expectedReturnMessage := "transaction is not executable and gas will not be consumed, not allowed to bypass guardian"
+	require.Equal(t, expectedReturnMessage, string(scr.ReturnMessage))
+	// balance tests:
+	//  alice: aliceCurrentBalance (no fee for the failed relayed transaction)
+	//  bob: initialMint
+	//  charlie: charlieCurrentBalance - rtxGasLimit * gasPrice
+	//  david: davidCurrentBalance
+	assert.Equal(t, aliceCurrentBalance, getBalance(testContext, alice))
+	bobExpectedBalance = big.NewInt(0).Set(initialMint)
+	assert.Equal(t, bobExpectedBalance, getBalance(testContext, bob))
+	charlieExpectedBalance = big.NewInt(0).Sub(charlieCurrentBalance, big.NewInt(int64(rTxGasLimit*gasPrice)))
+	assert.Equal(t, charlieExpectedBalance, getBalance(testContext, charlie))
+	assert.Equal(t, davidCurrentBalance, getBalance(testContext, david))
+}
+
+// 1. create & mint 4 addresses: alice, bob, charlie and david
+// 2. alice sets bob as guardian and the account becomes guarded
+// 3. test that charlie can not send a relayed transaction v2 on the behalf of alice to david
+//   3.1 cosigned transaction should not work
+//   3.2 single signed transaction should not work
+func TestGuardAccounts_RelayedTransactionV2(t *testing.T) {
+	testContext := prepareTestContextForGuardedAccounts(t)
+	defer testContext.Close()
+
+	// step 1 -  mint addresses
+	for _, address := range allAddresses {
+		mintAddress(t, testContext, address, initialMint)
+	}
+	expectedStatus := createUnGuardedAccountStatus()
+	for _, address := range allAddresses {
+		testGuardianStatus(t, testContext, address, expectedStatus)
+	}
+
+	currentEpoch := uint32(0)
+
+	// step 2 - alice sets bob as guardian
+	step2Epoch := currentEpoch
+	returnCode, err := setGuardian(testContext, alice, bob, uuid)
+	require.Nil(t, err)
+	require.Equal(t, vmcommon.Ok, returnCode)
+	currentEpoch += vm.EpochGuardianDelay
+	setNewEpochOnContext(testContext, currentEpoch)
+	returnCode, err = guardAccount(testContext, alice)
+	require.Nil(t, err)
+	require.Equal(t, vmcommon.Ok, returnCode)
+	expectedStatus = guardAccountStatus{
+		isGuarded: true,
+		active: &guardianInfo{
+			address: bob,
+			uuid:    uuid,
+			epoch:   step2Epoch + vm.EpochGuardianDelay,
+		},
+		pending: nil,
+	}
+	testGuardianStatus(t, testContext, alice, expectedStatus)
+
+	aliceCurrentBalance := getBalance(testContext, alice)
+	testContext.CleanIntermediateTransactions(t)
+
+	// step 3 - charlie sends a relayed transaction v1 on the behalf of alice
+	// 3.1 cosigned transaction should work
+	userTx := vm.CreateTransaction(
+		getNonce(testContext, alice),
+		transferValue,
+		alice,
+		david,
+		gasPrice,
+		transferGas+guardianSigVerificationGas,
+		make([]byte, 0))
+
+	userTx.GuardianAddr = bob
+	userTx.Options = userTx.Options | transaction.MaskGuardedTransaction
+	userTx.Version = txWithOptionVersion
+
+	rtxData := integrationTests.PrepareRelayedTxDataV2(userTx)
+	rTxGasLimit := 1 + transferGas + guardianSigVerificationGas + uint64(len(rtxData))
+	rtx := vm.CreateTransaction(getNonce(testContext, charlie), big.NewInt(0), charlie, alice, gasPrice, rTxGasLimit, rtxData)
+	returnCode, err = testContext.TxProcessor.ProcessTransaction(rtx)
+	require.Nil(t, err)
+	require.Equal(t, vmcommon.UserError, returnCode)
+	intermediateTxs := testContext.GetIntermediateTransactions(t)
+	require.Equal(t, 1, len(intermediateTxs))
+	scr := intermediateTxs[0].(*smartContractResult.SmartContractResult)
+	// expectedReturnMessage is hardcoded for backwards compatibility reasons
+	expectedReturnMessage := "transaction is not executable and gas will not be consumed, not allowed to bypass guardian"
+	require.Equal(t, expectedReturnMessage, string(scr.ReturnMessage))
+	// balance tests:
+	//  alice: aliceCurrentBalance (no fee for relayed transaction V2)
+	//  bob: initialMint
+	//  charlie: initialMint - rtxGasLimit * gasPrice
+	//  david: initialMint
+	assert.Equal(t, aliceCurrentBalance, getBalance(testContext, alice))
+	bobExpectedBalance := big.NewInt(0).Set(initialMint)
+	assert.Equal(t, bobExpectedBalance, getBalance(testContext, bob))
+	charlieExpectedBalance := big.NewInt(0).Sub(initialMint, big.NewInt(int64(rTxGasLimit*gasPrice)))
+	assert.Equal(t, charlieExpectedBalance, getBalance(testContext, charlie))
+	assert.Equal(t, initialMint, getBalance(testContext, david))
+
+	charlieCurrentBalance := getBalance(testContext, charlie)
+	testContext.CleanIntermediateTransactions(t)
+
+	// 3.1 single signed transaction should not work
+	userTx = vm.CreateTransaction(
+		getNonce(testContext, alice),
+		transferValue,
+		alice,
+		david,
+		gasPrice,
+		transferGas+guardianSigVerificationGas,
+		make([]byte, 0))
+
+	userTx.Version = txWithOptionVersion
+
+	rtxData = integrationTests.PrepareRelayedTxDataV2(userTx)
+	rTxGasLimit = 1 + transferGas + guardianSigVerificationGas + uint64(len(rtxData))
+	rtx = vm.CreateTransaction(getNonce(testContext, charlie), big.NewInt(0), charlie, alice, gasPrice, rTxGasLimit, rtxData)
+	returnCode, err = testContext.TxProcessor.ProcessTransaction(rtx)
+	require.Nil(t, err)
+	require.Equal(t, vmcommon.UserError, returnCode)
+	intermediateTxs = testContext.GetIntermediateTransactions(t)
+	require.Equal(t, 1, len(intermediateTxs))
+	scr = intermediateTxs[0].(*smartContractResult.SmartContractResult)
+	require.Equal(t, expectedReturnMessage, string(scr.ReturnMessage))
+	// balance tests:
+	//  alice: aliceCurrentBalance (no fee for the failed relayed transaction)
+	//  bob: initialMint
+	//  charlie: charlieCurrentBalance - rtxGasLimit * gasPrice
+	//  david: davidCurrentBalance
+	assert.Equal(t, aliceCurrentBalance, getBalance(testContext, alice))
+	bobExpectedBalance = big.NewInt(0).Set(initialMint)
+	assert.Equal(t, bobExpectedBalance, getBalance(testContext, bob))
+	charlieExpectedBalance = big.NewInt(0).Sub(charlieCurrentBalance, big.NewInt(int64(rTxGasLimit*gasPrice)))
+	assert.Equal(t, charlieExpectedBalance, getBalance(testContext, charlie))
+	assert.Equal(t, initialMint, getBalance(testContext, david))
 }

--- a/integrationTests/vm/txsFee/moveBalance_test.go
+++ b/integrationTests/vm/txsFee/moveBalance_test.go
@@ -25,7 +25,6 @@ func TestMoveBalanceSelfShouldWorkAndConsumeTxFee(t *testing.T) {
 	sndAddr := []byte("12345678901234567890123456789012")
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(10000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(100)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -61,7 +60,6 @@ func TestMoveBalanceAllFlagsEnabledLessBalanceThanGasLimitMulGasPrice(t *testing
 	sndAddr := []byte("12345678901234567890123456789012")
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(10000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(10000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -80,7 +78,6 @@ func TestMoveBalanceShouldWork(t *testing.T) {
 	rcvAddr := []byte("12345678901234567890123456789022")
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(10000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(100)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -120,10 +117,10 @@ func TestMoveBalanceInvalidHasGasButNoValueShouldConsumeGas(t *testing.T) {
 	sndAddr := []byte("12345678901234567890123456789012")
 	rcvAddr := []byte("12345678901234567890123456789022")
 	senderBalance := big.NewInt(100)
-	gasPrice := uint64(1)
+	gasPriceLocal := uint64(1)
 	gasLimit := uint64(20)
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
-	tx := vm.CreateTransaction(0, big.NewInt(100), sndAddr, rcvAddr, gasPrice, gasLimit, []byte("aaaa"))
+	tx := vm.CreateTransaction(0, big.NewInt(100), sndAddr, rcvAddr, gasPriceLocal, gasLimit, []byte("aaaa"))
 
 	returnCode, err := testContext.TxProcessor.ProcessTransaction(tx)
 	require.Equal(t, process.ErrFailedTransaction, err)
@@ -150,11 +147,11 @@ func TestMoveBalanceHigherNonceShouldNotConsumeGas(t *testing.T) {
 	rcvAddr := []byte("12345678901234567890123456789022")
 
 	senderBalance := big.NewInt(100)
-	gasPrice := uint64(1)
+	gasPriceLocal := uint64(1)
 	gasLimit := uint64(20)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
-	tx := vm.CreateTransaction(1, big.NewInt(500), sndAddr, rcvAddr, gasPrice, gasLimit, []byte("aaaa"))
+	tx := vm.CreateTransaction(1, big.NewInt(500), sndAddr, rcvAddr, gasPriceLocal, gasLimit, []byte("aaaa"))
 
 	_, err = testContext.TxProcessor.ProcessTransaction(tx)
 	require.Equal(t, process.ErrHigherNonceInTransaction, err)
@@ -180,11 +177,11 @@ func TestMoveBalanceMoreGasThanGasLimitPerMiniBlockForSafeCrossShard(t *testing.
 	rcvAddr := []byte("12345678901234567890123456789022")
 
 	senderBalance := big.NewInt(0).SetUint64(math.MaxUint64)
-	gasPrice := uint64(1)
+	gasPriceLocal := uint64(1)
 	gasLimit := uint64(math.MaxUint64)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
-	tx := vm.CreateTransaction(0, big.NewInt(500), sndAddr, rcvAddr, gasPrice, gasLimit, []byte("aaaa"))
+	tx := vm.CreateTransaction(0, big.NewInt(500), sndAddr, rcvAddr, gasPriceLocal, gasLimit, []byte("aaaa"))
 
 	returnCode, err := testContext.TxProcessor.ProcessTransaction(tx)
 	require.Equal(t, process.ErrMoreGasThanGasLimitPerBlock, err)
@@ -211,7 +208,6 @@ func TestMoveBalanceInvalidUserNames(t *testing.T) {
 	rcvAddr := []byte("12345678901234567890123456789022")
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(10000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(100)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)

--- a/integrationTests/vm/txsFee/moveBalance_test.go
+++ b/integrationTests/vm/txsFee/moveBalance_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const gasPrice = uint64(10)
+
 // minGasPrice = 1, gasPerDataByte = 1, minGasLimit = 1
 func TestMoveBalanceSelfShouldWorkAndConsumeTxFee(t *testing.T) {
 	testContext, err := vm.CreatePreparedTxProcessorWithVMs(config.EnableEpochs{})

--- a/integrationTests/vm/txsFee/multiESDTTransfer_test.go
+++ b/integrationTests/vm/txsFee/multiESDTTransfer_test.go
@@ -29,7 +29,6 @@ func TestMultiESDTTransferShouldWork(t *testing.T) {
 	secondToken := []byte("second")
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, big.NewInt(0), secondToken, 0, esdtBalance)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(4000)
 	tx := utils.CreateMultiTransferTX(0, sndAddr, rcvAddr, gasPrice, gasLimit, &utils.TransferESDTData{
 		Token: token,
@@ -87,7 +86,6 @@ func TestMultiESDTTransferFailsBecauseOfMaxLimit(t *testing.T) {
 	secondToken := []byte("second")
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, big.NewInt(0), secondToken, 0, esdtBalance)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(4000)
 	tx := utils.CreateMultiTransferTX(0, sndAddr, rcvAddr, gasPrice, gasLimit, &utils.TransferESDTData{
 		Token: token,

--- a/integrationTests/vm/txsFee/multiShard/relayedBuiltInFunctions_test.go
+++ b/integrationTests/vm/txsFee/multiShard/relayedBuiltInFunctions_test.go
@@ -56,7 +56,7 @@ func TestRelayedBuiltInFunctionExecuteOnRelayerAndDstShardShouldWork(t *testing.
 
 	_, _ = vm.CreateAccount(testContextRelayer.Accounts, relayerAddr, 0, big.NewInt(15000))
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, owner, gasPrice, rTxGasLimit, rtxData)
 

--- a/integrationTests/vm/txsFee/multiShard/relayedMoveBalance_test.go
+++ b/integrationTests/vm/txsFee/multiShard/relayedMoveBalance_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm/txsFee/utils"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
@@ -34,7 +35,7 @@ func TestRelayedMoveBalanceRelayerShard0InnerTxSenderAndReceiverShard1ShouldWork
 
 	userTx := vm.CreateTransaction(0, big.NewInt(100), sndAddr, rcvAddr, gasPrice, gasLimit, []byte("aaaa"))
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, userTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -80,7 +81,7 @@ func TestRelayedMoveBalanceRelayerAndInnerTxSenderShard0ReceiverShard1(t *testin
 
 	userTx := vm.CreateTransaction(0, big.NewInt(100), sndAddr, scAddrBytes, gasPrice, gasLimit, nil)
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, userTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -131,7 +132,7 @@ func TestRelayedMoveBalanceExecuteOnSourceAndDestination(t *testing.T) {
 
 	userTx := vm.CreateTransaction(0, big.NewInt(100), sndAddr, scAddrBytes, gasPrice, gasLimit, nil)
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, userTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -193,7 +194,7 @@ func TestRelayedMoveBalanceExecuteOnSourceAndDestinationRelayerAndInnerTxSenderS
 
 	userTx := vm.CreateTransaction(0, big.NewInt(100), sndAddr, rcvAddr, gasPrice, gasLimit, nil)
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, userTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -253,7 +254,7 @@ func TestRelayedMoveBalanceRelayerAndInnerTxReceiverShard0SenderShard1(t *testin
 
 	innerTx := vm.CreateTransaction(0, big.NewInt(100), sndAddr, rcvAddr, gasPrice, gasLimit, nil)
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -329,7 +330,7 @@ func TestMoveBalanceRelayerShard0InnerTxSenderShard1InnerTxReceiverShard2ShouldW
 
 	innerTx := vm.CreateTransaction(0, big.NewInt(100), sndAddr, rcvAddr, gasPrice, gasLimit, nil)
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 

--- a/integrationTests/vm/txsFee/multiShard/relayedScDeploy_test.go
+++ b/integrationTests/vm/txsFee/multiShard/relayedScDeploy_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm/txsFee/utils"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm/wasm"
@@ -39,7 +40,7 @@ func TestRelayedSCDeployShouldWork(t *testing.T) {
 	scCode := wasm.GetSCCode(contractPath)
 	userTx := vm.CreateTransaction(0, big.NewInt(0), sndAddr, vm.CreateEmptyAddress(), gasPrice, gasLimit, []byte(wasm.CreateDeployTxData(scCode)))
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, big.NewInt(0), relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 

--- a/integrationTests/vm/txsFee/multiShard/relayedTxScCalls_test.go
+++ b/integrationTests/vm/txsFee/multiShard/relayedTxScCalls_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm/txsFee/utils"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
@@ -57,7 +58,7 @@ func TestRelayedTxScCallMultiShardShouldWork(t *testing.T) {
 	gasLimit := uint64(500)
 
 	innerTx := vm.CreateTransaction(0, big.NewInt(0), sndAddr, scAddr, gasPrice, gasLimit, []byte("increment"))
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -162,7 +163,7 @@ func TestRelayedTxScCallMultiShardFailOnInnerTxDst(t *testing.T) {
 	gasLimit := uint64(500)
 
 	innerTx := vm.CreateTransaction(0, big.NewInt(0), sndAddr, scAddr, gasPrice, gasLimit, []byte("incremeno"))
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 

--- a/integrationTests/vm/txsFee/relayedAsyncCall_test.go
+++ b/integrationTests/vm/txsFee/relayedAsyncCall_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm/txsFee/utils"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
@@ -48,7 +49,7 @@ func TestRelayedAsyncCallShouldWork(t *testing.T) {
 
 	innerTx := vm.CreateTransaction(0, big.NewInt(0), senderAddr, secondSCAddress, gasPrice, gasLimit, []byte("doSomething"))
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, senderAddr, gasPrice, rTxGasLimit, rtxData)
 

--- a/integrationTests/vm/txsFee/relayedAsyncCall_test.go
+++ b/integrationTests/vm/txsFee/relayedAsyncCall_test.go
@@ -31,7 +31,6 @@ func TestRelayedAsyncCallShouldWork(t *testing.T) {
 	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, egldBalance)
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, egldBalance)
 
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(50000)
 

--- a/integrationTests/vm/txsFee/relayedAsyncESDT_test.go
+++ b/integrationTests/vm/txsFee/relayedAsyncESDT_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm/txsFee/utils"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
@@ -54,7 +55,7 @@ func TestRelayedAsyncESDTCallShouldWork(t *testing.T) {
 	innerTx := utils.CreateESDTTransferTx(0, sndAddr, firstSCAddress, token, big.NewInt(5000), gasPrice, gasLimit)
 	innerTx.Data = []byte(string(innerTx.Data) + "@" + hex.EncodeToString([]byte("transferToSecondContractHalf")))
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -113,7 +114,7 @@ func TestRelayedAsyncESDTCall_InvalidCallFirstContract(t *testing.T) {
 	innerTx := utils.CreateESDTTransferTx(0, sndAddr, firstSCAddress, token, big.NewInt(5000), gasPrice, gasLimit)
 	innerTx.Data = []byte(string(innerTx.Data) + "@" + hex.EncodeToString([]byte("transferToSecondContractRejected")))
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -172,7 +173,7 @@ func TestRelayedAsyncESDTCall_InvalidOutOfGas(t *testing.T) {
 	innerTx := utils.CreateESDTTransferTx(0, sndAddr, firstSCAddress, token, big.NewInt(5000), gasPrice, gasLimit)
 	innerTx.Data = []byte(string(innerTx.Data) + "@" + hex.EncodeToString([]byte("transferToSecondContractHalf")))
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 

--- a/integrationTests/vm/txsFee/relayedAsyncESDT_test.go
+++ b/integrationTests/vm/txsFee/relayedAsyncESDT_test.go
@@ -37,7 +37,6 @@ func TestRelayedAsyncESDTCallShouldWork(t *testing.T) {
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, egldBalance)
 
 	// deploy 2 contracts
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(50000)
 
@@ -96,7 +95,6 @@ func TestRelayedAsyncESDTCall_InvalidCallFirstContract(t *testing.T) {
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, egldBalance)
 
 	// deploy 2 contracts
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(50000)
 
@@ -155,7 +153,6 @@ func TestRelayedAsyncESDTCall_InvalidOutOfGas(t *testing.T) {
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, egldBalance)
 
 	// deploy 2 contracts
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(50000)
 

--- a/integrationTests/vm/txsFee/relayedBuiltInFunctions_test.go
+++ b/integrationTests/vm/txsFee/relayedBuiltInFunctions_test.go
@@ -42,7 +42,7 @@ func TestRelayedBuildInFunctionChangeOwnerCallShouldWork(t *testing.T) {
 
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, big.NewInt(30000))
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, owner, gasPrice, rTxGasLimit, rtxData)
 
@@ -89,7 +89,7 @@ func TestRelayedBuildInFunctionChangeOwnerCallWrongOwnerShouldConsumeGas(t *test
 
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, big.NewInt(30000))
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, owner, gasPrice, rTxGasLimit, rtxData)
 
@@ -135,7 +135,7 @@ func TestRelayedBuildInFunctionChangeOwnerInvalidAddressShouldConsumeGas(t *test
 
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, big.NewInt(30000))
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, owner, gasPrice, rTxGasLimit, rtxData)
 
@@ -180,7 +180,7 @@ func TestRelayedBuildInFunctionChangeOwnerCallInsufficientGasLimitShouldConsumeG
 
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, big.NewInt(30000))
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, owner, gasPrice, rTxGasLimit, rtxData)
 
@@ -225,7 +225,7 @@ func TestRelayedBuildInFunctionChangeOwnerCallOutOfGasShouldConsumeGas(t *testin
 
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, big.NewInt(30000))
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, owner, gasPrice, rTxGasLimit, rtxData)
 

--- a/integrationTests/vm/txsFee/relayedBuiltInFunctions_test.go
+++ b/integrationTests/vm/txsFee/relayedBuiltInFunctions_test.go
@@ -34,7 +34,6 @@ func TestRelayedBuildInFunctionChangeOwnerCallShouldWork(t *testing.T) {
 
 	relayerAddr := []byte("12345678901234567890123456789033")
 	newOwner := []byte("12345678901234567890123456789112")
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	txData := []byte(core.BuiltInFunctionChangeOwnerAddress + "@" + hex.EncodeToString(newOwner))
@@ -81,7 +80,6 @@ func TestRelayedBuildInFunctionChangeOwnerCallWrongOwnerShouldConsumeGas(t *test
 	relayerAddr := []byte("12345678901234567890123456789033")
 	sndAddr := []byte("12345678901234567890123456789113")
 	newOwner := []byte("12345678901234567890123456789112")
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	txData := []byte(core.BuiltInFunctionChangeOwnerAddress + "@" + hex.EncodeToString(newOwner))
@@ -127,7 +125,6 @@ func TestRelayedBuildInFunctionChangeOwnerInvalidAddressShouldConsumeGas(t *test
 
 	relayerAddr := []byte("12345678901234567890123456789033")
 	newOwner := []byte("invalidAddress")
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	txData := []byte(core.BuiltInFunctionChangeOwnerAddress + "@" + hex.EncodeToString(newOwner))
@@ -172,7 +169,6 @@ func TestRelayedBuildInFunctionChangeOwnerCallInsufficientGasLimitShouldConsumeG
 
 	relayerAddr := []byte("12345678901234567890123456789033")
 	newOwner := []byte("12345678901234567890123456789112")
-	gasPrice := uint64(10)
 
 	txData := []byte(core.BuiltInFunctionChangeOwnerAddress + "@" + hex.EncodeToString(newOwner))
 	gasLimit := uint64(len(txData) - 1)
@@ -217,7 +213,6 @@ func TestRelayedBuildInFunctionChangeOwnerCallOutOfGasShouldConsumeGas(t *testin
 
 	relayerAddr := []byte("12345678901234567890123456789033")
 	newOwner := []byte("12345678901234567890123456789112")
-	gasPrice := uint64(10)
 
 	txData := []byte(core.BuiltInFunctionChangeOwnerAddress + "@" + hex.EncodeToString(newOwner))
 	gasLimit := uint64(len(txData) + 1)

--- a/integrationTests/vm/txsFee/relayedDns_test.go
+++ b/integrationTests/vm/txsFee/relayedDns_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm/txsFee/utils"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
@@ -40,7 +41,7 @@ func TestRelayedTxDnsTransaction_ShouldWork(t *testing.T) {
 	// create user name for sender
 	innerTx := vm.CreateTransaction(0, big.NewInt(0), sndAddr, scAddress, gasPrice, gasLimit, txData)
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -62,7 +63,7 @@ func TestRelayedTxDnsTransaction_ShouldWork(t *testing.T) {
 	// create user name for receiver
 	innerTx = vm.CreateTransaction(0, big.NewInt(0), rcvAddr, scAddress, gasPrice, gasLimit, txData)
 
-	rtxData = utils.PrepareRelayerTxData(innerTx)
+	rtxData = integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit = 1 + gasLimit + uint64(len(rtxData))
 	rtx = vm.CreateTransaction(1, innerTx.Value, relayerAddr, rcvAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -84,7 +85,7 @@ func TestRelayedTxDnsTransaction_ShouldWork(t *testing.T) {
 	innerTx.SndUserName = sndAddrUserName
 	innerTx.RcvUserName = rcvAddrUserName
 
-	rtxData = utils.PrepareRelayerTxData(innerTx)
+	rtxData = integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit = 1 + gasLimit + uint64(len(rtxData))
 	rtx = vm.CreateTransaction(2, innerTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 

--- a/integrationTests/vm/txsFee/relayedDns_test.go
+++ b/integrationTests/vm/txsFee/relayedDns_test.go
@@ -29,7 +29,6 @@ func TestRelayedTxDnsTransaction_ShouldWork(t *testing.T) {
 	relayerAddr := []byte("12345678901234567890123456789033")
 	sndAddr := []byte("12345678901234567890123456789112")
 	rcvAddr := []byte("12345678901234567890123456789110")
-	gasPrice := uint64(10)
 	gasLimit := uint64(500000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, big.NewInt(0))

--- a/integrationTests/vm/txsFee/relayedESDT_test.go
+++ b/integrationTests/vm/txsFee/relayedESDT_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm/txsFee/utils"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
@@ -35,7 +36,7 @@ func TestRelayedESDTTransferShouldWork(t *testing.T) {
 	gasLimit := uint64(40)
 	innerTx := utils.CreateESDTTransferTx(0, sndAddr, rcvAddr, token, big.NewInt(100), gasPrice, gasLimit)
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -81,7 +82,7 @@ func TestTestRelayedESTTransferNotEnoughESTValueShouldConsumeGas(t *testing.T) {
 	gasLimit := uint64(40)
 	innerTx := utils.CreateESDTTransferTx(0, sndAddr, rcvAddr, token, big.NewInt(100000001), gasPrice, gasLimit)
 
-	rtxData := utils.PrepareRelayerTxData(innerTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(innerTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, innerTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 

--- a/integrationTests/vm/txsFee/relayedESDT_test.go
+++ b/integrationTests/vm/txsFee/relayedESDT_test.go
@@ -32,7 +32,6 @@ func TestRelayedESDTTransferShouldWork(t *testing.T) {
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, big.NewInt(0), token, 0, esdtBalance)
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, relayerBalance)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(40)
 	innerTx := utils.CreateESDTTransferTx(0, sndAddr, rcvAddr, token, big.NewInt(100), gasPrice, gasLimit)
 
@@ -78,7 +77,6 @@ func TestTestRelayedESTTransferNotEnoughESTValueShouldConsumeGas(t *testing.T) {
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, big.NewInt(0), token, 0, esdtBalance)
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, relayerBalance)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(40)
 	innerTx := utils.CreateESDTTransferTx(0, sndAddr, rcvAddr, token, big.NewInt(100000001), gasPrice, gasLimit)
 

--- a/integrationTests/vm/txsFee/relayedMoveBalance_test.go
+++ b/integrationTests/vm/txsFee/relayedMoveBalance_test.go
@@ -23,7 +23,6 @@ func TestRelayedMoveBalanceShouldWork(t *testing.T) {
 
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(0)
-	gasPrice := uint64(10)
 	gasLimit := uint64(100)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)

--- a/integrationTests/vm/txsFee/relayedMoveBalance_test.go
+++ b/integrationTests/vm/txsFee/relayedMoveBalance_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
-	"github.com/multiversx/mx-chain-go/integrationTests/vm/txsFee/utils"
 	"github.com/multiversx/mx-chain-go/process"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/stretchr/testify/require"
@@ -32,7 +32,7 @@ func TestRelayedMoveBalanceShouldWork(t *testing.T) {
 	// gas consumed = 50
 	userTx := vm.CreateTransaction(senderNonce, big.NewInt(100), sndAddr, rcvAddr, gasPrice, gasLimit, []byte("aaaa"))
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, userTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -73,7 +73,7 @@ func TestRelayedMoveBalanceInvalidGasLimitShouldConsumeGas(t *testing.T) {
 
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, big.NewInt(3000))
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 2 + userTx.GasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, userTx.Value, relayerAddr, sndAddr, 1, rTxGasLimit, rtxData)
 
@@ -105,7 +105,7 @@ func TestRelayedMoveBalanceInvalidUserTxShouldConsumeGas(t *testing.T) {
 
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, big.NewInt(3000))
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + userTx.GasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, userTx.Value, relayerAddr, sndAddr, 1, rTxGasLimit, rtxData)
 
@@ -137,7 +137,7 @@ func TestRelayedMoveBalanceInvalidUserTxValueShouldConsumeGas(t *testing.T) {
 
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, big.NewInt(3000))
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + userTx.GasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, big.NewInt(100), relayerAddr, sndAddr, 1, rTxGasLimit, rtxData)
 

--- a/integrationTests/vm/txsFee/relayedScCalls_test.go
+++ b/integrationTests/vm/txsFee/relayedScCalls_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm/txsFee/utils"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
@@ -35,7 +36,7 @@ func TestRelayedScCallShouldWork(t *testing.T) {
 
 	userTx := vm.CreateTransaction(0, big.NewInt(100), sndAddr, scAddress, gasPrice, gasLimit, []byte("increment"))
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, userTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -78,7 +79,7 @@ func TestRelayedScCallContractNotFoundShouldConsumeGas(t *testing.T) {
 
 	userTx := vm.CreateTransaction(0, big.NewInt(100), sndAddr, scAddrBytes, gasPrice, gasLimit, []byte("increment"))
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, userTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -118,7 +119,7 @@ func TestRelayedScCallInvalidMethodShouldConsumeGas(t *testing.T) {
 
 	userTx := vm.CreateTransaction(0, big.NewInt(100), sndAddr, scAddress, gasPrice, gasLimit, []byte("invalidMethod"))
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, userTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -158,7 +159,7 @@ func TestRelayedScCallInsufficientGasLimitShouldConsumeGas(t *testing.T) {
 
 	userTx := vm.CreateTransaction(0, big.NewInt(100), sndAddr, scAddress, gasPrice, gasLimit, []byte("increment"))
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, userTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -197,7 +198,7 @@ func TestRelayedScCallOutOfGasShouldConsumeGas(t *testing.T) {
 
 	userTx := vm.CreateTransaction(0, big.NewInt(100), sndAddr, scAddress, gasPrice, gasLimit, []byte("increment"))
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, userTx.Value, relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 

--- a/integrationTests/vm/txsFee/relayedScCalls_test.go
+++ b/integrationTests/vm/txsFee/relayedScCalls_test.go
@@ -28,7 +28,6 @@ func TestRelayedScCallShouldWork(t *testing.T) {
 
 	relayerAddr := []byte("12345678901234567890123456789033")
 	sndAddr := []byte("12345678901234567890123456789112")
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, big.NewInt(0))
@@ -71,7 +70,6 @@ func TestRelayedScCallContractNotFoundShouldConsumeGas(t *testing.T) {
 
 	relayerAddr := []byte("12345678901234567890123456789033")
 	sndAddr := []byte("12345678901234567890123456789112")
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, big.NewInt(0))
@@ -111,7 +109,6 @@ func TestRelayedScCallInvalidMethodShouldConsumeGas(t *testing.T) {
 
 	relayerAddr := []byte("12345678901234567890123456789033")
 	sndAddr := []byte("12345678901234567890123456789112")
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, big.NewInt(0))
@@ -151,7 +148,6 @@ func TestRelayedScCallInsufficientGasLimitShouldConsumeGas(t *testing.T) {
 
 	relayerAddr := []byte("12345678901234567890123456789033")
 	sndAddr := []byte("12345678901234567890123456789112")
-	gasPrice := uint64(10)
 	gasLimit := uint64(5)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, big.NewInt(0))
@@ -190,7 +186,6 @@ func TestRelayedScCallOutOfGasShouldConsumeGas(t *testing.T) {
 
 	relayerAddr := []byte("12345678901234567890123456789033")
 	sndAddr := []byte("12345678901234567890123456789112")
-	gasPrice := uint64(10)
 	gasLimit := uint64(20)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, big.NewInt(0))

--- a/integrationTests/vm/txsFee/relayedScDeploy_test.go
+++ b/integrationTests/vm/txsFee/relayedScDeploy_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
-	"github.com/multiversx/mx-chain-go/integrationTests/vm/txsFee/utils"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm/wasm"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/stretchr/testify/require"
@@ -36,7 +36,7 @@ func TestRelayedScDeployShouldWork(t *testing.T) {
 	scCode := wasm.GetSCCode("../wasm/testdata/misc/fib_wasm/output/fib_wasm.wasm")
 	userTx := vm.CreateTransaction(senderNonce, big.NewInt(0), sndAddr, vm.CreateEmptyAddress(), gasPrice, gasLimit, []byte(wasm.CreateDeployTxData(scCode)))
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, big.NewInt(0), relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -79,7 +79,7 @@ func TestRelayedScDeployInvalidCodeShouldConsumeGas(t *testing.T) {
 	scCodeBytes = append(scCodeBytes, []byte("aaaaa")...)
 	userTx := vm.CreateTransaction(senderNonce, big.NewInt(0), sndAddr, vm.CreateEmptyAddress(), gasPrice, gasLimit, scCodeBytes)
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, big.NewInt(0), relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -119,7 +119,7 @@ func TestRelayedScDeployInsufficientGasLimitShouldConsumeGas(t *testing.T) {
 	scCode := wasm.GetSCCode("../wasm/testdata/misc/fib_wasm/output/fib_wasm.wasm")
 	userTx := vm.CreateTransaction(senderNonce, big.NewInt(0), sndAddr, vm.CreateEmptyAddress(), gasPrice, gasLimit, []byte(wasm.CreateDeployTxData(scCode)))
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, big.NewInt(0), relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 
@@ -159,7 +159,7 @@ func TestRelayedScDeployOutOfGasShouldConsumeGas(t *testing.T) {
 	scCode := wasm.GetSCCode("../wasm/testdata/misc/fib_wasm/output/fib_wasm.wasm")
 	userTx := vm.CreateTransaction(senderNonce, big.NewInt(0), sndAddr, vm.CreateEmptyAddress(), gasPrice, gasLimit, []byte(wasm.CreateDeployTxData(scCode)))
 
-	rtxData := utils.PrepareRelayerTxData(userTx)
+	rtxData := integrationTests.PrepareRelayedTxDataV1(userTx)
 	rTxGasLimit := 1 + gasLimit + uint64(len(rtxData))
 	rtx := vm.CreateTransaction(0, big.NewInt(0), relayerAddr, sndAddr, gasPrice, rTxGasLimit, rtxData)
 

--- a/integrationTests/vm/txsFee/relayedScDeploy_test.go
+++ b/integrationTests/vm/txsFee/relayedScDeploy_test.go
@@ -27,7 +27,6 @@ func TestRelayedScDeployShouldWork(t *testing.T) {
 
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(0)
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -68,7 +67,6 @@ func TestRelayedScDeployInvalidCodeShouldConsumeGas(t *testing.T) {
 
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(0)
-	gasPrice := uint64(10)
 	gasLimit := uint64(500)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -110,7 +108,6 @@ func TestRelayedScDeployInsufficientGasLimitShouldConsumeGas(t *testing.T) {
 
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(0)
-	gasPrice := uint64(10)
 	gasLimit := uint64(500)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -150,7 +147,6 @@ func TestRelayedScDeployOutOfGasShouldConsumeGas(t *testing.T) {
 
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(0)
-	gasPrice := uint64(10)
 	gasLimit := uint64(570)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)

--- a/integrationTests/vm/txsFee/scCalls_test.go
+++ b/integrationTests/vm/txsFee/scCalls_test.go
@@ -96,7 +96,6 @@ func TestScCallShouldWork(t *testing.T) {
 
 	sndAddr := []byte("12345678901234567890123456789112")
 	senderBalance := big.NewInt(100000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -138,7 +137,6 @@ func TestScCallContractNotFoundShouldConsumeGas(t *testing.T) {
 	scAddrBytes, _ := hex.DecodeString(scAddress)
 	sndAddr := []byte("12345678901234567890123456789112")
 	senderBalance := big.NewInt(100000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -169,7 +167,6 @@ func TestScCallInvalidMethodToCallShouldConsumeGas(t *testing.T) {
 
 	sndAddr := []byte("12345678901234567890123456789112")
 	senderBalance := big.NewInt(100000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -202,7 +199,6 @@ func TestScCallInsufficientGasLimitShouldNotConsumeGas(t *testing.T) {
 
 	sndAddr := []byte("12345678901234567890123456789112")
 	senderBalance := big.NewInt(100000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(9)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -238,7 +234,6 @@ func TestScCallOutOfGasShouldConsumeGas(t *testing.T) {
 
 	sndAddr := []byte("12345678901234567890123456789112")
 	senderBalance := big.NewInt(100000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(20)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -274,7 +269,6 @@ func TestScCallAndGasChangeShouldWork(t *testing.T) {
 
 	sndAddr := []byte("12345678901234567890123456789112")
 	senderBalance := big.NewInt(10000000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -313,7 +307,6 @@ func TestESDTScCallAndGasChangeShouldWork(t *testing.T) {
 
 	owner := []byte("12345678901234567890123456789011")
 	senderBalance := big.NewInt(1000000000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(2000000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, owner, 0, senderBalance)
@@ -323,7 +316,6 @@ func TestESDTScCallAndGasChangeShouldWork(t *testing.T) {
 
 	sndAddr := []byte("12345678901234567890123456789112")
 	senderBalance = big.NewInt(10000000)
-	gasPrice = uint64(10)
 	gasLimit = uint64(30000)
 
 	esdtBalance := big.NewInt(100000000)
@@ -426,7 +418,6 @@ func TestScCallBuyNFT_OneFailedTxAndOneOkTx(t *testing.T) {
 	sndAddr1 := []byte("12345678901234567890123456789112")
 	sndAddr2 := []byte("12345678901234567890123456789113")
 	senderBalance := big.NewInt(1000000000000000000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr1, 0, senderBalance)
@@ -488,7 +479,6 @@ func TestScCallBuyNFT_TwoOkTxs(t *testing.T) {
 	sndAddr1 := []byte("12345678901234567890123456789112")
 	sndAddr2 := []byte("12345678901234567890123456789113")
 	senderBalance := big.NewInt(1000000000000000000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr1, 0, senderBalance)
@@ -558,7 +548,6 @@ func TestScCallDistributeStakingRewards_ShouldWork(t *testing.T) {
 	require.Nil(t, err)
 
 	senderBalance := big.NewInt(1000000000000000000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(600000000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr1, 0, senderBalance)

--- a/integrationTests/vm/txsFee/scDeploy_test.go
+++ b/integrationTests/vm/txsFee/scDeploy_test.go
@@ -25,7 +25,6 @@ func TestScDeployShouldWork(t *testing.T) {
 	sndAddr := []byte("12345678901234567890123456789012")
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(100000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -57,7 +56,6 @@ func TestScDeployInvalidContractCodeShouldConsumeGas(t *testing.T) {
 	sndAddr := []byte("12345678901234567890123456789012")
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(100000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -90,7 +88,6 @@ func TestScDeployInsufficientGasLimitShouldNotConsumeGas(t *testing.T) {
 	sndAddr := []byte("12345678901234567890123456789012")
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(100000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(568)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -122,7 +119,6 @@ func TestScDeployOutOfGasShouldConsumeGas(t *testing.T) {
 	sndAddr := []byte("12345678901234567890123456789012")
 	senderNonce := uint64(0)
 	senderBalance := big.NewInt(100000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(570)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)

--- a/integrationTests/vm/txsFee/txCostEstimator_test.go
+++ b/integrationTests/vm/txsFee/txCostEstimator_test.go
@@ -39,7 +39,6 @@ func TestSCCallCostTransactionCost(t *testing.T) {
 
 	sndAddr := []byte("12345678901234567890123456789112")
 	senderBalance := big.NewInt(100000)
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, sndAddr, 0, senderBalance)
@@ -86,7 +85,6 @@ func TestAsyncCallsTransactionCost(t *testing.T) {
 	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, egldBalance)
 	_, _ = vm.CreateAccount(testContext.Accounts, senderAddr, 0, egldBalance)
 
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(2000)
 
@@ -173,7 +171,6 @@ func TestAsyncESDTTransfer(t *testing.T) {
 	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance)
 
 	// deploy 2 contracts
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(50000)
 

--- a/integrationTests/vm/txsFee/utils/utils.go
+++ b/integrationTests/vm/txsFee/utils/utils.go
@@ -11,13 +11,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/scheduled"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/hashing/keccak"
-	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/integrationTests/mock"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm/wasm"
@@ -31,8 +29,7 @@ import (
 )
 
 var (
-	protoMarshalizer = &marshal.GogoProtoMarshalizer{}
-	log              = logger.GetOrCreate("integrationTests/vm/txFee/utils")
+	log = logger.GetOrCreate("integrationTests/vm/txFee/utils")
 )
 
 // DoDeploy -
@@ -253,12 +250,6 @@ func DoDeployDNS(t *testing.T, testContext *vm.VMTestContext, pathToContract str
 	scAddr, _ = testContext.BlockchainHook.NewAddress(owner, 0, factory.WasmVirtualMachine)
 	fmt.Println(hex.EncodeToString(scAddr))
 	return scAddr, owner
-}
-
-// PrepareRelayerTxData -
-func PrepareRelayerTxData(innerTx *transaction.Transaction) []byte {
-	userTxBytes, _ := protoMarshalizer.Marshal(innerTx)
-	return []byte(core.RelayedTransaction + "@" + hex.EncodeToString(userTxBytes))
 }
 
 // CheckOwnerAddr -

--- a/integrationTests/vm/txsFee/utils/utilsESDT.go
+++ b/integrationTests/vm/txsFee/utils/utilsESDT.go
@@ -10,6 +10,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data/esdt"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/testscommon/txDataBuilder"
@@ -46,7 +47,7 @@ func CreateAccountWithESDTBalance(
 		}
 	}
 
-	esdtDataBytes, err := protoMarshalizer.Marshal(esdtData)
+	esdtDataBytes, err := integrationTests.TestMarshalizer.Marshal(esdtData)
 	require.Nil(t, err)
 
 	key := append([]byte(core.ProtectedKeyPrefix), []byte(core.ESDTKeyIdentifier)...)
@@ -95,7 +96,7 @@ func CreateAccountWithNFT(
 		},
 	}
 
-	esdtDataBytes, err := protoMarshalizer.Marshal(esdtData)
+	esdtDataBytes, err := integrationTests.TestMarshalizer.Marshal(esdtData)
 	require.Nil(t, err)
 
 	key := append([]byte(core.ProtectedKeyPrefix), []byte(core.ESDTKeyIdentifier)...)
@@ -120,7 +121,7 @@ func saveNewTokenOnSystemAccount(t *testing.T, accnts state.AccountsAdapter, tok
 	esdtDataOnSystemAcc.Reserved = []byte{1}
 	esdtDataOnSystemAcc.Value.Set(esdtData.Value)
 
-	esdtDataBytes, err := protoMarshalizer.Marshal(esdtData)
+	esdtDataBytes, err := integrationTests.TestMarshalizer.Marshal(esdtData)
 	require.Nil(t, err)
 
 	sysAccount, err := accnts.LoadAccount(core.SystemAccountAddress)
@@ -179,7 +180,7 @@ func SetESDTRoles(
 		Roles: roles,
 	}
 
-	rolesDataBytes, err := protoMarshalizer.Marshal(rolesData)
+	rolesDataBytes, err := integrationTests.TestMarshalizer.Marshal(rolesData)
 	require.Nil(t, err)
 
 	err = userAccount.SaveKeyValue(key, rolesDataBytes)

--- a/integrationTests/vm/txsFee/validatorSC_test.go
+++ b/integrationTests/vm/txsFee/validatorSC_test.go
@@ -58,7 +58,6 @@ func TestValidatorsSC_DoStakePutInQueueUnStakeAndUnBondShouldRefund(t *testing.T
 	testContextMeta.BlockchainHook.(*hooks.BlockChainHookImpl).SetCurrentHeader(&block.MetaBlock{Epoch: 1})
 	saveDelegationManagerConfig(testContextMeta)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(4000)
 	sndAddr := []byte("12345678901234567890123456789012")
 	tx := vm.CreateTransaction(0, value2500EGLD, sndAddr, vmAddr.ValidatorSCAddress, gasPrice, gasLimit, []byte(validatorStakeData))
@@ -94,8 +93,8 @@ func checkReturnLog(t *testing.T, testContextMeta *vm.VMTestContext, subStr stri
 	}
 
 	found := false
-	for _, log := range allLogs {
-		for _, event := range log.GetLogEvents() {
+	for _, eventLog := range allLogs {
+		for _, event := range eventLog.GetLogEvents() {
 			if string(event.GetIdentifier()) == identifierStr {
 				require.True(t, strings.Contains(string(event.GetTopics()[1]), subStr))
 				found = true
@@ -115,7 +114,6 @@ func TestValidatorsSC_DoStakePutInQueueUnStakeAndUnBondTokensShouldRefund(t *tes
 	saveDelegationManagerConfig(testContextMeta)
 	testContextMeta.BlockchainHook.(*hooks.BlockChainHookImpl).SetCurrentHeader(&block.MetaBlock{Epoch: 1})
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(4000)
 	sndAddr := []byte("12345678901234567890123456789012")
 	tx := vm.CreateTransaction(0, value2500EGLD, sndAddr, vmAddr.ValidatorSCAddress, gasPrice, gasLimit, []byte(validatorStakeData))
@@ -158,7 +156,6 @@ func testValidatorsSCDoStakeWithTopUpValueTryToUnStakeTokensAndUnBondTokens(t *t
 	saveDelegationManagerConfig(testContextMeta)
 	testContextMeta.BlockchainHook.(*hooks.BlockChainHookImpl).SetCurrentHeader(&block.MetaBlock{Epoch: 0})
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(4000)
 	sndAddr := []byte("12345678901234567890123456789012")
 	tx := vm.CreateTransaction(0, value2700EGLD, sndAddr, vmAddr.ValidatorSCAddress, gasPrice, gasLimit, []byte(validatorStakeData))
@@ -186,7 +183,6 @@ func TestValidatorsSC_ToStakePutInQueueUnStakeAndUnBondShouldRefundUnBondTokens(
 	saveDelegationManagerConfig(testContextMeta)
 	testContextMeta.BlockchainHook.(*hooks.BlockChainHookImpl).SetCurrentHeader(&block.MetaBlock{Epoch: 1})
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(4000)
 	sndAddr := []byte("12345678901234567890123456789012")
 	tx := vm.CreateTransaction(0, value2700EGLD, sndAddr, vmAddr.ValidatorSCAddress, gasPrice, gasLimit, []byte(validatorStakeData))
@@ -233,7 +229,6 @@ func TestValidatorsSC_ToStakePutInQueueUnStakeNodesAndUnBondNodesShouldRefund(t 
 	saveDelegationManagerConfig(testContextMeta)
 	testContextMeta.BlockchainHook.(*hooks.BlockChainHookImpl).SetCurrentHeader(&block.MetaBlock{Epoch: 1})
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(4000)
 	sndAddr := []byte("12345678901234567890123456789012")
 	tx := vm.CreateTransaction(0, value2700EGLD, sndAddr, vmAddr.ValidatorSCAddress, gasPrice, gasLimit, []byte(validatorStakeData))


### PR DESCRIPTION
## Reasoning behind the pull request
- added semi-integration tests for guarded accounts & relayed (v1 + v2) transactions
- cleaned up redundant gasPrice definitions in tests
  
## Proposed changes
- added semi-integration tests for guarded accounts & relayed (v1 + v2) transactions
- cleaned up redundant gasPrice definitions in tests

## Testing procedure
- N/A

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
