### PR TITLE
wrap invalid guardian signature error

### DIFF
--- a/process/transaction/interceptedTransaction.go
+++ b/process/transaction/interceptedTransaction.go
@@ -225,7 +225,7 @@ func (inTx *InterceptedTransaction) verifyIfRelayedTxV2(tx *transaction.Transact
 
 	err = inTx.verifySig(userTx)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w while checking inner transaction's signature", err)
 	}
 
 	err = inTx.VerifyGuardianSig(userTx)
@@ -275,7 +275,7 @@ func (inTx *InterceptedTransaction) verifyIfRelayedTx(tx *transaction.Transactio
 
 	err = inTx.verifySig(userTx)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w while checking inner transaction's signature", err)
 	}
 
 	err = inTx.VerifyGuardianSig(userTx)

--- a/process/transaction/interceptedTransaction.go
+++ b/process/transaction/interceptedTransaction.go
@@ -397,7 +397,12 @@ func (inTx *InterceptedTransaction) VerifyGuardianSig(tx *transaction.Transactio
 		return err
 	}
 
-	return inTx.singleSigner.Verify(guardianPubKey, txMessageForSigVerification, tx.GuardianSignature)
+	errVerifySig := inTx.singleSigner.Verify(guardianPubKey, txMessageForSigVerification, tx.GuardianSignature)
+	if errVerifySig != nil {
+		return fmt.Errorf("%w when checking the guardian's signature", errVerifySig)
+	}
+
+	return nil
 }
 
 func verifyConsistencyForNotGuardedTx(tx *transaction.Transaction) error {

--- a/process/transaction/interceptedTransaction.go
+++ b/process/transaction/interceptedTransaction.go
@@ -225,12 +225,12 @@ func (inTx *InterceptedTransaction) verifyIfRelayedTxV2(tx *transaction.Transact
 
 	err = inTx.verifySig(userTx)
 	if err != nil {
-		return fmt.Errorf("%w while checking inner transaction's signature", err)
+		return fmt.Errorf("inner transaction: %w", err)
 	}
 
 	err = inTx.VerifyGuardianSig(userTx)
 	if err != nil {
-		return err
+		return fmt.Errorf("inner transaction: %w", err)
 	}
 
 	funcName, _, err = inTx.argsParser.ParseCallData(string(userTx.Data))
@@ -261,7 +261,7 @@ func (inTx *InterceptedTransaction) verifyIfRelayedTx(tx *transaction.Transactio
 
 	userTx, err := createTx(inTx.signMarshalizer, userTxArgs[0])
 	if err != nil {
-		return err
+		return fmt.Errorf("inner transaction: %w", err)
 	}
 
 	if !bytes.Equal(userTx.SndAddr, tx.RcvAddr) {
@@ -270,17 +270,17 @@ func (inTx *InterceptedTransaction) verifyIfRelayedTx(tx *transaction.Transactio
 
 	err = inTx.integrity(userTx)
 	if err != nil {
-		return err
+		return fmt.Errorf("inner transaction: %w", err)
 	}
 
 	err = inTx.verifySig(userTx)
 	if err != nil {
-		return fmt.Errorf("%w while checking inner transaction's signature", err)
+		return fmt.Errorf("inner transaction: %w", err)
 	}
 
 	err = inTx.VerifyGuardianSig(userTx)
 	if err != nil {
-		return err
+		return fmt.Errorf("inner transaction: %w", err)
 	}
 
 	if len(userTx.Data) == 0 {

--- a/process/transaction/interceptedTransaction_test.go
+++ b/process/transaction/interceptedTransaction_test.go
@@ -1408,7 +1408,8 @@ func TestInterceptedTransaction_CheckValidityOfRelayedTx(t *testing.T) {
 	tx.Data = []byte(core.RelayedTransaction + "@" + hex.EncodeToString(userTxData))
 	txi, _ = createInterceptedTxFromPlainTxWithArgParser(tx)
 	err = txi.CheckValidity()
-	assert.Equal(t, errSignerMockVerifySigFails, err)
+	assert.ErrorIs(t, err, errSignerMockVerifySigFails)
+	assert.Contains(t, err.Error(), "inner transaction's signature")
 
 	userTx.Signature = sigOk
 	userTx.SndAddr = []byte("otherAddress")
@@ -1477,7 +1478,8 @@ func TestInterceptedTransaction_CheckValidityOfRelayedTxV2(t *testing.T) {
 	tx.Data = []byte(core.RelayedTransactionV2 + "@" + hex.EncodeToString(userTx.RcvAddr) + "@" + hex.EncodeToString(big.NewInt(0).SetUint64(userTx.Nonce).Bytes()) + "@" + hex.EncodeToString(userTx.Data) + "@" + hex.EncodeToString(userTx.Signature))
 	txi, _ = createInterceptedTxFromPlainTxWithArgParser(tx)
 	err = txi.CheckValidity()
-	assert.Equal(t, errSignerMockVerifySigFails, err)
+	assert.ErrorIs(t, err, errSignerMockVerifySigFails)
+	assert.Contains(t, err.Error(), "inner transaction's signature")
 
 	userTx.Signature = sigOk
 	userTx.SndAddr = []byte("otherAddress")

--- a/process/transaction/interceptedTransaction_test.go
+++ b/process/transaction/interceptedTransaction_test.go
@@ -1812,7 +1812,8 @@ func TestInterceptedTransaction_VerifyGuardianSig(t *testing.T) {
 		require.Nil(t, err)
 
 		err = inTx.VerifyGuardianSig(&tx)
-		require.Equal(t, errSignerMockVerifySigFails, err)
+		require.ErrorIs(t, err, errSignerMockVerifySigFails)
+		require.Contains(t, err.Error(), "guardian's signature")
 	})
 	t.Run("normal TX with not empty guardian address", func(t *testing.T) {
 		tx := tx
@@ -1848,7 +1849,8 @@ func TestInterceptedTransaction_VerifyGuardianSig(t *testing.T) {
 		require.Nil(t, err)
 
 		err = inTx.VerifyGuardianSig(&tx)
-		require.Equal(t, errSignerMockVerifySigFails, err)
+		require.ErrorIs(t, err, errSignerMockVerifySigFails)
+		require.Contains(t, err.Error(), "guardian's signature")
 	})
 	t.Run("correct guardian sig", func(t *testing.T) {
 		tx := tx

--- a/process/transaction/interceptedTransaction_test.go
+++ b/process/transaction/interceptedTransaction_test.go
@@ -1394,7 +1394,7 @@ func TestInterceptedTransaction_CheckValidityOfRelayedTx(t *testing.T) {
 	tx.Data = []byte(core.RelayedTransaction + "@" + hex.EncodeToString(userTxData))
 	txi, _ = createInterceptedTxFromPlainTxWithArgParser(tx)
 	err = txi.CheckValidity()
-	assert.Equal(t, process.ErrNilValue, err)
+	assert.ErrorIs(t, err, data.ErrNilValue)
 
 	userTx.Value = big.NewInt(0)
 	userTxData, _ = marshalizer.Marshal(userTx)
@@ -1409,7 +1409,7 @@ func TestInterceptedTransaction_CheckValidityOfRelayedTx(t *testing.T) {
 	txi, _ = createInterceptedTxFromPlainTxWithArgParser(tx)
 	err = txi.CheckValidity()
 	assert.ErrorIs(t, err, errSignerMockVerifySigFails)
-	assert.Contains(t, err.Error(), "inner transaction's signature")
+	assert.Contains(t, err.Error(), "inner transaction")
 
 	userTx.Signature = sigOk
 	userTx.SndAddr = []byte("otherAddress")
@@ -1479,7 +1479,7 @@ func TestInterceptedTransaction_CheckValidityOfRelayedTxV2(t *testing.T) {
 	txi, _ = createInterceptedTxFromPlainTxWithArgParser(tx)
 	err = txi.CheckValidity()
 	assert.ErrorIs(t, err, errSignerMockVerifySigFails)
-	assert.Contains(t, err.Error(), "inner transaction's signature")
+	assert.Contains(t, err.Error(), "inner transaction")
 
 	userTx.Signature = sigOk
 	userTx.SndAddr = []byte("otherAddress")


### PR DESCRIPTION
## Reasoning behind the pull request
- if a tx had an invalid guardian signature, one was not able to tell if the wrong signature is the tx's signature of the guardian's signature 
  
## Proposed changes
- wrap error

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
