### PR TITLE
Fix seldom failing tests in hb v2

### DIFF
--- a/heartbeat/processor/export_test.go
+++ b/heartbeat/processor/export_test.go
@@ -1,0 +1,6 @@
+package processor
+
+// NewPeerAuthenticationRequestsProcessorWithoutGoRoutine -
+func NewPeerAuthenticationRequestsProcessorWithoutGoRoutine(args ArgPeerAuthenticationRequestsProcessor) (*peerAuthenticationRequestsProcessor, error) {
+	return newPeerAuthenticationRequestsProcessor(args)
+}


### PR DESCRIPTION
## Reasoning behind the pull request
- some unit tests for the peerAuthenticationRequestsProcessor component were seldom failing
  
## Proposed changes
- added new unit tests
- reworked tests that tested logic to work on a component that did not launched go routines
- minor production code refactoring

## Testing procedure
- standard system test
- when analyzing the logs, we should find prints like: 
```
received enough messages, closing peerAuthenticationRequestsProcessor go routine
```
or 
```
closing peerAuthenticationRequestsProcessor...
closing peerAuthenticationRequestsProcessor go routine
```

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
