### PR TITLE
Bug-fix `gasUsed` and `fee` transasctionsFeeProcessor

### DIFF
--- a/node/external/transactionAPI/gasUsedAndFeeProcessor.go
+++ b/node/external/transactionAPI/gasUsedAndFeeProcessor.go
@@ -36,6 +36,9 @@ func (gfp *gasUsedAndFeeProcessor) computeAndAttachGasUsedAndFee(tx *transaction
 		if !scr.IsRefund {
 			continue
 		}
+		if scr.RcvAddr != tx.Sender {
+			continue
+		}
 
 		gfp.setGasUsedAndFeeBaseOnRefundValue(tx, scr.Value)
 		hasRefund = true

--- a/node/external/transactionAPI/gasUsedAndFeeProcessor_test.go
+++ b/node/external/transactionAPI/gasUsedAndFeeProcessor_test.go
@@ -145,11 +145,14 @@ func TestComputeTransactionGasUsedAndFeeTransactionWithScrWithRefund(t *testing.
 			RcvAddr:  silentDecodeAddress(receiver),
 			Data:     []byte("relayedTx@"),
 		},
+		Sender:   sender,
+		Receiver: receiver,
 		GasLimit: 10_000_000,
 		SmartContractResults: []*transaction.ApiSmartContractResult{
 			{
 				Value:    big.NewInt(66350000000000),
 				IsRefund: true,
+				RcvAddr:  sender,
 			},
 		},
 		Logs: &transaction.ApiLogs{

--- a/outport/process/transactionsfee/transactionsFeeProcessor.go
+++ b/outport/process/transactionsfee/transactionsFeeProcessor.go
@@ -1,6 +1,7 @@
 package transactionsfee
 
 import (
+	"bytes"
 	"math/big"
 
 	"github.com/multiversx/mx-chain-core-go/core"
@@ -181,6 +182,11 @@ func (tep *transactionsFeeProcessor) prepareScrsNoTx(transactionsAndScrs *transa
 		txFromStorage, err := tep.txGetter.GetTxByHash(scr.OriginalTxHash)
 		if err != nil {
 			tep.log.Trace("transactionsFeeProcessor.prepareScrsNoTx: cannot find transaction in storage", "hash", scr.OriginalTxHash, "error", err.Error())
+			continue
+		}
+
+		isForInitialTxSender := bytes.Equal(scr.RcvAddr, txFromStorage.SndAddr)
+		if !isForInitialTxSender {
 			continue
 		}
 

--- a/outport/process/transactionsfee/transactionsFeeProcessor_test.go
+++ b/outport/process/transactionsfee/transactionsFeeProcessor_test.go
@@ -150,6 +150,7 @@ func TestPutFeeAndGasUsedScrNoTx(t *testing.T) {
 	initialTx := &transaction.Transaction{
 		GasLimit: 30000000,
 		GasPrice: 1000000000,
+		SndAddr:  []byte("erd1k7j6ewjsla4zsgv8v6f6fe3dvrkgv3d0d9jerczw45hzedhyed8sh2u34u"),
 	}
 	txBytes, _ := arg.Marshaller.Marshal(initialTx)
 
@@ -387,4 +388,50 @@ func TestPutFeeAndGasUsedScrWithRefundNoTx(t *testing.T) {
 	require.Equal(t, big.NewInt(0), scr.GetFee())
 	require.Equal(t, uint64(0), scr.GetGasUsed())
 	require.True(t, wasCalled)
+}
+
+func TestPutFeeAndGasUsedScrWithRefundNotForInitialSender(t *testing.T) {
+	t.Parallel()
+
+	txHash := []byte("tx")
+	scrWithRefund := []byte("scrWithRefund")
+
+	refundValueBig, _ := big.NewInt(0).SetString("226498540000000", 10)
+
+	scr := outportcore.NewTransactionHandlerWithGasAndFee(&smartContractResult.SmartContractResult{
+		Nonce:          3,
+		SndAddr:        []byte("erd1qqqqqqqqqqqqqpgq3dswlnnlkfd3gqrcv3dhzgnvh8ryf27g5rfsecnn2s"),
+		RcvAddr:        []byte("erd1k7j6ewjsla4zsgv8v6f6fe3dvrkgv3d0d9jerczw45hzedhyed8sh2u34u"),
+		PrevTxHash:     []byte("f639cb7a0231191e04ec19dcb1359bd93a03fe8dc4a28a80d00835c5d1c988f8"),
+		OriginalTxHash: txHash,
+		Value:          refundValueBig,
+		Data:           []byte(""),
+	}, 0, big.NewInt(0))
+
+	pool := &outportcore.Pool{
+		Scrs: map[string]coreData.TransactionHandlerWithGasUsedAndFee{
+			"wrong":               outportcore.NewTransactionHandlerWithGasAndFee(&transaction.Transaction{}, 0, big.NewInt(0)),
+			string(scrWithRefund): scr,
+		},
+	}
+
+	arg := prepareMockArg()
+
+	initialTx := &transaction.Transaction{
+		GasLimit: 30_000_000,
+		GasPrice: 1000000000,
+		SndAddr:  []byte("erd1dglncxk6sl9a3xumj78n6z2xux4ghp5c92cstv5zsn56tjgtdwpsk46qrs"),
+	}
+	txBytes, _ := arg.Marshaller.Marshal(initialTx)
+
+	_ = arg.TransactionsStorer.Put(txHash, txBytes)
+
+	txsFeeProc, err := NewTransactionsFeeProcessor(arg)
+	require.NotNil(t, txsFeeProc)
+	require.Nil(t, err)
+
+	err = txsFeeProc.PutFeeAndGasUsed(pool)
+	require.Nil(t, err)
+	require.Equal(t, big.NewInt(0), scr.GetFee())
+	require.Equal(t, uint64(0), scr.GetGasUsed())
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- Bug-fix the case when a smart contract result with a refund is generated but the receiver is not the sender of the initial transaction.  In this case, the `fee` and `gasUsed` was calculated based on a refund that never arrived at the sender of the transaction, which is wrong.
  
## Proposed changes
- Added an extra check that verifies if the receiver of the smart contract result with refund is the sender of the initial transaction. 


## Testing procedure
- Verify that for the case from above the `gasused` and `fee` fields are calculated correctly

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
