### PR TITLE
add extra fields on prepare transaction

### DIFF
--- a/node/external/transactionAPI/unmarshaller.go
+++ b/node/external/transactionAPI/unmarshaller.go
@@ -102,7 +102,7 @@ func (tu *txUnmarshaller) unmarshalTransaction(txBytes []byte, txType transactio
 }
 
 func (tu *txUnmarshaller) prepareNormalTx(tx *transaction.Transaction) (*transaction.ApiTransactionResult, error) {
-	return &transaction.ApiTransactionResult{
+	apiTx := &transaction.ApiTransactionResult{
 		Tx:               tx,
 		Type:             string(transaction.TxTypeNormal),
 		Nonce:            tx.Nonce,
@@ -118,11 +118,18 @@ func (tu *txUnmarshaller) prepareNormalTx(tx *transaction.Transaction) (*transac
 		Options:          tx.Options,
 		Version:          tx.Version,
 		ChainID:          string(tx.ChainID),
-	}, nil
+	}
+
+	if len(tx.GuardianAddr) > 0 {
+		apiTx.GuardianAddr = tu.addressPubKeyConverter.Encode(tx.GuardianAddr)
+		apiTx.GuardianSignature = hex.EncodeToString(tx.GuardianSignature)
+	}
+
+	return apiTx, nil
 }
 
 func (tu *txUnmarshaller) prepareInvalidTx(tx *transaction.Transaction) (*transaction.ApiTransactionResult, error) {
-	return &transaction.ApiTransactionResult{
+	apiTx := &transaction.ApiTransactionResult{
 		Tx:               tx,
 		Type:             string(transaction.TxTypeInvalid),
 		Nonce:            tx.Nonce,
@@ -135,7 +142,17 @@ func (tu *txUnmarshaller) prepareInvalidTx(tx *transaction.Transaction) (*transa
 		GasLimit:         tx.GasLimit,
 		Data:             tx.Data,
 		Signature:        hex.EncodeToString(tx.Signature),
-	}, nil
+		Options:          tx.Options,
+		Version:          tx.Version,
+		ChainID:          string(tx.ChainID),
+	}
+
+	if len(tx.GuardianAddr) > 0 {
+		apiTx.GuardianAddr = tu.addressPubKeyConverter.Encode(tx.GuardianAddr)
+		apiTx.GuardianSignature = hex.EncodeToString(tx.GuardianSignature)
+	}
+
+	return apiTx, nil
 }
 
 func (tu *txUnmarshaller) prepareRewardTx(tx *rewardTxData.RewardTx) (*transaction.ApiTransactionResult, error) {


### PR DESCRIPTION
## Reasoning behind the pull request
- missing fields in the transaction response for guarded transactions
  
## Proposed changes
- added the missing fields

## Testing procedure
- send guarded transactions and check for the fields on observer and proxy 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
