### PR TITLE
always return empty responses when accounts are not found

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -157,13 +157,11 @@ func (n *Node) GetConsensusGroupSize() int {
 func (n *Node) GetBalance(address string, options api.AccountQueryOptions) (*big.Int, api.BlockInfo, error) {
 	userAccount, blockInfo, err := n.loadUserAccountHandlerByAddress(address, options)
 	if err != nil {
-		apiBlockInfo, ok := extractApiBlockInfoIfErrAccountNotFoundAtBlock(err)
-		if ok {
-			return big.NewInt(0), apiBlockInfo, nil
+		adaptedBlockInfo, adaptErr := adaptBlockInfoIfError(err)
+		if adaptErr == nil {
+			return big.NewInt(0), adaptedBlockInfo, nil
 		}
-		if err == ErrCannotCastAccountHandlerToUserAccountHandler {
-			return big.NewInt(0), api.BlockInfo{}, nil
-		}
+
 		return nil, api.BlockInfo{}, err
 	}
 
@@ -174,6 +172,11 @@ func (n *Node) GetBalance(address string, options api.AccountQueryOptions) (*big
 func (n *Node) GetUsername(address string, options api.AccountQueryOptions) (string, api.BlockInfo, error) {
 	userAccount, blockInfo, err := n.loadUserAccountHandlerByAddress(address, options)
 	if err != nil {
+		adaptedBlockInfo, adaptErr := adaptBlockInfoIfError(err)
+		if adaptErr == nil {
+			return "", adaptedBlockInfo, nil
+		}
+
 		return "", api.BlockInfo{}, err
 	}
 
@@ -185,6 +188,11 @@ func (n *Node) GetUsername(address string, options api.AccountQueryOptions) (str
 func (n *Node) GetCodeHash(address string, options api.AccountQueryOptions) ([]byte, api.BlockInfo, error) {
 	userAccount, blockInfo, err := n.loadUserAccountHandlerByAddress(address, options)
 	if err != nil {
+		adaptedBlockInfo, adaptErr := adaptBlockInfoIfError(err)
+		if adaptErr == nil {
+			return make([]byte, 0), adaptedBlockInfo, nil
+		}
+
 		return nil, api.BlockInfo{}, err
 	}
 
@@ -200,6 +208,7 @@ func (n *Node) GetAllIssuedESDTs(tokenType string, ctx context.Context) ([]strin
 
 	userAccount, _, err := n.loadUserAccountHandlerByPubKey(vm.ESDTSCAddress, api.AccountQueryOptions{})
 	if err != nil {
+		// don't return 0 values here - not finding the ESDT SC address is an error that should be returned
 		return nil, err
 	}
 
@@ -277,6 +286,11 @@ func (n *Node) getEsdtDataFromLeaf(leaf core.KeyValueHolder, userAccount state.U
 func (n *Node) GetKeyValuePairs(address string, options api.AccountQueryOptions, ctx context.Context) (map[string]string, api.BlockInfo, error) {
 	userAccount, blockInfo, err := n.loadUserAccountHandlerByAddress(address, options)
 	if err != nil {
+		adaptedBlockInfo, adaptErr := adaptBlockInfoIfError(err)
+		if adaptErr == nil {
+			return make(map[string]string), adaptedBlockInfo, nil
+		}
+
 		return nil, api.BlockInfo{}, err
 	}
 
@@ -331,6 +345,11 @@ func (n *Node) GetValueForKey(address string, key string, options api.AccountQue
 
 	userAccount, blockInfo, err := n.loadUserAccountHandlerByAddress(address, options)
 	if err != nil {
+		adaptedBlockInfo, adaptErr := adaptBlockInfoIfError(err)
+		if adaptErr == nil {
+			return "", adaptedBlockInfo, nil
+		}
+
 		return "", api.BlockInfo{}, err
 	}
 
@@ -347,6 +366,13 @@ func (n *Node) GetESDTData(address, tokenID string, nonce uint64, options api.Ac
 	// TODO: refactor here as to ensure userAccount and systemAccount are on the same root-hash
 	userAccount, _, err := n.loadUserAccountHandlerByAddress(address, options)
 	if err != nil {
+		adaptedBlockInfo, adaptErr := adaptBlockInfoIfError(err)
+		if adaptErr == nil {
+			return &esdt.ESDigitalToken{
+				Value: big.NewInt(0),
+			}, adaptedBlockInfo, nil
+		}
+
 		return nil, api.BlockInfo{}, err
 	}
 
@@ -512,6 +538,11 @@ func (n *Node) GetAllESDTTokens(address string, options api.AccountQueryOptions,
 	// TODO: refactor here as to ensure userAccount and systemAccount are on the same root-hash
 	userAccount, _, err := n.loadUserAccountHandlerByAddress(address, options)
 	if err != nil {
+		adaptedBlockInfo, adaptErr := adaptBlockInfoIfError(err)
+		if adaptErr == nil {
+			return make(map[string]*esdt.ESDigitalToken), adaptedBlockInfo, nil
+		}
+
 		return nil, api.BlockInfo{}, err
 	}
 
@@ -839,13 +870,13 @@ func (n *Node) CreateTransaction(
 func (n *Node) GetAccount(address string, options api.AccountQueryOptions) (api.AccountResponse, api.BlockInfo, error) {
 	account, blockInfo, err := n.loadUserAccountHandlerByAddress(address, options)
 	if err != nil {
-		apiBlockInfo, ok := extractApiBlockInfoIfErrAccountNotFoundAtBlock(err)
-		if ok {
+		adaptedBlockInfo, adaptErr := adaptBlockInfoIfError(err)
+		if adaptErr == nil {
 			return api.AccountResponse{
 				Address:         address,
 				Balance:         "0",
 				DeveloperReward: "0",
-			}, apiBlockInfo, nil
+			}, adaptedBlockInfo, nil
 		}
 
 		return api.AccountResponse{}, api.BlockInfo{}, err
@@ -868,6 +899,21 @@ func (n *Node) GetAccount(address string, options api.AccountQueryOptions) (api.
 		DeveloperReward: account.GetDeveloperReward().String(),
 		OwnerAddress:    ownerAddress,
 	}, blockInfo, nil
+}
+
+func adaptBlockInfoIfError(err error) (api.BlockInfo, error) {
+	if err == nil {
+		return api.BlockInfo{}, nil
+	}
+
+	apiBlockInfo, ok := extractApiBlockInfoIfErrAccountNotFoundAtBlock(err)
+	if ok {
+		return apiBlockInfo, nil
+	}
+	if err == ErrCannotCastAccountHandlerToUserAccountHandler {
+		return api.BlockInfo{}, nil
+	}
+	return api.BlockInfo{}, err
 }
 
 // GetCode returns the code for the given code hash

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -65,7 +65,7 @@ import (
 type testBlockInfo struct {
 }
 
-func (t testBlockInfo) asApiResult() api.BlockInfo {
+func (t testBlockInfo) apiResult() api.BlockInfo {
 	return api.BlockInfo{
 		Nonce:    37,
 		Hash:     hex.EncodeToString([]byte("hash")),
@@ -73,7 +73,7 @@ func (t testBlockInfo) asApiResult() api.BlockInfo {
 	}
 }
 
-func (t testBlockInfo) asForProcessing() common.BlockInfo {
+func (t testBlockInfo) forProcessing() common.BlockInfo {
 	hash := []byte("hash")
 	rHash := []byte("root")
 	return holders.NewBlockInfo(hash, 37, rHash)
@@ -216,7 +216,7 @@ func TestNode_GetBalanceAccNotFoundShouldReturnEmpty(t *testing.T) {
 
 	accDB := &stateMock.AccountsStub{
 		GetAccountWithBlockInfoCalled: func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error) {
-			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.asForProcessing())
+			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.forProcessing())
 		},
 		RecreateTrieCalled: func(_ []byte) error {
 			return nil
@@ -245,7 +245,7 @@ func TestNode_GetBalanceAccNotFoundShouldReturnEmpty(t *testing.T) {
 
 	balance, bInfo, err := n.GetBalance(testscommon.TestAddressAlice, api.AccountQueryOptions{})
 	require.Nil(t, err)
-	require.Equal(t, dummyBlockInfo.asApiResult(), bInfo)
+	require.Equal(t, dummyBlockInfo.apiResult(), bInfo)
 	require.Empty(t, balance)
 }
 
@@ -318,7 +318,7 @@ func TestNode_GetCodeHashAccNotFoundShouldReturnEmpty(t *testing.T) {
 
 	accDB := &stateMock.AccountsStub{
 		GetAccountWithBlockInfoCalled: func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error) {
-			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.asForProcessing())
+			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.forProcessing())
 		},
 		RecreateTrieCalled: func(_ []byte) error {
 			return nil
@@ -347,7 +347,7 @@ func TestNode_GetCodeHashAccNotFoundShouldReturnEmpty(t *testing.T) {
 
 	codeHash, bInfo, err := n.GetCodeHash("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th", api.AccountQueryOptions{})
 	require.Nil(t, err)
-	require.Equal(t, dummyBlockInfo.asApiResult(), bInfo)
+	require.Equal(t, dummyBlockInfo.apiResult(), bInfo)
 	require.Empty(t, codeHash)
 }
 
@@ -389,7 +389,7 @@ func TestNode_GetKeyValuePairsAccNotFoundShouldReturnEmpty(t *testing.T) {
 
 	accDB := &stateMock.AccountsStub{
 		GetAccountWithBlockInfoCalled: func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error) {
-			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.asForProcessing())
+			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.forProcessing())
 		},
 		RecreateTrieCalled: func(_ []byte) error {
 			return nil
@@ -418,7 +418,7 @@ func TestNode_GetKeyValuePairsAccNotFoundShouldReturnEmpty(t *testing.T) {
 
 	pairs, bInfo, err := n.GetKeyValuePairs(testscommon.TestAddressAlice, api.AccountQueryOptions{}, context.Background())
 	require.Nil(t, err)
-	require.Equal(t, dummyBlockInfo.asApiResult(), bInfo)
+	require.Equal(t, dummyBlockInfo.apiResult(), bInfo)
 	require.Len(t, pairs, 0)
 }
 
@@ -607,7 +607,7 @@ func TestNode_GetValueForKeyAccNotFoundShouldReturnEmpty(t *testing.T) {
 
 	accDB := &stateMock.AccountsStub{
 		GetAccountWithBlockInfoCalled: func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error) {
-			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.asForProcessing())
+			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.forProcessing())
 		},
 		RecreateTrieCalled: func(_ []byte) error {
 			return nil
@@ -636,7 +636,7 @@ func TestNode_GetValueForKeyAccNotFoundShouldReturnEmpty(t *testing.T) {
 
 	value, bInfo, err := n.GetValueForKey(testscommon.TestAddressAlice, "0a0a", api.AccountQueryOptions{})
 	require.Nil(t, err)
-	require.Equal(t, dummyBlockInfo.asApiResult(), bInfo)
+	require.Equal(t, dummyBlockInfo.apiResult(), bInfo)
 	require.Empty(t, value)
 }
 
@@ -689,7 +689,7 @@ func TestNode_GetESDTDataAccNotFoundShouldReturnEmpty(t *testing.T) {
 
 	accDB := &stateMock.AccountsStub{
 		GetAccountWithBlockInfoCalled: func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error) {
-			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.asForProcessing())
+			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.forProcessing())
 		},
 		RecreateTrieCalled: func(_ []byte) error {
 			return nil
@@ -718,7 +718,7 @@ func TestNode_GetESDTDataAccNotFoundShouldReturnEmpty(t *testing.T) {
 
 	esdtTokenData, bInfo, err := n.GetESDTData(testscommon.TestAddressAlice, esdtToken, 0, api.AccountQueryOptions{})
 	require.Nil(t, err)
-	require.Equal(t, dummyBlockInfo.asApiResult(), bInfo)
+	require.Equal(t, dummyBlockInfo.apiResult(), bInfo)
 	require.Equal(t, "0", esdtTokenData.Value.String())
 }
 
@@ -1003,7 +1003,7 @@ func TestNode_GetAllESDTsAccNotFoundShouldReturnEmpty(t *testing.T) {
 
 	accDB := &stateMock.AccountsStub{
 		GetAccountWithBlockInfoCalled: func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error) {
-			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.asForProcessing())
+			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.forProcessing())
 		},
 		RecreateTrieCalled: func(_ []byte) error {
 			return nil
@@ -1032,7 +1032,7 @@ func TestNode_GetAllESDTsAccNotFoundShouldReturnEmpty(t *testing.T) {
 
 	tokens, bInfo, err := n.GetAllESDTTokens(testscommon.TestAddressAlice, api.AccountQueryOptions{}, context.Background())
 	require.Nil(t, err)
-	require.Equal(t, dummyBlockInfo.asApiResult(), bInfo)
+	require.Equal(t, dummyBlockInfo.apiResult(), bInfo)
 	require.Len(t, tokens, 0)
 }
 
@@ -3195,7 +3195,7 @@ func TestNode_GetAccountAccNotFoundShouldReturnEmpty(t *testing.T) {
 
 	accDB := &stateMock.AccountsStub{
 		GetAccountWithBlockInfoCalled: func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error) {
-			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.asForProcessing())
+			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.forProcessing())
 		},
 		RecreateTrieCalled: func(_ []byte) error {
 			return nil
@@ -3224,7 +3224,7 @@ func TestNode_GetAccountAccNotFoundShouldReturnEmpty(t *testing.T) {
 
 	acc, bInfo, err := n.GetAccount(testscommon.TestAddressAlice, api.AccountQueryOptions{})
 	require.Nil(t, err)
-	require.Equal(t, dummyBlockInfo.asApiResult(), bInfo)
+	require.Equal(t, dummyBlockInfo.apiResult(), bInfo)
 	require.Equal(t, api.AccountResponse{Address: testscommon.TestAddressAlice, Balance: "0", DeveloperReward: "0"}, acc)
 }
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -62,6 +62,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testBlockInfo struct {
+}
+
+func (t testBlockInfo) asApiResult() api.BlockInfo {
+	return api.BlockInfo{
+		Nonce:    37,
+		Hash:     hex.EncodeToString([]byte("hash")),
+		RootHash: hex.EncodeToString([]byte("root")),
+	}
+}
+
+func (t testBlockInfo) asForProcessing() common.BlockInfo {
+	hash := []byte("hash")
+	rHash := []byte("root")
+	return holders.NewBlockInfo(hash, 37, rHash)
+}
+
+var dummyBlockInfo = testBlockInfo{}
+
 func createMockPubkeyConverter() *mock.PubkeyConverterMock {
 	return mock.NewPubkeyConverterMock(32)
 }
@@ -192,6 +211,44 @@ func TestGetBalance_AccountNotFoundShouldReturnZeroBalance(t *testing.T) {
 	assert.Equal(t, big.NewInt(0), balance)
 }
 
+func TestNode_GetBalanceAccNotFoundShouldReturnEmpty(t *testing.T) {
+	t.Parallel()
+
+	accDB := &stateMock.AccountsStub{
+		GetAccountWithBlockInfoCalled: func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error) {
+			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.asForProcessing())
+		},
+		RecreateTrieCalled: func(_ []byte) error {
+			return nil
+		},
+	}
+
+	dataComponents := getDefaultDataComponents()
+	coreComponents := getDefaultCoreComponents()
+	coreComponents.IntMarsh = getMarshalizer()
+	coreComponents.VmMarsh = getMarshalizer()
+	coreComponents.Hash = getHasher()
+
+	stateComponents := getDefaultStateComponents()
+	args := state.ArgsAccountsRepository{
+		FinalStateAccountsWrapper:      accDB,
+		CurrentStateAccountsWrapper:    accDB,
+		HistoricalStateAccountsWrapper: accDB,
+	}
+	stateComponents.AccountsRepo, _ = state.NewAccountsRepository(args)
+
+	n, _ := node.NewNode(
+		node.WithDataComponents(dataComponents),
+		node.WithCoreComponents(coreComponents),
+		node.WithStateComponents(stateComponents),
+	)
+
+	balance, bInfo, err := n.GetBalance(testscommon.TestAddressAlice, api.AccountQueryOptions{})
+	require.Nil(t, err)
+	require.Equal(t, dummyBlockInfo.asApiResult(), bInfo)
+	require.Empty(t, balance)
+}
+
 func TestGetBalance(t *testing.T) {
 	t.Parallel()
 
@@ -256,6 +313,44 @@ func TestGetUsername(t *testing.T) {
 	assert.Equal(t, string(expectedUsername), username)
 }
 
+func TestNode_GetCodeHashAccNotFoundShouldReturnEmpty(t *testing.T) {
+	t.Parallel()
+
+	accDB := &stateMock.AccountsStub{
+		GetAccountWithBlockInfoCalled: func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error) {
+			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.asForProcessing())
+		},
+		RecreateTrieCalled: func(_ []byte) error {
+			return nil
+		},
+	}
+
+	dataComponents := getDefaultDataComponents()
+	coreComponents := getDefaultCoreComponents()
+	coreComponents.IntMarsh = getMarshalizer()
+	coreComponents.VmMarsh = getMarshalizer()
+	coreComponents.Hash = getHasher()
+
+	stateComponents := getDefaultStateComponents()
+	args := state.ArgsAccountsRepository{
+		FinalStateAccountsWrapper:      accDB,
+		CurrentStateAccountsWrapper:    accDB,
+		HistoricalStateAccountsWrapper: accDB,
+	}
+	stateComponents.AccountsRepo, _ = state.NewAccountsRepository(args)
+
+	n, _ := node.NewNode(
+		node.WithDataComponents(dataComponents),
+		node.WithCoreComponents(coreComponents),
+		node.WithStateComponents(stateComponents),
+	)
+
+	codeHash, bInfo, err := n.GetCodeHash("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th", api.AccountQueryOptions{})
+	require.Nil(t, err)
+	require.Equal(t, dummyBlockInfo.asApiResult(), bInfo)
+	require.Empty(t, codeHash)
+}
+
 func TestGetCodeHash(t *testing.T) {
 	t.Parallel()
 
@@ -287,6 +382,44 @@ func TestGetCodeHash(t *testing.T) {
 	codeHash, _, err := n.GetCodeHash(testscommon.TestAddressAlice, api.AccountQueryOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, expectedCodeHash, codeHash)
+}
+
+func TestNode_GetKeyValuePairsAccNotFoundShouldReturnEmpty(t *testing.T) {
+	t.Parallel()
+
+	accDB := &stateMock.AccountsStub{
+		GetAccountWithBlockInfoCalled: func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error) {
+			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.asForProcessing())
+		},
+		RecreateTrieCalled: func(_ []byte) error {
+			return nil
+		},
+	}
+
+	dataComponents := getDefaultDataComponents()
+	coreComponents := getDefaultCoreComponents()
+	coreComponents.IntMarsh = getMarshalizer()
+	coreComponents.VmMarsh = getMarshalizer()
+	coreComponents.Hash = getHasher()
+
+	stateComponents := getDefaultStateComponents()
+	args := state.ArgsAccountsRepository{
+		FinalStateAccountsWrapper:      accDB,
+		CurrentStateAccountsWrapper:    accDB,
+		HistoricalStateAccountsWrapper: accDB,
+	}
+	stateComponents.AccountsRepo, _ = state.NewAccountsRepository(args)
+
+	n, _ := node.NewNode(
+		node.WithDataComponents(dataComponents),
+		node.WithCoreComponents(coreComponents),
+		node.WithStateComponents(stateComponents),
+	)
+
+	pairs, bInfo, err := n.GetKeyValuePairs(testscommon.TestAddressAlice, api.AccountQueryOptions{}, context.Background())
+	require.Nil(t, err)
+	require.Equal(t, dummyBlockInfo.asApiResult(), bInfo)
+	require.Len(t, pairs, 0)
 }
 
 func TestNode_GetKeyValuePairs(t *testing.T) {
@@ -469,6 +602,44 @@ func TestNode_GetKeyValuePairsContextShouldTimeout(t *testing.T) {
 	assert.Equal(t, node.ErrTrieOperationsTimeout, err)
 }
 
+func TestNode_GetValueForKeyAccNotFoundShouldReturnEmpty(t *testing.T) {
+	t.Parallel()
+
+	accDB := &stateMock.AccountsStub{
+		GetAccountWithBlockInfoCalled: func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error) {
+			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.asForProcessing())
+		},
+		RecreateTrieCalled: func(_ []byte) error {
+			return nil
+		},
+	}
+
+	dataComponents := getDefaultDataComponents()
+	coreComponents := getDefaultCoreComponents()
+	coreComponents.IntMarsh = getMarshalizer()
+	coreComponents.VmMarsh = getMarshalizer()
+	coreComponents.Hash = getHasher()
+
+	stateComponents := getDefaultStateComponents()
+	args := state.ArgsAccountsRepository{
+		FinalStateAccountsWrapper:      accDB,
+		CurrentStateAccountsWrapper:    accDB,
+		HistoricalStateAccountsWrapper: accDB,
+	}
+	stateComponents.AccountsRepo, _ = state.NewAccountsRepository(args)
+
+	n, _ := node.NewNode(
+		node.WithDataComponents(dataComponents),
+		node.WithCoreComponents(coreComponents),
+		node.WithStateComponents(stateComponents),
+	)
+
+	value, bInfo, err := n.GetValueForKey(testscommon.TestAddressAlice, "0a0a", api.AccountQueryOptions{})
+	require.Nil(t, err)
+	require.Equal(t, dummyBlockInfo.asApiResult(), bInfo)
+	require.Empty(t, value)
+}
+
 func TestNode_GetValueForKey(t *testing.T) {
 	t.Parallel()
 
@@ -509,6 +680,46 @@ func TestNode_GetValueForKey(t *testing.T) {
 	value, _, err := n.GetValueForKey(createDummyHexAddress(64), hex.EncodeToString(k1), api.AccountQueryOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, hex.EncodeToString(v1), value)
+}
+
+func TestNode_GetESDTDataAccNotFoundShouldReturnEmpty(t *testing.T) {
+	t.Parallel()
+
+	esdtToken := "newToken"
+
+	accDB := &stateMock.AccountsStub{
+		GetAccountWithBlockInfoCalled: func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error) {
+			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.asForProcessing())
+		},
+		RecreateTrieCalled: func(_ []byte) error {
+			return nil
+		},
+	}
+
+	dataComponents := getDefaultDataComponents()
+	coreComponents := getDefaultCoreComponents()
+	coreComponents.IntMarsh = getMarshalizer()
+	coreComponents.VmMarsh = getMarshalizer()
+	coreComponents.Hash = getHasher()
+
+	stateComponents := getDefaultStateComponents()
+	args := state.ArgsAccountsRepository{
+		FinalStateAccountsWrapper:      accDB,
+		CurrentStateAccountsWrapper:    accDB,
+		HistoricalStateAccountsWrapper: accDB,
+	}
+	stateComponents.AccountsRepo, _ = state.NewAccountsRepository(args)
+
+	n, _ := node.NewNode(
+		node.WithDataComponents(dataComponents),
+		node.WithCoreComponents(coreComponents),
+		node.WithStateComponents(stateComponents),
+	)
+
+	esdtTokenData, bInfo, err := n.GetESDTData(testscommon.TestAddressAlice, esdtToken, 0, api.AccountQueryOptions{})
+	require.Nil(t, err)
+	require.Equal(t, dummyBlockInfo.asApiResult(), bInfo)
+	require.Equal(t, "0", esdtTokenData.Value.String())
 }
 
 func TestNode_GetESDTData(t *testing.T) {
@@ -785,6 +996,44 @@ func TestNode_GetAllESDTTokensContextShouldTimeout(t *testing.T) {
 	value, _, err := n.GetAllESDTTokens(testscommon.TestAddressAlice, api.AccountQueryOptions{}, ctxWithTimeout)
 	assert.Nil(t, value)
 	assert.Equal(t, node.ErrTrieOperationsTimeout, err)
+}
+
+func TestNode_GetAllESDTsAccNotFoundShouldReturnEmpty(t *testing.T) {
+	t.Parallel()
+
+	accDB := &stateMock.AccountsStub{
+		GetAccountWithBlockInfoCalled: func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error) {
+			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.asForProcessing())
+		},
+		RecreateTrieCalled: func(_ []byte) error {
+			return nil
+		},
+	}
+
+	dataComponents := getDefaultDataComponents()
+	coreComponents := getDefaultCoreComponents()
+	coreComponents.IntMarsh = getMarshalizer()
+	coreComponents.VmMarsh = getMarshalizer()
+	coreComponents.Hash = getHasher()
+
+	stateComponents := getDefaultStateComponents()
+	args := state.ArgsAccountsRepository{
+		FinalStateAccountsWrapper:      accDB,
+		CurrentStateAccountsWrapper:    accDB,
+		HistoricalStateAccountsWrapper: accDB,
+	}
+	stateComponents.AccountsRepo, _ = state.NewAccountsRepository(args)
+
+	n, _ := node.NewNode(
+		node.WithDataComponents(dataComponents),
+		node.WithCoreComponents(coreComponents),
+		node.WithStateComponents(stateComponents),
+	)
+
+	tokens, bInfo, err := n.GetAllESDTTokens(testscommon.TestAddressAlice, api.AccountQueryOptions{}, context.Background())
+	require.Nil(t, err)
+	require.Equal(t, dummyBlockInfo.asApiResult(), bInfo)
+	require.Len(t, tokens, 0)
 }
 
 func TestNode_GetAllESDTTokensShouldReturnEsdtAndFormattedNft(t *testing.T) {
@@ -2939,6 +3188,44 @@ func TestNode_GetAccountAccountsRepositoryFailsShouldErr(t *testing.T) {
 	assert.Empty(t, recovAccnt)
 	assert.NotNil(t, err)
 	assert.ErrorIs(t, err, errExpected)
+}
+
+func TestNode_GetAccountAccNotFoundShouldReturnEmpty(t *testing.T) {
+	t.Parallel()
+
+	accDB := &stateMock.AccountsStub{
+		GetAccountWithBlockInfoCalled: func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error) {
+			return nil, nil, state.NewErrAccountNotFoundAtBlock(dummyBlockInfo.asForProcessing())
+		},
+		RecreateTrieCalled: func(_ []byte) error {
+			return nil
+		},
+	}
+
+	dataComponents := getDefaultDataComponents()
+	coreComponents := getDefaultCoreComponents()
+	coreComponents.IntMarsh = getMarshalizer()
+	coreComponents.VmMarsh = getMarshalizer()
+	coreComponents.Hash = getHasher()
+
+	stateComponents := getDefaultStateComponents()
+	args := state.ArgsAccountsRepository{
+		FinalStateAccountsWrapper:      accDB,
+		CurrentStateAccountsWrapper:    accDB,
+		HistoricalStateAccountsWrapper: accDB,
+	}
+	stateComponents.AccountsRepo, _ = state.NewAccountsRepository(args)
+
+	n, _ := node.NewNode(
+		node.WithDataComponents(dataComponents),
+		node.WithCoreComponents(coreComponents),
+		node.WithStateComponents(stateComponents),
+	)
+
+	acc, bInfo, err := n.GetAccount(testscommon.TestAddressAlice, api.AccountQueryOptions{})
+	require.Nil(t, err)
+	require.Equal(t, dummyBlockInfo.asApiResult(), bInfo)
+	require.Equal(t, api.AccountResponse{Address: testscommon.TestAddressAlice, Balance: "0", DeveloperReward: "0"}, acc)
 }
 
 func TestNode_GetAccountAccountExistsShouldReturn(t *testing.T) {


### PR DESCRIPTION
## Reasoning behind the pull request
- there were some inconsistencies between how several endpoints returned data when the account was not found 
  
## Proposed changes
- return empty responses instead of errors each time an account that does not exist is passed as input

**This PR brings breaking changes on the node's API level, so they should be communicated properly before reaching a release**

## Testing procedure
Call the following endpoints 2 ways: for a node running this branch and for a node running `feat/polaris-fixes`. Node with this branch should return empty responses, while the node with feat/polaris-fixes _could_ return errors (not in each case).
_these examples require that the used address does not exist or is in another shard_
- 127.0.0.1:8080/address/erd12fzhhrv4pnjflvsy0d7zpq54lz4fjuafqnarlwvspsz569zj4dfqlquphc
- 127.0.0.1:8080/address/erd12fzhhrv4pnjflvsy0d7zpq54lz4fjuafqnarlwvspsz569zj4dfqlquphc/balance
- 127.0.0.1:8080/address/erd12fzhhrv4pnjflvsy0d7zpq54lz4fjuafqnarlwvspsz569zj4dfqlquphc/esdt
- 127.0.0.1:8080/address/erd12fzhhrv4pnjflvsy0d7zpq54lz4fjuafqnarlwvspsz569zj4dfqlquphc/esdt/new-esdt
- 127.0.0.1:8080/address/erd12fzhhrv4pnjflvsy0d7zpq54lz4fjuafqnarlwvspsz569zj4dfqlquphc/code-hash
- 127.0.0.1:8080/address/erd12fzhhrv4pnjflvsy0d7zpq54lz4fjuafqnarlwvspsz569zj4dfqlquphc/username
- 127.0.0.1:8080/address/erd12fzhhrv4pnjflvsy0d7zpq54lz4fjuafqnarlwvspsz569zj4dfqlquphc/keys
- 127.0.0.1:8080/address/erd12fzhhrv4pnjflvsy0d7zpq54lz4fjuafqnarlwvspsz569zj4dfqlquphc/key/0a0a0a

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
