### PR TITLE
Return err every time system vm

### DIFF
--- a/integrationTests/vm/esdt/process/esdtProcess_test.go
+++ b/integrationTests/vm/esdt/process/esdtProcess_test.go
@@ -179,6 +179,7 @@ func TestESDTCallBurnOnANonBurnableToken(t *testing.T) {
 		OptimizeGasUsedInCrossMiniBlocksEnableEpoch: integrationTests.UnreachableEpoch,
 		ScheduledMiniBlocksEnableEpoch:              integrationTests.UnreachableEpoch,
 		MiniBlockPartialExecutionEnableEpoch:        integrationTests.UnreachableEpoch,
+		MultiClaimOnDelegationEnableEpoch:           integrationTests.UnreachableEpoch,
 	}
 
 	nodes := integrationTests.CreateNodesWithEnableEpochs(

--- a/integrationTests/vm/txsFee/validatorSC_test.go
+++ b/integrationTests/vm/txsFee/validatorSC_test.go
@@ -171,9 +171,9 @@ func testValidatorsSCDoStakeWithTopUpValueTryToUnStakeTokensAndUnBondTokens(t *t
 	testContextMeta.TxsLogsProcessor.Clean()
 
 	tx = vm.CreateTransaction(0, big.NewInt(0), sndAddr, vmAddr.ValidatorSCAddress, gasPrice, gasLimit, []byte("unBondTokens@"+hex.EncodeToString(value200EGLD.Bytes())))
-	executeTxAndCheckResults(t, testContextMeta, tx, vmcommon.Ok, nil)
+	executeTxAndCheckResults(t, testContextMeta, tx, vmcommon.UserError, nil)
 
-	checkReturnLog(t, testContextMeta, noTokensToUnBondMessage, false)
+	checkReturnLog(t, testContextMeta, noTokensToUnBondMessage, true)
 }
 
 func TestValidatorsSC_ToStakePutInQueueUnStakeAndUnBondShouldRefundUnBondTokens(t *testing.T) {

--- a/vm/systemSmartContracts/delegation.go
+++ b/vm/systemSmartContracts/delegation.go
@@ -2088,6 +2088,9 @@ func (d *delegation) withdraw(args *vmcommon.ContractCallInput) vmcommon.ReturnC
 	}
 	if totalUnBondable.Cmp(zero) == 0 {
 		d.eei.AddReturnMessage("nothing to unBond")
+		if d.enableEpochsHandler.IsMultiClaimOnDelegationEnabled() {
+			return vmcommon.UserError
+		}
 		return vmcommon.Ok
 	}
 

--- a/vm/systemSmartContracts/delegation_test.go
+++ b/vm/systemSmartContracts/delegation_test.go
@@ -53,6 +53,7 @@ func createMockArgumentsForDelegation() ArgsNewDelegation {
 			IsComputeRewardCheckpointFlagEnabledField:              true,
 			IsValidatorToDelegationFlagEnabledField:                true,
 			IsReDelegateBelowMinCheckFlagEnabledField:              true,
+			IsMultiClaimOnDelegationEnabledField:                   true,
 		},
 	}
 }
@@ -2091,6 +2092,10 @@ func TestDelegationSystemSC_ExecuteWithdraw(t *testing.T) {
 
 	output := d.Execute(vmInput)
 	assert.Equal(t, vmcommon.Ok, output)
+
+	output = d.Execute(vmInput)
+	assert.Equal(t, vmcommon.UserError, output)
+	assert.Equal(t, eei.returnMessage, "nothing to unBond")
 
 	gFundData, _ := d.getGlobalFundData()
 	assert.Equal(t, big.NewInt(80), gFundData.TotalUnStaked)

--- a/vm/systemSmartContracts/esdt.go
+++ b/vm/systemSmartContracts/esdt.go
@@ -812,6 +812,9 @@ func (e *esdt) burn(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
 		}
 
 		e.eei.AddReturnMessage("token is not burnable")
+		if e.enableEpochsHandler.IsMultiClaimOnDelegationEnabled() {
+			return vmcommon.UserError
+		}
 		return vmcommon.Ok
 	}
 

--- a/vm/systemSmartContracts/validator.go
+++ b/vm/systemSmartContracts/validator.go
@@ -1709,6 +1709,9 @@ func (v *validatorSC) unBondTokens(args *vmcommon.ContractCallInput) vmcommon.Re
 	}
 	if totalUnBond.Cmp(zero) == 0 {
 		v.eei.AddReturnMessage("no tokens that can be unbond at this time")
+		if v.enableEpochsHandler.IsMultiClaimOnDelegationEnabled() {
+			return vmcommon.UserError
+		}
 		return vmcommon.Ok
 	}
 
@@ -2134,6 +2137,9 @@ func (v *validatorSC) getBlsKeysStatus(args *vmcommon.ContractCallInput) vmcommo
 
 	if len(registrationData.BlsPubKeys) == 0 {
 		v.eei.AddReturnMessage("no bls keys")
+		if v.enableEpochsHandler.IsMultiClaimOnDelegationEnabled() {
+			return vmcommon.UserError
+		}
 		return vmcommon.Ok
 	}
 

--- a/vm/systemSmartContracts/validator_test.go
+++ b/vm/systemSmartContracts/validator_test.go
@@ -63,6 +63,7 @@ func createMockArgumentsForValidatorSCWithSystemScAddresses(
 			IsUnBondTokensV2FlagEnabledField:        true,
 			IsValidatorToDelegationFlagEnabledField: true,
 			IsDoubleKeyProtectionFlagEnabledField:   true,
+			IsMultiClaimOnDelegationEnabledField:    true,
 		},
 	}
 
@@ -3028,7 +3029,7 @@ func TestValidatorStakingSC_getBlsStatusNoBlsKeys(t *testing.T) {
 	arguments.Arguments = append(arguments.Arguments, []byte("erd key"))
 
 	returnCode := sc.Execute(arguments)
-	assert.Equal(t, vmcommon.Ok, returnCode)
+	assert.Equal(t, vmcommon.UserError, returnCode)
 	assert.True(t, strings.Contains(eei.returnMessage, "no bls keys"))
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request
To increase consistency in system smart contract we should return error on case of all user errors. Otherwise it is hard to make integrations of these functions into other SCs.
  
## Proposed changes
Return error when needed.

## Testing procedure
Test withdraw from a delegation contract when there is nothing to unBond. After flag is activated, it should return error.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
