### PR TITLE
fix for delete edgecase and remove some code

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -82,7 +82,6 @@ func EmptyErrChanReturningHadContained(errChan chan error) bool {
 // DirtyData -
 type DirtyData struct {
 	Value      []byte
-	OldVersion core.TrieNodeVersion
 	NewVersion core.TrieNodeVersion
 }
 
@@ -93,7 +92,6 @@ func (tdaw *trackableDataTrie) DirtyData() map[string]DirtyData {
 	for key, value := range tdaw.dirtyData {
 		dd[key] = DirtyData{
 			Value:      value.value,
-			OldVersion: value.oldVersion.version,
 			NewVersion: value.newVersion,
 		}
 	}

--- a/state/trackableDataTrie.go
+++ b/state/trackableDataTrie.go
@@ -152,10 +152,29 @@ func (tdaw *trackableDataTrie) MigrateDataTrieLeaves(args vmcommon.ArgsMigrateDa
 			newVersion: args.NewVersion,
 		}
 
-		tdaw.dirtyData[string(leafData.Key)] = dataEntry
+		originalKey, err := tdaw.getOriginalKeyFromTrieData(leafData)
+		if err != nil {
+			return err
+		}
+
+		tdaw.dirtyData[string(originalKey)] = dataEntry
 	}
 
 	return nil
+}
+
+func (tdaw *trackableDataTrie) getOriginalKeyFromTrieData(trieData core.TrieData) ([]byte, error) {
+	if trieData.Version == core.AutoBalanceEnabled {
+		valWithMetadata := &dataTrieValue.TrieLeafData{}
+		err := tdaw.marshaller.Unmarshal(valWithMetadata, trieData.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		return valWithMetadata.Key, nil
+	}
+
+	return trieData.Key, nil
 }
 
 func (tdaw *trackableDataTrie) getKeyForVersion(key []byte, version core.TrieNodeVersion) []byte {

--- a/state/trackableDataTrie_test.go
+++ b/state/trackableDataTrie_test.go
@@ -810,17 +810,17 @@ func TestTrackableDataTrie_MigrateDataTrieLeaves(t *testing.T) {
 			{
 				Key:     []byte("key1"),
 				Value:   []byte("value1"),
-				Version: core.AutoBalanceEnabled,
+				Version: core.NotSpecified,
 			},
 			{
 				Key:     []byte("key2"),
 				Value:   []byte("value2"),
-				Version: core.AutoBalanceEnabled,
+				Version: core.NotSpecified,
 			},
 			{
 				Key:     []byte("key3"),
 				Value:   []byte("value3"),
-				Version: core.AutoBalanceEnabled,
+				Version: core.NotSpecified,
 			},
 		}
 		tr := &trieMock.TrieStub{

--- a/state/trackableDataTrie_test.go
+++ b/state/trackableDataTrie_test.go
@@ -252,6 +252,72 @@ func TestTrackableDataTrie_RetrieveValue(t *testing.T) {
 		assert.Equal(t, errExpected, err)
 		assert.Nil(t, valRecovered)
 	})
+
+	t.Run("val not found in trie - auto balance enabled", func(t *testing.T) {
+		t.Parallel()
+
+		identifier := []byte("identifier")
+		expectedKey := []byte("key")
+		hasher := &hashingMocks.HasherMock{}
+		marshaller := &marshallerMock.MarshalizerMock{}
+
+		trie := &trieMock.TrieStub{
+			UpdateCalled: func(key, value []byte) error {
+				return nil
+			},
+			GetCalled: func(key []byte) ([]byte, uint32, error) {
+				return nil, 0, nil
+			},
+		}
+		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsAutoBalanceDataTriesEnabledField: true,
+		}
+		tdt, _ := state.NewTrackableDataTrie(
+			identifier,
+			trie,
+			hasher,
+			marshaller,
+			enableEpochsHandler,
+		)
+		assert.NotNil(t, tdt)
+
+		valRecovered, _, err := tdt.RetrieveValue(expectedKey)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte(nil), valRecovered)
+	})
+
+	t.Run("val not found in trie - auto balance disabled", func(t *testing.T) {
+		t.Parallel()
+
+		identifier := []byte("identifier")
+		expectedKey := []byte("key")
+		hasher := &hashingMocks.HasherMock{}
+		marshaller := &marshallerMock.MarshalizerMock{}
+
+		trie := &trieMock.TrieStub{
+			UpdateCalled: func(key, value []byte) error {
+				return nil
+			},
+			GetCalled: func(key []byte) ([]byte, uint32, error) {
+				return nil, 0, nil
+			},
+		}
+		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsAutoBalanceDataTriesEnabledField: false,
+		}
+		tdt, _ := state.NewTrackableDataTrie(
+			identifier,
+			trie,
+			hasher,
+			marshaller,
+			enableEpochsHandler,
+		)
+		assert.NotNil(t, tdt)
+
+		valRecovered, _, err := tdt.RetrieveValue(expectedKey)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte(nil), valRecovered)
+	})
 }
 
 func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
@@ -611,7 +677,7 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		t.Parallel()
 
 		expectedKey := []byte("key")
-		deleteCalled := false
+		deleteCalled := 0
 		trie := &trieMock.TrieStub{
 			GetCalled: func(key []byte) ([]byte, uint32, error) {
 				if bytes.Equal(expectedKey, key) {
@@ -622,7 +688,7 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 			},
 			DeleteCalled: func(key []byte) error {
 				assert.Equal(t, expectedKey, key)
-				deleteCalled = true
+				deleteCalled++
 				return nil
 			},
 		}
@@ -636,7 +702,55 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		_, err := tdt.SaveDirtyData(trie)
 		assert.Nil(t, err)
 		assert.Equal(t, 0, len(tdt.DirtyData()))
-		assert.True(t, deleteCalled)
+		assert.Equal(t, 1, deleteCalled)
+	})
+
+	t.Run("not present in trie - autobalance disabled", func(t *testing.T) {
+		t.Parallel()
+
+		identifier := []byte("identifier")
+		expectedKey := []byte("key")
+		newVal := []byte("value")
+		valueWithMetadata := append(newVal, expectedKey...)
+		valueWithMetadata = append(valueWithMetadata, identifier...)
+		hasher := &hashingMocks.HasherMock{}
+		marshaller := &marshallerMock.MarshalizerMock{}
+		updateCalled := false
+
+		trie := &trieMock.TrieStub{
+			GetCalled: func(key []byte) ([]byte, uint32, error) {
+				return nil, 0, nil
+			},
+			UpdateWithVersionCalled: func(key, value []byte, version core.TrieNodeVersion) error {
+				assert.Equal(t, expectedKey, key)
+				assert.Equal(t, valueWithMetadata, value)
+				updateCalled = true
+				return nil
+			},
+			DeleteCalled: func(key []byte) error {
+				assert.Fail(t, "this delete should not have been called")
+				return nil
+			},
+		}
+
+		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsAutoBalanceDataTriesEnabledField: false,
+		}
+		tdt, _ := state.NewTrackableDataTrie(
+			identifier,
+			trie,
+			hasher,
+			marshaller,
+			enableEpochsHandler,
+		)
+
+		_ = tdt.SaveKeyValue(expectedKey, newVal)
+		oldValues, err := tdt.SaveDirtyData(trie)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(oldValues))
+		assert.Equal(t, expectedKey, oldValues[0].Key)
+		assert.Equal(t, []byte(nil), oldValues[0].Value)
+		assert.True(t, updateCalled)
 	})
 }
 
@@ -737,7 +851,6 @@ func TestTrackableDataTrie_MigrateDataTrieLeaves(t *testing.T) {
 		for i := range leavesToBeMigrated {
 			d := dirtyData[string(leavesToBeMigrated[i].Key)]
 			assert.Equal(t, leavesToBeMigrated[i].Value, d.Value)
-			assert.Equal(t, leavesToBeMigrated[i].Version, d.OldVersion)
 			assert.Equal(t, core.TrieNodeVersion(100), d.NewVersion)
 		}
 	})


### PR DESCRIPTION
## Reasoning behind the pull request
- Fix a case in which `Delete()` is called twice in a row for the same key
- Remove unnecessary code 
- Fix `MigrateDataTrieLeaves()` func. If the version that needs to be migrated is `AutoBalanceEnabled`, get the proper key.



## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
