### PR TITLE
extracted configuration value for vm-queries delay

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -589,6 +589,8 @@
     TrieOperationsDeadlineMilliseconds = 10000
     # GetAddressesBulkMaxSize represents the maximum number of addresses to be fetched in a bulk per API request. 0 means unlimited
     GetAddressesBulkMaxSize = 100
+    # VmQueryDelayAfterStartInSec represents the number of seconds to wait when starting node before accepting vm query requests
+    VmQueryDelayAfterStartInSec = 5
     # EndpointsThrottlers represents a map for maximum simultaneous go routines for an endpoint
     EndpointsThrottlers = [{ Endpoint = "/transaction/:hash", MaxNumGoRoutines = 10 },
                            { Endpoint = "/transaction/send", MaxNumGoRoutines = 2 },

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -590,7 +590,7 @@
     # GetAddressesBulkMaxSize represents the maximum number of addresses to be fetched in a bulk per API request. 0 means unlimited
     GetAddressesBulkMaxSize = 100
     # VmQueryDelayAfterStartInSec represents the number of seconds to wait when starting node before accepting vm query requests
-    VmQueryDelayAfterStartInSec = 5
+    VmQueryDelayAfterStartInSec = 120
     # EndpointsThrottlers represents a map for maximum simultaneous go routines for an endpoint
     EndpointsThrottlers = [{ Endpoint = "/transaction/:hash", MaxNumGoRoutines = 10 },
                            { Endpoint = "/transaction/send", MaxNumGoRoutines = 2 },

--- a/config/config.go
+++ b/config/config.go
@@ -318,6 +318,7 @@ type WebServerAntifloodConfig struct {
 	SameSourceResetIntervalInSec       uint32
 	TrieOperationsDeadlineMilliseconds uint32
 	GetAddressesBulkMaxSize            uint32
+	VmQueryDelayAfterStartInSec        uint32
 	EndpointsThrottlers                []EndpointsThrottlersConfig
 }
 

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -518,6 +518,7 @@ func (nr *nodeRunner) executeOneComponentCreationCycle(
 
 	delayInSecBeforeAllowingVmQueries := configs.GeneralConfig.WebServerAntiflood.VmQueryDelayAfterStartInSec
 	if delayInSecBeforeAllowingVmQueries == 0 {
+		log.Warn("WebServerAntiflood.VmQueryDelayAfterStartInSec value not set. will use default", "default", defaultDelayBeforeScQueriesStartInSec)
 		delayInSecBeforeAllowingVmQueries = defaultDelayBeforeScQueriesStartInSec
 	}
 	// TODO: remove this and treat better the VM versions switching

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -68,8 +68,8 @@ import (
 
 const (
 	// TODO: remove this after better handling VM versions switching
-	// delayBeforeScQueriesStart represents the delay before the sc query processor should start to allow external queries
-	delayBeforeScQueriesStart = 2 * time.Minute
+	// defaultDelayBeforeScQueriesStartInSec represents the default delay before the sc query processor should start to allow external queries
+	defaultDelayBeforeScQueriesStartInSec = 120
 
 	maxTimeToClose = 10 * time.Second
 	// SoftRestartMessage is the custom message used when the node does a soft restart operation
@@ -516,9 +516,13 @@ func (nr *nodeRunner) executeOneComponentCreationCycle(
 
 	log.Info("application is now running")
 
+	delayInSecBeforeAllowingVmQueries := configs.GeneralConfig.WebServerAntiflood.VmQueryDelayAfterStartInSec
+	if delayInSecBeforeAllowingVmQueries == 0 {
+		delayInSecBeforeAllowingVmQueries = defaultDelayBeforeScQueriesStartInSec
+	}
 	// TODO: remove this and treat better the VM versions switching
 	go func(statusHandler core.AppStatusHandler) {
-		time.Sleep(delayBeforeScQueriesStart)
+		time.Sleep(time.Duration(delayInSecBeforeAllowingVmQueries) * time.Second)
 		close(allowExternalVMQueriesChan)
 		statusHandler.SetStringValue(common.MetricAreVMQueriesReady, strconv.FormatBool(true))
 	}(managedStatusCoreComponents.AppStatusHandler())


### PR DESCRIPTION
## Reasoning behind the pull request
- the delay before the node allows external (API) vm queries was fixed to 2 minutes
  
## Proposed changes
- extracted configuration value

## Testing procedure
- play around with the `VmQueryDelayAfterStartInSec` value and (re)start a node. after the number of seconds specified in the config, it should accept API VM Queries. Query example:
```
curl --request POST \
  --url http://127.0.0.1:8080/vm-values/query \
  --header 'Content-Type: application/json' \
  --data '{
	"scAddress": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
	"funcName": "getContractConfig"
}'
```

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
