### PR TITLE
Fix missing account on GetGuardianData

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -348,6 +348,10 @@ func (n *Node) GetValueForKey(address string, key string, options api.AccountQue
 func (n *Node) GetGuardianData(address string, options api.AccountQueryOptions) (api.GuardianData, api.BlockInfo, error) {
 	userAccount, blockInfo, err := n.loadUserAccountHandlerByAddress(address, options)
 	if err != nil {
+		apiBlockInfo, ok := extractApiBlockInfoIfErrAccountNotFoundAtBlock(err)
+		if ok {
+			return api.GuardianData{}, apiBlockInfo, nil
+		}
 		return api.GuardianData{}, api.BlockInfo{}, err
 	}
 


### PR DESCRIPTION
## Reasoning behind the pull request
- error was returned on GetGuardianData in case of missing account instead of nil error and empty data as GetAccount
  
## Proposed changes
- return empty data following GetAccount example

## Testing procedure
- will be tested with full feat branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
