### PR TITLE
pass storageMarker as argument when SyncAccounts() is called

### DIFF
--- a/common/interface.go
+++ b/common/interface.go
@@ -46,6 +46,11 @@ type TrieStats interface {
 	GetTrieStats(address string, rootHash []byte) (*statistics.TrieStatsDTO, error)
 }
 
+// StorageMarker is used to mark the given storer as synced and active
+type StorageMarker interface {
+	MarkStorerAsSyncedAndActive(storer StorageManager)
+}
+
 // KeyBuilder is used for building trie keys as you traverse the trie
 type KeyBuilder interface {
 	BuildKey(keyPart []byte)

--- a/common/interface.go
+++ b/common/interface.go
@@ -49,6 +49,7 @@ type TrieStats interface {
 // StorageMarker is used to mark the given storer as synced and active
 type StorageMarker interface {
 	MarkStorerAsSyncedAndActive(storer StorageManager)
+	IsInterfaceNil() bool
 }
 
 // KeyBuilder is used for building trie keys as you traverse the trie

--- a/dataRetriever/storageRequesters/trieNodeRequester_test.go
+++ b/dataRetriever/storageRequesters/trieNodeRequester_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/endProcess"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/dataRetriever/mock"
-	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/p2pmocks"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	trieMock "github.com/multiversx/mx-chain-go/testscommon/trie"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,7 +23,7 @@ func createMockTrieRequesterArguments() ArgTrieRequester {
 		ResponseTopicName:        "",
 		Marshalizer:              &mock.MarshalizerStub{},
 		TrieDataGetter:           &trieMock.TrieStub{},
-		TrieStorageManager:       &testscommon.StorageManagerStub{},
+		TrieStorageManager:       &storageManager.StorageManagerStub{},
 		ManualEpochStartNotifier: &mock.ManualEpochStartNotifierStub{},
 		ChanGracefullyClose:      make(chan endProcess.ArgEndProcess, 1),
 		DelayBeforeGracefulClose: 0,

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -1076,7 +1076,6 @@ func (e *epochStartBootstrap) syncUserAccountsState(rootHash []byte) error {
 			MaxHardCapForMissingNodes:         e.maxHardCapForMissingNodes,
 			TrieSyncerVersion:                 e.trieSyncerVersion,
 			CheckNodesOnDisk:                  e.checkNodesOnDisk,
-			StorageMarker:                     storageMarker.NewTrieStorageMarker(),
 			UserAccountsSyncStatisticsHandler: e.trieSyncStatisticsProvider,
 			AppStatusHandler:                  e.statusHandler,
 		},
@@ -1089,7 +1088,7 @@ func (e *epochStartBootstrap) syncUserAccountsState(rootHash []byte) error {
 		return err
 	}
 
-	err = accountsDBSyncer.SyncAccounts(rootHash)
+	err = accountsDBSyncer.SyncAccounts(rootHash, storageMarker.NewTrieStorageMarker())
 	if err != nil {
 		return err
 	}
@@ -1147,7 +1146,6 @@ func (e *epochStartBootstrap) syncValidatorAccountsState(rootHash []byte) error 
 			MaxHardCapForMissingNodes:         e.maxHardCapForMissingNodes,
 			TrieSyncerVersion:                 e.trieSyncerVersion,
 			CheckNodesOnDisk:                  e.checkNodesOnDisk,
-			StorageMarker:                     storageMarker.NewTrieStorageMarker(),
 			UserAccountsSyncStatisticsHandler: statistics.NewTrieSyncStatistics(),
 			AppStatusHandler:                  disabledCommon.NewAppStatusHandler(),
 		},
@@ -1157,7 +1155,7 @@ func (e *epochStartBootstrap) syncValidatorAccountsState(rootHash []byte) error 
 		return err
 	}
 
-	err = accountsDBSyncer.SyncAccounts(rootHash)
+	err = accountsDBSyncer.SyncAccounts(rootHash, storageMarker.NewTrieStorageMarker())
 	if err != nil {
 		return err
 	}

--- a/epochStart/interface.go
+++ b/epochStart/interface.go
@@ -115,12 +115,6 @@ type PendingMiniBlocksSyncHandler interface {
 	IsInterfaceNil() bool
 }
 
-// AccountsDBSyncer defines the methods for the accounts db syncer
-type AccountsDBSyncer interface {
-	SyncAccounts(rootHash []byte) error
-	IsInterfaceNil() bool
-}
-
 // StartOfEpochMetaSyncer defines the methods to synchronize epoch start meta block from the network when nothing is known
 type StartOfEpochMetaSyncer interface {
 	SyncEpochStartMeta(waitTime time.Duration) (data.MetaHeaderHandler, error)

--- a/factory/consensus/consensusComponents.go
+++ b/factory/consensus/consensusComponents.go
@@ -26,7 +26,6 @@ import (
 	"github.com/multiversx/mx-chain-go/sharding"
 	"github.com/multiversx/mx-chain-go/state/syncer"
 	"github.com/multiversx/mx-chain-go/trie/statistics"
-	"github.com/multiversx/mx-chain-go/trie/storageMarker"
 	"github.com/multiversx/mx-chain-go/update"
 	logger "github.com/multiversx/mx-chain-logger-go"
 	"github.com/multiversx/mx-chain-storage-go/timecache"
@@ -529,7 +528,6 @@ func (ccf *consensusComponentsFactory) createArgsBaseAccountsSyncer(trieStorageM
 		MaxHardCapForMissingNodes:         ccf.config.TrieSync.MaxHardCapForMissingNodes,
 		TrieSyncerVersion:                 ccf.config.TrieSync.TrieSyncerVersion,
 		CheckNodesOnDisk:                  ccf.config.TrieSync.CheckNodesOnDisk,
-		StorageMarker:                     storageMarker.NewTrieStorageMarker(),
 		UserAccountsSyncStatisticsHandler: statistics.NewTrieSyncStatistics(),
 		AppStatusHandler:                  disabled.NewAppStatusHandler(),
 	}

--- a/factory/state/stateComponentsHandler_test.go
+++ b/factory/state/stateComponentsHandler_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/factory/mock"
 	stateComp "github.com/multiversx/mx-chain-go/factory/state"
-	"github.com/multiversx/mx-chain-go/testscommon"
 	componentsMock "github.com/multiversx/mx-chain-go/testscommon/components"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	trieMock "github.com/multiversx/mx-chain-go/testscommon/trie"
 	"github.com/stretchr/testify/require"
 )
@@ -108,7 +108,7 @@ func TestManagedStateComponents_Setters(t *testing.T) {
 	require.NoError(t, err)
 
 	triesContainer := &trieMock.TriesHolderStub{}
-	triesStorageManagers := map[string]common.StorageManager{"a": &testscommon.StorageManagerStub{}}
+	triesStorageManagers := map[string]common.StorageManager{"a": &storageManager.StorageManagerStub{}}
 
 	err = managedStateComponents.SetTriesContainer(triesContainer)
 	require.NoError(t, err)

--- a/integrationTests/mock/accountsDBSyncerStub.go
+++ b/integrationTests/mock/accountsDBSyncerStub.go
@@ -7,7 +7,7 @@ import (
 // AccountsDBSyncerStub -
 type AccountsDBSyncerStub struct {
 	GetSyncedTriesCalled func() map[string]common.Trie
-	SyncAccountsCalled   func(rootHash []byte) error
+	SyncAccountsCalled   func(rootHash []byte, storageMarker common.StorageMarker) error
 }
 
 // GetSyncedTries -
@@ -19,9 +19,9 @@ func (a *AccountsDBSyncerStub) GetSyncedTries() map[string]common.Trie {
 }
 
 // SyncAccounts -
-func (a *AccountsDBSyncerStub) SyncAccounts(rootHash []byte) error {
+func (a *AccountsDBSyncerStub) SyncAccounts(rootHash []byte, storageMarker common.StorageMarker) error {
 	if a.SyncAccountsCalled != nil {
-		return a.SyncAccountsCalled(rootHash)
+		return a.SyncAccountsCalled(rootHash, storageMarker)
 	}
 	return nil
 }

--- a/integrationTests/state/stateTrieSync/stateTrieSync_test.go
+++ b/integrationTests/state/stateTrieSync/stateTrieSync_test.go
@@ -346,7 +346,7 @@ func testMultipleDataTriesSync(t *testing.T, numAccounts int, numDataTrieLeaves 
 	userAccSyncer, err := syncer.NewUserAccountsSyncer(syncerArgs)
 	assert.Nil(t, err)
 
-	err = userAccSyncer.SyncAccounts(rootHash)
+	err = userAccSyncer.SyncAccounts(rootHash, storageMarker.NewDisabledStorageMarker())
 	assert.Nil(t, err)
 
 	_ = nRequester.AccntState.RecreateTrie(rootHash)
@@ -588,7 +588,6 @@ func getUserAccountSyncerArgs(node *integrationTests.TestProcessorNode, version 
 			MaxTrieLevelInMemory:              200,
 			MaxHardCapForMissingNodes:         5000,
 			TrieSyncerVersion:                 version,
-			StorageMarker:                     storageMarker.NewTrieStorageMarker(),
 			UserAccountsSyncStatisticsHandler: statistics.NewTrieSyncStatistics(),
 			AppStatusHandler:                  integrationTests.TestAppStatusHandler,
 		},

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -111,6 +111,7 @@ import (
 	stateMock "github.com/multiversx/mx-chain-go/testscommon/state"
 	statusHandlerMock "github.com/multiversx/mx-chain-go/testscommon/statusHandler"
 	storageStubs "github.com/multiversx/mx-chain-go/testscommon/storage"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	trieMock "github.com/multiversx/mx-chain-go/testscommon/trie"
 	"github.com/multiversx/mx-chain-go/trie/keyBuilder"
 	"github.com/multiversx/mx-chain-go/update"
@@ -3184,9 +3185,9 @@ func GetDefaultStateComponents() *testscommon.StateComponentsMock {
 		AccountsRepo: &stateMock.AccountsRepositoryStub{},
 		Tries:        &trieMock.TriesHolderStub{},
 		StorageManagers: map[string]common.StorageManager{
-			"0":                                     &testscommon.StorageManagerStub{},
-			dataRetriever.UserAccountsUnit.String(): &testscommon.StorageManagerStub{},
-			dataRetriever.PeerAccountsUnit.String(): &testscommon.StorageManagerStub{},
+			"0":                                     &storageManager.StorageManagerStub{},
+			dataRetriever.UserAccountsUnit.String(): &storageManager.StorageManagerStub{},
+			dataRetriever.PeerAccountsUnit.String(): &storageManager.StorageManagerStub{},
 		},
 	}
 }
@@ -3225,7 +3226,7 @@ func getDefaultBootstrapComponents(shardCoordinator sharding.Coordinator) *mainF
 	return &mainFactoryMocks.BootstrapComponentsStub{
 		Bootstrapper: &bootstrapMocks.EpochStartBootstrapperStub{
 			TrieHolder:      &trieMock.TriesHolderStub{},
-			StorageManagers: map[string]common.StorageManager{"0": &testscommon.StorageManagerStub{}},
+			StorageManagers: map[string]common.StorageManager{"0": &storageManager.StorageManagerStub{}},
 			BootstrapCalled: nil,
 		},
 		BootstrapParams:      &bootstrapMocks.BootstrapParamsHandlerMock{},

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -60,7 +60,6 @@ import (
 	storageFactory "github.com/multiversx/mx-chain-go/storage/factory"
 	"github.com/multiversx/mx-chain-go/storage/storageunit"
 	trieStatistics "github.com/multiversx/mx-chain-go/trie/statistics"
-	"github.com/multiversx/mx-chain-go/trie/storageMarker"
 	"github.com/multiversx/mx-chain-go/update/trigger"
 	logger "github.com/multiversx/mx-chain-logger-go"
 )
@@ -674,7 +673,6 @@ func getBaseAccountSyncerArgs(
 		MaxTrieLevelInMemory:              maxTrieLevelInMemory,
 		MaxHardCapForMissingNodes:         config.TrieSync.MaxHardCapForMissingNodes,
 		TrieSyncerVersion:                 config.TrieSync.TrieSyncerVersion,
-		StorageMarker:                     storageMarker.NewDisabledStorageMarker(),
 		CheckNodesOnDisk:                  true,
 		UserAccountsSyncStatisticsHandler: trieStatistics.NewTrieSyncStatistics(),
 		AppStatusHandler:                  disabled.NewAppStatusHandler(),

--- a/node/nodeTesting_test.go
+++ b/node/nodeTesting_test.go
@@ -23,6 +23,7 @@ import (
 	dataRetrieverMock "github.com/multiversx/mx-chain-go/testscommon/dataRetriever"
 	"github.com/multiversx/mx-chain-go/testscommon/p2pmocks"
 	stateMock "github.com/multiversx/mx-chain-go/testscommon/state"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	trieMock "github.com/multiversx/mx-chain-go/testscommon/trie"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -397,7 +398,7 @@ func getDefaultCryptoComponents() *factoryMock.CryptoComponentsMock {
 		PubKeyBytes:             []byte("pubKey"),
 		BlockSig:                &mock.SingleSignerMock{},
 		TxSig:                   &mock.SingleSignerMock{},
-		MultiSigContainer: cryptoMocks.NewMultiSignerContainerMock(                cryptoMocks.NewMultiSigner()),
+		MultiSigContainer:       cryptoMocks.NewMultiSignerContainerMock(cryptoMocks.NewMultiSigner()),
 		PeerSignHandler:         &mock.PeerSignatureHandler{},
 		BlKeyGen:                &mock.KeyGenMock{},
 		TxKeyGen:                &mock.KeyGenMock{},
@@ -415,7 +416,7 @@ func getDefaultStateComponents() *testscommon.StateComponentsMock {
 		AccountsAPI:     &stateMock.AccountsStub{},
 		AccountsRepo:    &stateMock.AccountsRepositoryStub{},
 		Tries:           &trieMock.TriesHolderStub{},
-		StorageManagers: map[string]common.StorageManager{"0": &testscommon.StorageManagerStub{}},
+		StorageManagers: map[string]common.StorageManager{"0": &storageManager.StorageManagerStub{}},
 	}
 }
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -54,6 +54,7 @@ import (
 	stateMock "github.com/multiversx/mx-chain-go/testscommon/state"
 	statusHandlerMock "github.com/multiversx/mx-chain-go/testscommon/statusHandler"
 	"github.com/multiversx/mx-chain-go/testscommon/storage"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	trieMock "github.com/multiversx/mx-chain-go/testscommon/trie"
 	"github.com/multiversx/mx-chain-go/testscommon/txsSenderMock"
 	"github.com/multiversx/mx-chain-go/vm/systemSmartContracts"
@@ -4007,7 +4008,7 @@ func getDefaultBootstrapComponents() *mainFactoryMocks.BootstrapComponentsStub {
 	return &mainFactoryMocks.BootstrapComponentsStub{
 		Bootstrapper: &bootstrapMocks.EpochStartBootstrapperStub{
 			TrieHolder:      &trieMock.TriesHolderStub{},
-			StorageManagers: map[string]common.StorageManager{"0": &testscommon.StorageManagerStub{}},
+			StorageManagers: map[string]common.StorageManager{"0": &storageManager.StorageManagerStub{}},
 			BootstrapCalled: nil,
 		},
 		BootstrapParams:      &bootstrapMocks.BootstrapParamsHandlerMock{},

--- a/process/interface.go
+++ b/process/interface.go
@@ -1179,7 +1179,7 @@ type InterceptedChunksProcessor interface {
 
 // AccountsDBSyncer defines the methods for the accounts db syncer
 type AccountsDBSyncer interface {
-	SyncAccounts(rootHash []byte) error
+	SyncAccounts(rootHash []byte, storageMarker common.StorageMarker) error
 	IsInterfaceNil() bool
 }
 

--- a/process/mock/accountsDBSyncerStub.go
+++ b/process/mock/accountsDBSyncerStub.go
@@ -7,7 +7,7 @@ import (
 // AccountsDBSyncerStub -
 type AccountsDBSyncerStub struct {
 	GetSyncedTriesCalled func() map[string]common.Trie
-	SyncAccountsCalled   func(rootHash []byte) error
+	SyncAccountsCalled   func(rootHash []byte, storageMarker common.StorageMarker) error
 }
 
 // GetSyncedTries -
@@ -19,9 +19,9 @@ func (a *AccountsDBSyncerStub) GetSyncedTries() map[string]common.Trie {
 }
 
 // SyncAccounts -
-func (a *AccountsDBSyncerStub) SyncAccounts(rootHash []byte) error {
+func (a *AccountsDBSyncerStub) SyncAccounts(rootHash []byte, storageMarker common.StorageMarker) error {
 	if a.SyncAccountsCalled != nil {
-		return a.SyncAccountsCalled(rootHash)
+		return a.SyncAccountsCalled(rootHash, storageMarker)
 	}
 	return nil
 }

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -27,6 +27,7 @@ import (
 	"github.com/multiversx/mx-chain-go/sharding"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/storage"
+	"github.com/multiversx/mx-chain-go/trie/storageMarker"
 	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
@@ -696,7 +697,7 @@ func (boot *baseBootstrap) handleTrieSyncError(err error, ctx context.Context) {
 
 func (boot *baseBootstrap) syncUserAccountsState(key []byte) error {
 	log.Warn("base sync: started syncUserAccountsState")
-	return boot.accountsDBSyncer.SyncAccounts(key)
+	return boot.accountsDBSyncer.SyncAccounts(key, storageMarker.NewDisabledStorageMarker())
 }
 
 func (boot *baseBootstrap) cleanNoncesSyncedWithErrorsBehindFinal() {

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -12,6 +12,7 @@ import (
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/storage"
+	"github.com/multiversx/mx-chain-go/trie/storageMarker"
 )
 
 // MetaBootstrap implements the bootstrap mechanism
@@ -216,7 +217,7 @@ func (boot *MetaBootstrap) syncAccountsDBs(key []byte, id string) error {
 
 func (boot *MetaBootstrap) syncValidatorAccountsState(key []byte) error {
 	log.Warn("base sync: started syncValidatorAccountsState")
-	return boot.validatorStatisticsDBSyncer.SyncAccounts(key)
+	return boot.validatorStatisticsDBSyncer.SyncAccounts(key, storageMarker.NewDisabledStorageMarker())
 }
 
 // Close closes the synchronization loop

--- a/process/sync/metablock_test.go
+++ b/process/sync/metablock_test.go
@@ -1682,7 +1682,7 @@ func TestMetaBootstrap_SyncBlockErrGetNodeDBShouldSyncAccounts(t *testing.T) {
 	)
 	accountsSyncCalled := false
 	args.AccountsDBSyncer = &mock.AccountsDBSyncerStub{
-		SyncAccountsCalled: func(rootHash []byte) error {
+		SyncAccountsCalled: func(rootHash []byte, _ common.StorageMarker) error {
 			accountsSyncCalled = true
 			return nil
 		},
@@ -1736,7 +1736,7 @@ func TestMetaBootstrap_SyncAccountsDBs(t *testing.T) {
 		args := CreateMetaBootstrapMockArguments()
 		accountsSyncCalled := false
 		args.AccountsDBSyncer = &mock.AccountsDBSyncerStub{
-			SyncAccountsCalled: func(rootHash []byte) error {
+			SyncAccountsCalled: func(rootHash []byte, _ common.StorageMarker) error {
 				accountsSyncCalled = true
 				return nil
 			},
@@ -1776,7 +1776,7 @@ func TestMetaBootstrap_SyncAccountsDBs(t *testing.T) {
 		args := CreateMetaBootstrapMockArguments()
 		accountsSyncCalled := false
 		args.ValidatorStatisticsDBSyncer = &mock.AccountsDBSyncerStub{
-			SyncAccountsCalled: func(rootHash []byte) error {
+			SyncAccountsCalled: func(rootHash []byte, _ common.StorageMarker) error {
 				accountsSyncCalled = true
 				return nil
 			},

--- a/process/sync/shardblock_test.go
+++ b/process/sync/shardblock_test.go
@@ -2135,7 +2135,7 @@ func TestShardBootstrap_SyncBlockGetNodeDBErrorShouldSync(t *testing.T) {
 
 	syncCalled := false
 	args.AccountsDBSyncer = &mock.AccountsDBSyncerStub{
-		SyncAccountsCalled: func(rootHash []byte) error {
+		SyncAccountsCalled: func(rootHash []byte, _ common.StorageMarker) error {
 			syncCalled = true
 			return nil
 		}}

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -19,6 +19,7 @@ import (
 	"github.com/multiversx/mx-chain-go/common/holders"
 	"github.com/multiversx/mx-chain-go/trie/keyBuilder"
 	"github.com/multiversx/mx-chain-go/trie/statistics"
+	"github.com/multiversx/mx-chain-go/trie/storageMarker"
 	logger "github.com/multiversx/mx-chain-logger-go"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
@@ -1295,7 +1296,7 @@ func (adb *AccountsDB) syncMissingNodes(missingNodesChan chan []byte, errChan ch
 	}
 
 	for missingNode := range missingNodesChan {
-		err := syncer.SyncAccounts(missingNode)
+		err := syncer.SyncAccounts(missingNode, storageMarker.NewDisabledStorageMarker())
 		if err != nil {
 			log.Error("could not sync missing node",
 				"missing node hash", missingNode,

--- a/state/accountsDB_test.go
+++ b/state/accountsDB_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
 	stateMock "github.com/multiversx/mx-chain-go/testscommon/state"
 	"github.com/multiversx/mx-chain-go/testscommon/statusHandler"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	trieMock "github.com/multiversx/mx-chain-go/testscommon/trie"
 	"github.com/multiversx/mx-chain-go/trie"
 	"github.com/multiversx/mx-chain-go/trie/hashesHolder"
@@ -44,7 +45,7 @@ func createMockAccountsDBArgs() state.ArgsAccountsDB {
 	return state.ArgsAccountsDB{
 		Trie: &trieMock.TrieStub{
 			GetStorageManagerCalled: func() common.StorageManager {
-				return &testscommon.StorageManagerStub{}
+				return &storageManager.StorageManagerStub{}
 			},
 		},
 		Hasher:     &hashingMocks.HasherMock{},
@@ -232,7 +233,7 @@ func TestAccountsDB_SaveAccountNilAccountShouldErr(t *testing.T) {
 
 	adb := generateAccountDBFromTrie(&trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	})
 
@@ -249,7 +250,7 @@ func TestAccountsDB_SaveAccountErrWhenGettingOldAccountShouldErr(t *testing.T) {
 			return nil, 0, expectedErr
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	})
 
@@ -268,7 +269,7 @@ func TestAccountsDB_SaveAccountNilOldAccount(t *testing.T) {
 			return nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	})
 
@@ -292,7 +293,7 @@ func TestAccountsDB_SaveAccountExistingOldAccount(t *testing.T) {
 			return nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	})
 
@@ -329,7 +330,7 @@ func TestAccountsDB_SaveAccountSavesCodeAndDataTrieForUserAccount(t *testing.T) 
 			return trieStub, nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	})
 
@@ -351,7 +352,7 @@ func TestAccountsDB_SaveAccountMalfunctionMarshallerShouldErr(t *testing.T) {
 	account := generateAccount()
 	mockTrie := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	marshaller := &testscommon.MarshalizerMock{}
@@ -380,7 +381,7 @@ func TestAccountsDB_SaveAccountWithSomeValuesShouldWork(t *testing.T) {
 			return nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	_, account, adb := generateAddressAccountAccountsDB(ts)
@@ -407,7 +408,7 @@ func TestAccountsDB_RemoveAccountShouldWork(t *testing.T) {
 			return nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 
@@ -427,7 +428,7 @@ func TestAccountsDB_LoadAccountMalfunctionTrieShouldErr(t *testing.T) {
 
 	trieStub := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	adr := make([]byte, 32)
@@ -448,7 +449,7 @@ func TestAccountsDB_LoadAccountNotFoundShouldCreateEmpty(t *testing.T) {
 			return nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 
@@ -489,7 +490,7 @@ func TestAccountsDB_LoadAccountExistingShouldLoadDataTrie(t *testing.T) {
 			return dataTrie, nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 
@@ -508,7 +509,7 @@ func TestAccountsDB_GetExistingAccountMalfunctionTrieShouldErr(t *testing.T) {
 
 	trieStub := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	adr := make([]byte, 32)
@@ -526,7 +527,7 @@ func TestAccountsDB_GetExistingAccountNotFoundShouldRetNil(t *testing.T) {
 			return nil, 0, nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 
@@ -567,7 +568,7 @@ func TestAccountsDB_GetExistingAccountFoundShouldRetAccount(t *testing.T) {
 			return dataTrie, nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 
@@ -586,7 +587,7 @@ func TestAccountsDB_GetAccountAccountNotFound(t *testing.T) {
 
 	tr := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	adr, _, _ := generateAddressAccountAccountsDB(tr)
@@ -626,7 +627,7 @@ func TestAccountsDB_LoadCodeWrongHashLengthShouldErr(t *testing.T) {
 
 	tr := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	_, account, adb := generateAddressAccountAccountsDB(tr)
@@ -644,7 +645,7 @@ func TestAccountsDB_LoadCodeMalfunctionTrieShouldErr(t *testing.T) {
 	account := generateAccount()
 	mockTrie := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	adb := generateAccountDBFromTrie(mockTrie)
@@ -661,7 +662,7 @@ func TestAccountsDB_LoadCodeOkValsShouldWork(t *testing.T) {
 
 	tr := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	adr, account, _ := generateAddressAccountAccountsDB(tr)
@@ -674,7 +675,7 @@ func TestAccountsDB_LoadCodeOkValsShouldWork(t *testing.T) {
 			return serializedCodeEntry, 0, err
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 
@@ -699,7 +700,7 @@ func TestAccountsDB_LoadDataNilRootShouldRetNil(t *testing.T) {
 
 	tr := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	_, account, adb := generateAddressAccountAccountsDB(tr)
@@ -715,7 +716,7 @@ func TestAccountsDB_LoadDataBadLengthShouldErr(t *testing.T) {
 
 	_, account, adb := generateAddressAccountAccountsDB(&trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	})
 
@@ -734,7 +735,7 @@ func TestAccountsDB_LoadDataMalfunctionTrieShouldErr(t *testing.T) {
 
 	mockTrie := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	adb := generateAccountDBFromTrie(mockTrie)
@@ -749,7 +750,7 @@ func TestAccountsDB_LoadDataNotFoundRootShouldReturnErr(t *testing.T) {
 
 	_, account, adb := generateAddressAccountAccountsDB(&trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	})
 
@@ -794,7 +795,7 @@ func TestAccountsDB_LoadDataWithSomeValuesShouldWork(t *testing.T) {
 			return dataTrie, nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	adb := generateAccountDBFromTrie(mockTrie)
@@ -850,7 +851,7 @@ func TestAccountsDB_CommitShouldCallCommitFromTrie(t *testing.T) {
 			}, nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 
@@ -876,7 +877,7 @@ func TestAccountsDB_RecreateTrieMalfunctionTrieShouldErr(t *testing.T) {
 	errExpected := errors.New("failure")
 	trieStub := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	trieStub.RecreateFromEpochCalled = func(_ common.RootHashHolder) (tree common.Trie, e error) {
@@ -898,7 +899,7 @@ func TestAccountsDB_RecreateTrieOutputsNilTrieShouldErr(t *testing.T) {
 
 	trieStub := trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	trieStub.RecreateFromEpochCalled = func(_ common.RootHashHolder) (tree common.Trie, e error) {
@@ -921,7 +922,7 @@ func TestAccountsDB_RecreateTrieOkValsShouldWork(t *testing.T) {
 
 	trieStub := trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 		RecreateFromEpochCalled: func(_ common.RootHashHolder) (common.Trie, error) {
 			wasCalled = true
@@ -943,7 +944,7 @@ func TestAccountsDB_SnapshotState(t *testing.T) {
 	snapshotMut := sync.Mutex{}
 	trieStub := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{
+			return &storageManager.StorageManagerStub{
 				TakeSnapshotCalled: func(_ string, _ []byte, _ []byte, _ *common.TrieIteratorChannels, _ chan []byte, _ common.SnapshotStatisticsHandler, _ uint32) {
 					snapshotMut.Lock()
 					takeSnapshotWasCalled = true
@@ -969,7 +970,7 @@ func TestAccountsDB_SnapshotStateOnAClosedStorageManagerShouldNotMarkActiveDB(t 
 	activeDBWasPut := false
 	trieStub := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{
+			return &storageManager.StorageManagerStub{
 				ShouldTakeSnapshotCalled: func() bool {
 					return true
 				},
@@ -1022,7 +1023,7 @@ func TestAccountsDB_SnapshotStateWithErrorsShouldNotMarkActiveDB(t *testing.T) {
 	expectedErr := errors.New("expected error")
 	trieStub := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{
+			return &storageManager.StorageManagerStub{
 				ShouldTakeSnapshotCalled: func() bool {
 					return true
 				},
@@ -1073,7 +1074,7 @@ func TestAccountsDB_SnapshotStateGetLatestStorageEpochErrDoesNotSnapshot(t *test
 	takeSnapshotCalled := false
 	trieStub := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{
+			return &storageManager.StorageManagerStub{
 				GetLatestStorageEpochCalled: func() (uint32, error) {
 					return 0, fmt.Errorf("new error")
 				},
@@ -1100,7 +1101,7 @@ func TestAccountsDB_SnapshotStateSnapshotSameRootHash(t *testing.T) {
 	takeSnapshotCalled := 0
 	trieStub := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{
+			return &storageManager.StorageManagerStub{
 				GetLatestStorageEpochCalled: func() (uint32, error) {
 					return latestEpoch, nil
 				},
@@ -1183,7 +1184,7 @@ func TestAccountsDB_SnapshotStateSkipSnapshotIfSnapshotInProgress(t *testing.T) 
 	takeSnapshotCalled := 0
 	trieStub := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{
+			return &storageManager.StorageManagerStub{
 				GetLatestStorageEpochCalled: func() (uint32, error) {
 					return latestEpoch, nil
 				},
@@ -1247,7 +1248,7 @@ func TestAccountsDB_SetStateCheckpoint(t *testing.T) {
 	snapshotMut := sync.Mutex{}
 	trieStub := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{
+			return &storageManager.StorageManagerStub{
 				SetCheckpointCalled: func(_ []byte, _ []byte, _ *common.TrieIteratorChannels, _ chan []byte, _ common.SnapshotStatisticsHandler) {
 					snapshotMut.Lock()
 					setCheckPointWasCalled = true
@@ -1270,7 +1271,7 @@ func TestAccountsDB_IsPruningEnabled(t *testing.T) {
 
 	trieStub := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{
+			return &storageManager.StorageManagerStub{
 				IsPruningEnabledCalled: func() bool {
 					return true
 				},
@@ -1288,7 +1289,7 @@ func TestAccountsDB_RevertToSnapshotOutOfBounds(t *testing.T) {
 
 	trieStub := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	adb := generateAccountDBFromTrie(trieStub)
@@ -1410,7 +1411,7 @@ func TestAccountsDB_RootHash(t *testing.T) {
 			return rootHash, nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	adb := generateAccountDBFromTrie(trieStub)
@@ -1433,7 +1434,7 @@ func TestAccountsDB_GetAllLeaves(t *testing.T) {
 			return nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 
@@ -2403,7 +2404,7 @@ func TestAccountsDB_Close(t *testing.T) {
 			return nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 	marshaller := &testscommon.MarshalizerMock{}
@@ -2474,7 +2475,7 @@ func TestAccountsDB_GetAccountFromBytesShouldLoadDataTrie(t *testing.T) {
 			return dataTrie, nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 	}
 
@@ -2498,7 +2499,7 @@ func TestAccountsDB_SetSyncerAndStartSnapshotIfNeeded(t *testing.T) {
 				return rootHash, nil
 			},
 			GetStorageManagerCalled: func() common.StorageManager {
-				return &testscommon.StorageManagerStub{
+				return &storageManager.StorageManagerStub{
 					ShouldTakeSnapshotCalled: func() bool {
 						return true
 					},
@@ -2531,7 +2532,7 @@ func TestAccountsDB_SetSyncerAndStartSnapshotIfNeeded(t *testing.T) {
 				return rootHash, nil
 			},
 			GetStorageManagerCalled: func() common.StorageManager {
-				return &testscommon.StorageManagerStub{
+				return &storageManager.StorageManagerStub{
 					ShouldTakeSnapshotCalled: func() bool {
 						return true
 					},
@@ -2560,7 +2561,7 @@ func TestAccountsDB_SetSyncerAndStartSnapshotIfNeeded(t *testing.T) {
 				return rootHash, nil
 			},
 			GetStorageManagerCalled: func() common.StorageManager {
-				return &testscommon.StorageManagerStub{
+				return &storageManager.StorageManagerStub{
 					ShouldTakeSnapshotCalled: func() bool {
 						return true
 					},
@@ -2603,7 +2604,7 @@ func TestAccountsDB_NewAccountsDbStartsSnapshotAfterRestart(t *testing.T) {
 			return rootHash, nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{
+			return &storageManager.StorageManagerStub{
 				GetCalled: func(key []byte) ([]byte, error) {
 					if bytes.Equal(key, []byte(common.ActiveDBKey)) {
 						return nil, fmt.Errorf("key not found")
@@ -2838,7 +2839,7 @@ func TestAccountsDB_SyncMissingSnapshotNodes(t *testing.T) {
 		trieHashes, _ = tr.GetAllHashes()
 
 		syncer := &mock.AccountsDBSyncerStub{
-			SyncAccountsCalled: func(rootHash []byte) error {
+			SyncAccountsCalled: func(rootHash []byte, _ common.StorageMarker) error {
 				isSyncError = true
 				return errors.New("sync error")
 			},

--- a/state/factory/accountsAdapterAPICreator_test.go
+++ b/state/factory/accountsAdapterAPICreator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/multiversx/mx-chain-go/testscommon"
 	mockState "github.com/multiversx/mx-chain-go/testscommon/state"
 	"github.com/multiversx/mx-chain-go/testscommon/statusHandler"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	mockTrie "github.com/multiversx/mx-chain-go/testscommon/trie"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +19,7 @@ func createMockAccountsArgs() state.ArgsAccountsDB {
 	return state.ArgsAccountsDB{
 		Trie: &mockTrie.TrieStub{
 			GetStorageManagerCalled: func() common.StorageManager {
-				return &testscommon.StorageManagerStub{}
+				return &storageManager.StorageManagerStub{}
 			},
 		},
 		Hasher:                &testscommon.HasherStub{},

--- a/state/interface.go
+++ b/state/interface.go
@@ -131,7 +131,7 @@ type AccountsAdapter interface {
 
 // AccountsDBSyncer defines the methods for the accounts db syncer
 type AccountsDBSyncer interface {
-	SyncAccounts(rootHash []byte) error
+	SyncAccounts(rootHash []byte, storageMarker common.StorageMarker) error
 	IsInterfaceNil() bool
 }
 

--- a/state/peerAccountsDB_test.go
+++ b/state/peerAccountsDB_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/process/mock"
 	"github.com/multiversx/mx-chain-go/state"
-	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	trieMock "github.com/multiversx/mx-chain-go/testscommon/trie"
 	"github.com/stretchr/testify/assert"
 )
@@ -98,7 +98,7 @@ func TestNewPeerAccountsDB_SnapshotState(t *testing.T) {
 	args := createMockAccountsDBArgs()
 	args.Trie = &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{
+			return &storageManager.StorageManagerStub{
 				TakeSnapshotCalled: func(_ string, _ []byte, _ []byte, _ *common.TrieIteratorChannels, _ chan []byte, _ common.SnapshotStatisticsHandler, _ uint32) {
 					snapshotCalled = true
 				},
@@ -121,7 +121,7 @@ func TestNewPeerAccountsDB_SnapshotStateGetLatestStorageEpochErrDoesNotSnapshot(
 	args := createMockAccountsDBArgs()
 	args.Trie = &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{
+			return &storageManager.StorageManagerStub{
 				GetLatestStorageEpochCalled: func() (uint32, error) {
 					return 0, fmt.Errorf("new error")
 				},
@@ -146,7 +146,7 @@ func TestNewPeerAccountsDB_SetStateCheckpoint(t *testing.T) {
 	args := createMockAccountsDBArgs()
 	args.Trie = &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{
+			return &storageManager.StorageManagerStub{
 				SetCheckpointCalled: func(_ []byte, _ []byte, _ *common.TrieIteratorChannels, _ chan []byte, _ common.SnapshotStatisticsHandler) {
 					checkpointCalled = true
 				},
@@ -169,7 +169,7 @@ func TestNewPeerAccountsDB_RecreateAllTries(t *testing.T) {
 	args := createMockAccountsDBArgs()
 	args.Trie = &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{}
+			return &storageManager.StorageManagerStub{}
 		},
 		RecreateCalled: func(_ []byte) (common.Trie, error) {
 			recreateCalled = true
@@ -198,7 +198,7 @@ func TestPeerAccountsDB_SetSyncerAndStartSnapshotIfNeeded(t *testing.T) {
 			return rootHash, nil
 		},
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{
+			return &storageManager.StorageManagerStub{
 				GetCalled: func(key []byte) ([]byte, error) {
 					if bytes.Equal(key, []byte(common.ActiveDBKey)) {
 						return nil, fmt.Errorf("key not found")
@@ -253,7 +253,7 @@ func TestPeerAccountsDB_MarkSnapshotDone(t *testing.T) {
 		args := createMockAccountsDBArgs()
 		args.Trie = &trieMock.TrieStub{
 			GetStorageManagerCalled: func() common.StorageManager {
-				return &testscommon.StorageManagerStub{
+				return &storageManager.StorageManagerStub{
 					PutInEpochCalled: func(bytes []byte, bytes2 []byte, u uint32) error {
 						assert.Fail(t, "should have not called put in epoch")
 						return nil
@@ -283,7 +283,7 @@ func TestPeerAccountsDB_MarkSnapshotDone(t *testing.T) {
 		args := createMockAccountsDBArgs()
 		args.Trie = &trieMock.TrieStub{
 			GetStorageManagerCalled: func() common.StorageManager {
-				return &testscommon.StorageManagerStub{
+				return &storageManager.StorageManagerStub{
 					PutInEpochWithoutCacheCalled: func(key []byte, value []byte, epoch uint32) error {
 						assert.Equal(t, common.ActiveDBKey, string(key))
 						assert.Equal(t, common.ActiveDBVal, string(value))
@@ -306,7 +306,7 @@ func TestPeerAccountsDB_MarkSnapshotDone(t *testing.T) {
 		args := createMockAccountsDBArgs()
 		args.Trie = &trieMock.TrieStub{
 			GetStorageManagerCalled: func() common.StorageManager {
-				return &testscommon.StorageManagerStub{
+				return &storageManager.StorageManagerStub{
 					PutInEpochWithoutCacheCalled: func(key []byte, value []byte, epoch uint32) error {
 						assert.Equal(t, common.ActiveDBKey, string(key))
 						assert.Equal(t, common.ActiveDBVal, string(value))
@@ -337,7 +337,7 @@ func TestPeerAccountsDB_SetSyncerAndStartSnapshotIfNeededMarksActiveDB(t *testin
 				return rootHash, nil
 			},
 			GetStorageManagerCalled: func() common.StorageManager {
-				return &testscommon.StorageManagerStub{
+				return &storageManager.StorageManagerStub{
 					ShouldTakeSnapshotCalled: func() bool {
 						return true
 					},
@@ -372,7 +372,7 @@ func TestPeerAccountsDB_SetSyncerAndStartSnapshotIfNeededMarksActiveDB(t *testin
 				return rootHash, nil
 			},
 			GetStorageManagerCalled: func() common.StorageManager {
-				return &testscommon.StorageManagerStub{
+				return &storageManager.StorageManagerStub{
 					ShouldTakeSnapshotCalled: func() bool {
 						return true
 					},
@@ -403,7 +403,7 @@ func TestPeerAccountsDB_SetSyncerAndStartSnapshotIfNeededMarksActiveDB(t *testin
 				return rootHash, nil
 			},
 			GetStorageManagerCalled: func() common.StorageManager {
-				return &testscommon.StorageManagerStub{
+				return &storageManager.StorageManagerStub{
 					ShouldTakeSnapshotCalled: func() bool {
 						return true
 					},
@@ -443,7 +443,7 @@ func TestPeerAccountsDB_SnapshotStateOnAClosedStorageManagerShouldNotMarkActiveD
 	activeDBWasPut := false
 	trieStub := &trieMock.TrieStub{
 		GetStorageManagerCalled: func() common.StorageManager {
-			return &testscommon.StorageManagerStub{
+			return &storageManager.StorageManagerStub{
 				ShouldTakeSnapshotCalled: func() bool {
 					return true
 				},

--- a/state/syncer/baseAccountsSyncer.go
+++ b/state/syncer/baseAccountsSyncer.go
@@ -32,7 +32,6 @@ type baseAccountsSyncer struct {
 	name                              string
 	maxHardCapForMissingNodes         int
 	checkNodesOnDisk                  bool
-	storageMarker                     trie.StorageMarker
 	userAccountsSyncStatisticsHandler common.SizeSyncStatisticsHandler
 	appStatusHandler                  core.AppStatusHandler
 
@@ -48,7 +47,6 @@ type ArgsNewBaseAccountsSyncer struct {
 	Hasher                            hashing.Hasher
 	Marshalizer                       marshal.Marshalizer
 	TrieStorageManager                common.StorageManager
-	StorageMarker                     trie.StorageMarker
 	RequestHandler                    trie.RequestHandler
 	Timeout                           time.Duration
 	Cacher                            storage.Cacher

--- a/state/syncer/errors.go
+++ b/state/syncer/errors.go
@@ -4,3 +4,6 @@ import "errors"
 
 // ErrNilPubkeyConverter signals that a nil public key converter was provided
 var ErrNilPubkeyConverter = errors.New("nil pubkey converter")
+
+// ErrNilStorageMarker signals that a nil storage marker was provided
+var ErrNilStorageMarker = errors.New("nil storage marker")

--- a/state/syncer/userAccountSyncer_test.go
+++ b/state/syncer/userAccountSyncer_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TODO add more tests
+
 func getDefaultBaseAccSyncerArgs() ArgsNewBaseAccountsSyncer {
 	return ArgsNewBaseAccountsSyncer{
 		Hasher:                            &hashingMocks.HasherMock{},

--- a/state/syncer/userAccountSyncer_test.go
+++ b/state/syncer/userAccountSyncer_test.go
@@ -1,0 +1,47 @@
+package syncer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/multiversx/mx-chain-go/dataRetriever/mock"
+	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
+	"github.com/multiversx/mx-chain-go/testscommon/statusHandler"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
+	"github.com/stretchr/testify/assert"
+)
+
+func getDefaultBaseAccSyncerArgs() ArgsNewBaseAccountsSyncer {
+	return ArgsNewBaseAccountsSyncer{
+		Hasher:                            &hashingMocks.HasherMock{},
+		Marshalizer:                       testscommon.MarshalizerMock{},
+		TrieStorageManager:                &storageManager.StorageManagerStub{},
+		RequestHandler:                    &testscommon.RequestHandlerStub{},
+		Timeout:                           time.Second,
+		Cacher:                            testscommon.NewCacherMock(),
+		UserAccountsSyncStatisticsHandler: &testscommon.SizeSyncStatisticsHandlerStub{},
+		AppStatusHandler:                  &statusHandler.AppStatusHandlerStub{},
+		MaxTrieLevelInMemory:              0,
+		MaxHardCapForMissingNodes:         100,
+		TrieSyncerVersion:                 2,
+		CheckNodesOnDisk:                  false,
+	}
+}
+
+func TestUserAccountsSyncer_SyncAccounts(t *testing.T) {
+	t.Parallel()
+
+	args := ArgsNewUserAccountsSyncer{
+		ArgsNewBaseAccountsSyncer: getDefaultBaseAccSyncerArgs(),
+		ShardId:                   0,
+		Throttler:                 &mock.ThrottlerStub{},
+		AddressPubKeyConverter:    &testscommon.PubkeyConverterStub{},
+	}
+	syncer, err := NewUserAccountsSyncer(args)
+	assert.Nil(t, err)
+	assert.NotNil(t, syncer)
+
+	err = syncer.SyncAccounts([]byte("rootHash"), nil)
+	assert.Equal(t, ErrNilStorageMarker, err)
+}

--- a/state/syncer/userAccountsSyncer.go
+++ b/state/syncer/userAccountsSyncer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-go/common"
-	"github.com/multiversx/mx-chain-go/epochStart"
 	"github.com/multiversx/mx-chain-go/process/factory"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/trie"
@@ -20,7 +19,7 @@ import (
 	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
-var _ epochStart.AccountsDBSyncer = (*userAccountsSyncer)(nil)
+var _ state.AccountsDBSyncer = (*userAccountsSyncer)(nil)
 
 var log = logger.GetOrCreate("syncer")
 
@@ -88,7 +87,6 @@ func NewUserAccountsSyncer(args ArgsNewUserAccountsSyncer) (*userAccountsSyncer,
 		maxHardCapForMissingNodes:         args.MaxHardCapForMissingNodes,
 		trieSyncerVersion:                 args.TrieSyncerVersion,
 		checkNodesOnDisk:                  args.CheckNodesOnDisk,
-		storageMarker:                     args.StorageMarker,
 		userAccountsSyncStatisticsHandler: args.UserAccountsSyncStatisticsHandler,
 		appStatusHandler:                  args.AppStatusHandler,
 	}
@@ -104,7 +102,7 @@ func NewUserAccountsSyncer(args ArgsNewUserAccountsSyncer) (*userAccountsSyncer,
 }
 
 // SyncAccounts will launch the syncing method to gather all the data needed for userAccounts - it is a blocking method
-func (u *userAccountsSyncer) SyncAccounts(rootHash []byte) error {
+func (u *userAccountsSyncer) SyncAccounts(rootHash []byte, storageMarker common.StorageMarker) error {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 
@@ -134,7 +132,7 @@ func (u *userAccountsSyncer) SyncAccounts(rootHash []byte) error {
 		return err
 	}
 
-	u.storageMarker.MarkStorerAsSyncedAndActive(mainTrie.GetStorageManager())
+	storageMarker.MarkStorerAsSyncedAndActive(mainTrie.GetStorageManager())
 
 	return nil
 }

--- a/state/syncer/userAccountsSyncer.go
+++ b/state/syncer/userAccountsSyncer.go
@@ -103,6 +103,10 @@ func NewUserAccountsSyncer(args ArgsNewUserAccountsSyncer) (*userAccountsSyncer,
 
 // SyncAccounts will launch the syncing method to gather all the data needed for userAccounts - it is a blocking method
 func (u *userAccountsSyncer) SyncAccounts(rootHash []byte, storageMarker common.StorageMarker) error {
+	if check.IfNil(storageMarker) {
+		return ErrNilStorageMarker
+	}
+
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 

--- a/state/syncer/validatorAccountsSyncer.go
+++ b/state/syncer/validatorAccountsSyncer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/process/factory"
 	"github.com/multiversx/mx-chain-go/state"
@@ -61,6 +62,10 @@ func NewValidatorAccountsSyncer(args ArgsNewValidatorAccountsSyncer) (*validator
 
 // SyncAccounts will launch the syncing method to gather all the data needed for validatorAccounts - it is a blocking method
 func (v *validatorAccountsSyncer) SyncAccounts(rootHash []byte, storageMarker common.StorageMarker) error {
+	if check.IfNil(storageMarker) {
+		return ErrNilStorageMarker
+	}
+
 	v.mutex.Lock()
 	defer v.mutex.Unlock()
 

--- a/state/syncer/validatorAccountsSyncer.go
+++ b/state/syncer/validatorAccountsSyncer.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-go/common"
-	"github.com/multiversx/mx-chain-go/epochStart"
 	"github.com/multiversx/mx-chain-go/process/factory"
+	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/trie/statistics"
 )
 
-var _ epochStart.AccountsDBSyncer = (*validatorAccountsSyncer)(nil)
+var _ state.AccountsDBSyncer = (*validatorAccountsSyncer)(nil)
 
 type validatorAccountsSyncer struct {
 	*baseAccountsSyncer
@@ -48,7 +48,6 @@ func NewValidatorAccountsSyncer(args ArgsNewValidatorAccountsSyncer) (*validator
 		maxHardCapForMissingNodes:         args.MaxHardCapForMissingNodes,
 		trieSyncerVersion:                 args.TrieSyncerVersion,
 		checkNodesOnDisk:                  args.CheckNodesOnDisk,
-		storageMarker:                     args.StorageMarker,
 		userAccountsSyncStatisticsHandler: statistics.NewTrieSyncStatistics(),
 		appStatusHandler:                  args.AppStatusHandler,
 	}
@@ -61,7 +60,7 @@ func NewValidatorAccountsSyncer(args ArgsNewValidatorAccountsSyncer) (*validator
 }
 
 // SyncAccounts will launch the syncing method to gather all the data needed for validatorAccounts - it is a blocking method
-func (v *validatorAccountsSyncer) SyncAccounts(rootHash []byte) error {
+func (v *validatorAccountsSyncer) SyncAccounts(rootHash []byte, storageMarker common.StorageMarker) error {
 	v.mutex.Lock()
 	defer v.mutex.Unlock()
 
@@ -80,7 +79,7 @@ func (v *validatorAccountsSyncer) SyncAccounts(rootHash []byte) error {
 		return err
 	}
 
-	v.storageMarker.MarkStorerAsSyncedAndActive(mainTrie.GetStorageManager())
+	storageMarker.MarkStorerAsSyncedAndActive(mainTrie.GetStorageManager())
 
 	return nil
 }

--- a/state/syncer/validatorAccountsSyncer_test.go
+++ b/state/syncer/validatorAccountsSyncer_test.go
@@ -1,0 +1,22 @@
+package syncer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidatorAccountsSyncer_SyncAccounts(t *testing.T) {
+	t.Parallel()
+
+	args := ArgsNewValidatorAccountsSyncer{
+		ArgsNewBaseAccountsSyncer: getDefaultBaseAccSyncerArgs(),
+	}
+
+	syncer, err := NewValidatorAccountsSyncer(args)
+	assert.Nil(t, err)
+	assert.NotNil(t, syncer)
+
+	err = syncer.SyncAccounts([]byte("rootHash"), nil)
+	assert.Equal(t, ErrNilStorageMarker, err)
+}

--- a/state/syncer/validatorAccountsSyncer_test.go
+++ b/state/syncer/validatorAccountsSyncer_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TODO add more tests
+
 func TestValidatorAccountsSyncer_SyncAccounts(t *testing.T) {
 	t.Parallel()
 

--- a/testscommon/components/default.go
+++ b/testscommon/components/default.go
@@ -18,6 +18,7 @@ import (
 	"github.com/multiversx/mx-chain-go/testscommon/shardingMocks"
 	stateMock "github.com/multiversx/mx-chain-go/testscommon/state"
 	"github.com/multiversx/mx-chain-go/testscommon/storage"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	trieMock "github.com/multiversx/mx-chain-go/testscommon/trie"
 )
 
@@ -91,9 +92,9 @@ func GetDefaultStateComponents() *testscommon.StateComponentsMock {
 		Accounts: &stateMock.AccountsStub{},
 		Tries:    &trieMock.TriesHolderStub{},
 		StorageManagers: map[string]common.StorageManager{
-			"0":                                     &testscommon.StorageManagerStub{},
-			dataRetriever.UserAccountsUnit.String(): &testscommon.StorageManagerStub{},
-			dataRetriever.PeerAccountsUnit.String(): &testscommon.StorageManagerStub{},
+			"0":                                     &storageManager.StorageManagerStub{},
+			dataRetriever.UserAccountsUnit.String(): &storageManager.StorageManagerStub{},
+			dataRetriever.PeerAccountsUnit.String(): &storageManager.StorageManagerStub{},
 		},
 	}
 }

--- a/testscommon/storageManager/storageManagerStub.go
+++ b/testscommon/storageManager/storageManagerStub.go
@@ -1,4 +1,4 @@
-package testscommon
+package storageManager
 
 import (
 	"github.com/multiversx/mx-chain-go/common"

--- a/trie/export_test.go
+++ b/trie/export_test.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/multiversx/mx-chain-go/common"
-	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 )
 
 func (ts *trieSyncer) trieNodeIntercepted(hash []byte, val interface{}) {
@@ -79,7 +79,7 @@ func WriteInChanNonBlocking(errChan chan error, err error) {
 }
 
 type StorageManagerExtensionStub struct {
-	*testscommon.StorageManagerStub
+	*storageManager.StorageManagerStub
 }
 
 // IsBaseTrieStorageManager -

--- a/trie/interface.go
+++ b/trie/interface.go
@@ -123,11 +123,6 @@ type storageManagerExtension interface {
 	RemoveFromCheckpointHashesHolder(hash []byte)
 }
 
-// StorageMarker is used to mark the given storer as synced and active
-type StorageMarker interface {
-	MarkStorerAsSyncedAndActive(storer common.StorageManager)
-}
-
 type dbWriteCacherWithIdentifier interface {
 	GetIdentifier() string
 }

--- a/trie/storageMarker/disabledStorageMarker.go
+++ b/trie/storageMarker/disabledStorageMarker.go
@@ -13,3 +13,8 @@ func NewDisabledStorageMarker() *disabledStorageMarker {
 // MarkStorerAsSyncedAndActive does nothing for this implementation
 func (dsm *disabledStorageMarker) MarkStorerAsSyncedAndActive(_ common.StorageManager) {
 }
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (dsm *disabledStorageMarker) IsInterfaceNil() bool {
+	return dsm == nil
+}

--- a/trie/storageMarker/trieStorageMarker.go
+++ b/trie/storageMarker/trieStorageMarker.go
@@ -39,3 +39,8 @@ func (sm *trieStorageMarker) MarkStorerAsSyncedAndActive(storer common.StorageMa
 	}
 	log.Debug("set activeDB in epoch", "epoch", lastEpoch)
 }
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (sm *trieStorageMarker) IsInterfaceNil() bool {
+	return sm == nil
+}

--- a/trie/storageMarker/trieStorageMarker_test.go
+++ b/trie/storageMarker/trieStorageMarker_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/common"
-	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,7 +17,7 @@ func TestTrieStorageMarker_MarkStorerAsSyncedAndActive(t *testing.T) {
 
 		trieSyncedKeyPut := false
 		activeDbKeyPut := false
-		storer := &testscommon.StorageManagerStub{
+		storer := &storageManager.StorageManagerStub{
 			GetLatestStorageEpochCalled: func() (uint32, error) {
 				return 5, nil
 			},
@@ -45,7 +45,7 @@ func TestTrieStorageMarker_MarkStorerAsSyncedAndActive(t *testing.T) {
 
 		trieSyncedKeyPut := false
 		activeDbKeyPut := false
-		storer := &testscommon.StorageManagerStub{
+		storer := &storageManager.StorageManagerStub{
 			GetLatestStorageEpochCalled: func() (uint32, error) {
 				return 0, nil
 			},

--- a/trie/trieStorageManagerFactory_test.go
+++ b/trie/trieStorageManagerFactory_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-go/common"
-	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	trieMock "github.com/multiversx/mx-chain-go/testscommon/trie"
 	"github.com/multiversx/mx-chain-go/trie"
 	"github.com/stretchr/testify/assert"
@@ -66,7 +66,7 @@ func TestTrieStorageManager_SerialFuncShadowingCallsExpectedImpl(t *testing.T) {
 	getCalled := false
 	returnedVal := []byte("existingVal")
 	putCalled := 0
-	tsm = &testscommon.StorageManagerStub{
+	tsm = &storageManager.StorageManagerStub{
 		GetCalled: func(_ []byte) ([]byte, error) {
 			getCalled = true
 			return returnedVal, nil

--- a/trie/trieStorageManagerInEpoch_test.go
+++ b/trie/trieStorageManagerInEpoch_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-go/storage/database"
-	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	"github.com/multiversx/mx-chain-go/testscommon/trie"
 	"github.com/stretchr/testify/assert"
 )
@@ -22,7 +22,7 @@ func TestNewTrieStorageManagerInEpochNilStorageManager(t *testing.T) {
 func TestNewTrieStorageManagerInEpochInvalidStorageManagerType(t *testing.T) {
 	t.Parallel()
 
-	trieStorage := &testscommon.StorageManagerStub{}
+	trieStorage := &storageManager.StorageManagerStub{}
 
 	tsmie, err := newTrieStorageManagerInEpoch(trieStorage, 0)
 	assert.True(t, check.IfNil(tsmie))

--- a/trie/trieStorageManagerWithoutPruning_test.go
+++ b/trie/trieStorageManagerWithoutPruning_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/common"
-	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	"github.com/multiversx/mx-chain-go/trie"
 	"github.com/stretchr/testify/assert"
 )
@@ -39,7 +39,7 @@ func TestTrieStorageManagerWithoutPruning_Remove(t *testing.T) {
 
 	removeFromCheckpointHashesHolderCalled := false
 	tsm := &trie.StorageManagerExtensionStub{
-		StorageManagerStub: &testscommon.StorageManagerStub{
+		StorageManagerStub: &storageManager.StorageManagerStub{
 			RemoveFromCheckpointHashesHolderCalled: func(hash []byte) {
 				removeFromCheckpointHashesHolderCalled = true
 			},

--- a/update/container/accountDBSyncers_test.go
+++ b/update/container/accountDBSyncers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/update"
 	"github.com/multiversx/mx-chain-go/update/mock"
 	"github.com/stretchr/testify/require"
@@ -69,7 +70,7 @@ func TestAccountDBSyncers_ReplaceShouldWork(t *testing.T) {
 
 	// update
 	newTestVal := &mock.AccountsDBSyncerStub{
-		SyncAccountsCalled: func(_ []byte) error {
+		SyncAccountsCalled: func(_ []byte, _ common.StorageMarker) error {
 			return errors.New("local error")
 		},
 	}

--- a/update/factory/accountDBSyncerContainerFactory.go
+++ b/update/factory/accountDBSyncerContainerFactory.go
@@ -15,7 +15,6 @@ import (
 	"github.com/multiversx/mx-chain-go/storage"
 	"github.com/multiversx/mx-chain-go/trie"
 	"github.com/multiversx/mx-chain-go/trie/statistics"
-	"github.com/multiversx/mx-chain-go/trie/storageMarker"
 	"github.com/multiversx/mx-chain-go/update"
 	containers "github.com/multiversx/mx-chain-go/update/container"
 	"github.com/multiversx/mx-chain-go/update/genesis"
@@ -150,7 +149,6 @@ func (a *accountDBSyncersContainerFactory) createUserAccountsSyncer(shardId uint
 			MaxHardCapForMissingNodes:         a.maxHardCapForMissingNodes,
 			TrieSyncerVersion:                 a.trieSyncerVersion,
 			CheckNodesOnDisk:                  a.checkNodesOnDisk,
-			StorageMarker:                     storageMarker.NewTrieStorageMarker(),
 			UserAccountsSyncStatisticsHandler: statistics.NewTrieSyncStatistics(),
 			AppStatusHandler:                  disabled.NewAppStatusHandler(),
 		},
@@ -180,7 +178,6 @@ func (a *accountDBSyncersContainerFactory) createValidatorAccountsSyncer(shardId
 			MaxHardCapForMissingNodes:         a.maxHardCapForMissingNodes,
 			TrieSyncerVersion:                 a.trieSyncerVersion,
 			CheckNodesOnDisk:                  a.checkNodesOnDisk,
-			StorageMarker:                     storageMarker.NewTrieStorageMarker(),
 			UserAccountsSyncStatisticsHandler: statistics.NewTrieSyncStatistics(),
 			AppStatusHandler:                  disabled.NewAppStatusHandler(),
 		},

--- a/update/genesis/import_test.go
+++ b/update/genesis/import_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
+	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	"github.com/multiversx/mx-chain-go/update"
 	"github.com/multiversx/mx-chain-go/update/mock"
 	"github.com/stretchr/testify/assert"
@@ -23,7 +24,7 @@ import (
 
 func TestNewStateImport(t *testing.T) {
 	trieStorageManagers := make(map[string]common.StorageManager)
-	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = &testscommon.StorageManagerStub{}
+	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = &storageManager.StorageManagerStub{}
 	tests := []struct {
 		name    string
 		args    ArgsNewStateImport
@@ -86,8 +87,8 @@ func TestImportAll(t *testing.T) {
 	t.Parallel()
 
 	trieStorageManagers := make(map[string]common.StorageManager)
-	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = &testscommon.StorageManagerStub{}
-	trieStorageManagers[dataRetriever.PeerAccountsUnit.String()] = &testscommon.StorageManagerStub{}
+	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = &storageManager.StorageManagerStub{}
+	trieStorageManagers[dataRetriever.PeerAccountsUnit.String()] = &storageManager.StorageManagerStub{}
 
 	args := ArgsNewStateImport{
 		HardforkStorer:      &mock.HardforkStorerStub{},
@@ -110,7 +111,7 @@ func TestStateImport_ImportUnFinishedMetaBlocksShouldWork(t *testing.T) {
 	t.Parallel()
 
 	trieStorageManagers := make(map[string]common.StorageManager)
-	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = &testscommon.StorageManagerStub{}
+	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = &storageManager.StorageManagerStub{}
 
 	hasher := &hashingMocks.HasherMock{}
 	marshahlizer := &mock.MarshalizerMock{}

--- a/update/interface.go
+++ b/update/interface.go
@@ -175,7 +175,7 @@ type WhiteListHandler interface {
 // AccountsDBSyncer defines the methods for the accounts db syncer
 type AccountsDBSyncer interface {
 	GetSyncedTries() map[string]common.Trie
-	SyncAccounts(rootHash []byte) error
+	SyncAccounts(rootHash []byte, storageMarker common.StorageMarker) error
 	IsInterfaceNil() bool
 }
 

--- a/update/mock/accountsDBSyncerStub.go
+++ b/update/mock/accountsDBSyncerStub.go
@@ -7,7 +7,7 @@ import (
 // AccountsDBSyncerStub -
 type AccountsDBSyncerStub struct {
 	GetSyncedTriesCalled func() map[string]common.Trie
-	SyncAccountsCalled   func(rootHash []byte) error
+	SyncAccountsCalled   func(rootHash []byte, storageMarker common.StorageMarker) error
 }
 
 // GetSyncedTries -
@@ -19,9 +19,9 @@ func (a *AccountsDBSyncerStub) GetSyncedTries() map[string]common.Trie {
 }
 
 // SyncAccounts -
-func (a *AccountsDBSyncerStub) SyncAccounts(rootHash []byte) error {
+func (a *AccountsDBSyncerStub) SyncAccounts(rootHash []byte, storageMarker common.StorageMarker) error {
 	if a.SyncAccountsCalled != nil {
-		return a.SyncAccountsCalled(rootHash)
+		return a.SyncAccountsCalled(rootHash, storageMarker)
 	}
 	return nil
 }

--- a/update/sync/coordinator_test.go
+++ b/update/sync/coordinator_test.go
@@ -109,7 +109,7 @@ func createSyncTrieState(retErr bool) update.EpochStartTriesSyncHandler {
 		AccountsDBsSyncers: &mock.AccountsDBSyncersStub{
 			GetCalled: func(key string) (syncer update.AccountsDBSyncer, err error) {
 				return &mock.AccountsDBSyncerStub{
-					SyncAccountsCalled: func(rootHash []byte) error {
+					SyncAccountsCalled: func(rootHash []byte, _ common.StorageMarker) error {
 						if retErr {
 							return errors.New("err")
 						}

--- a/update/sync/syncAccountsDBs.go
+++ b/update/sync/syncAccountsDBs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/state"
+	"github.com/multiversx/mx-chain-go/trie/storageMarker"
 	"github.com/multiversx/mx-chain-go/update"
 	"github.com/multiversx/mx-chain-go/update/genesis"
 )
@@ -149,7 +150,7 @@ func (st *syncAccountsDBs) syncAccountsOfType(accountType genesis.Type, trieID s
 		return err
 	}
 
-	err = accountsDBSyncer.SyncAccounts(rootHash)
+	err = accountsDBSyncer.SyncAccounts(rootHash, storageMarker.NewDisabledStorageMarker())
 	if err != nil {
 		// TODO: critical error - should not happen - maybe recreate trie syncer here
 		return err


### PR DESCRIPTION
## Reasoning behind the pull request
- When a missing trie node is found, the subtrie starting from that hash will be synced. This is triggered on `SyncBlock()`. However, the storage should not be marked as synced and active - not the whole trie was synced, but just a missing subtrie.
  
## Proposed changes
- Pass `storageMarker` to `SyncAccounts()` func. This way, a disabled storage marker can be given in case the db should not be marked as synced.

## Testing procedure
- Normal testing procedure with missing trie nodes.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
