### PR TITLE
termui: display if the node is full archive

### DIFF
--- a/cmd/termui/view/termuic/termuiRenders/widgetsRender.go
+++ b/cmd/termui/view/termuic/termuiRenders/widgetsRender.go
@@ -124,11 +124,15 @@ func (wr *WidgetsRender) prepareInstanceInfo() {
 	shardId := wr.presenter.GetShardId()
 	instanceType := wr.presenter.GetNodeType()
 	peerType := wr.presenter.GetPeerType()
+	peerSubType := wr.presenter.GetPeerSubType()
 	chainID := wr.presenter.GetChainID()
 
 	nodeTypeAndListDisplay := instanceType
 	if peerType != string(common.ObserverList) && !strings.Contains(peerType, invalidKey) {
 		nodeTypeAndListDisplay += fmt.Sprintf(" - %s", peerType)
+	}
+	if peerSubType == core.FullHistoryObserver.String() {
+		nodeTypeAndListDisplay += " - full archive"
 	}
 	shardIdStr := fmt.Sprintf("%d", shardId)
 	if shardId == uint64(core.MetachainShardId) {

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -242,6 +242,9 @@ func (pcf *processComponentsFactory) Create() (*processComponents, error) {
 		return nil, err
 	}
 
+	if pcf.prefConfigs.FullArchive {
+		pcf.statusCoreComponents.AppStatusHandler().SetStringValue(common.MetricPeerSubType, core.FullHistoryObserver.String())
+	}
 	pcf.epochNotifier.RegisterNotifyHandler(currentEpochProvider)
 
 	fallbackHeaderValidator, err := fallback.NewFallbackHeaderValidator(

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -242,10 +242,6 @@ func (pcf *processComponentsFactory) Create() (*processComponents, error) {
 		return nil, err
 	}
 
-	if pcf.prefConfigs.FullArchive {
-		pcf.statusCoreComponents.AppStatusHandler().SetStringValue(common.MetricPeerType, core.ObserverPeer.String())
-		pcf.statusCoreComponents.AppStatusHandler().SetStringValue(common.MetricPeerSubType, core.FullHistoryObserver.String())
-	}
 	pcf.epochNotifier.RegisterNotifyHandler(currentEpochProvider)
 
 	fallbackHeaderValidator, err := fallback.NewFallbackHeaderValidator(

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -243,6 +243,7 @@ func (pcf *processComponentsFactory) Create() (*processComponents, error) {
 	}
 
 	if pcf.prefConfigs.FullArchive {
+		pcf.statusCoreComponents.AppStatusHandler().SetStringValue(common.MetricPeerType, core.ObserverPeer.String())
 		pcf.statusCoreComponents.AppStatusHandler().SetStringValue(common.MetricPeerSubType, core.FullHistoryObserver.String())
 	}
 	pcf.epochNotifier.RegisterNotifyHandler(currentEpochProvider)

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -816,6 +816,11 @@ func (nr *nodeRunner) createMetrics(
 	metrics.SaveStringMetric(statusCoreComponents.AppStatusHandler(), common.MetricTopUpFactor, fmt.Sprintf("%g", coreComponents.EconomicsData().RewardsTopUpFactor()))
 	metrics.SaveStringMetric(statusCoreComponents.AppStatusHandler(), common.MetricGasPriceModifier, fmt.Sprintf("%g", coreComponents.EconomicsData().GasPriceModifier()))
 	metrics.SaveUint64Metric(statusCoreComponents.AppStatusHandler(), common.MetricMaxGasPerTransaction, coreComponents.EconomicsData().MaxGasLimitPerTx())
+	if nr.configs.PreferencesConfig.Preferences.FullArchive {
+		metrics.SaveStringMetric(statusCoreComponents.AppStatusHandler(), common.MetricPeerType, core.ObserverPeer.String())
+		metrics.SaveStringMetric(statusCoreComponents.AppStatusHandler(), common.MetricPeerSubType, core.FullHistoryObserver.String())
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request
- previously, one couldn't figure out if a node if full archive or not by looking at the termui window
  
## Proposed changes
- display a message if the node is in full archive mode
![image](https://user-images.githubusercontent.com/51945539/236176169-dde5d69a-9836-43b9-a391-a814831d5953.png)


## Testing procedure
- by using this branch, connect via termui to a node that is a full archive and to one that is not. Termui should display accordingly

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
