### PR TITLE
Add identifer in tsm

### DIFF
--- a/epochStart/metachain/baseRewards_test.go
+++ b/epochStart/metachain/baseRewards_test.go
@@ -1136,11 +1136,11 @@ func getBaseRewardsArguments() BaseRewardsCreatorArgs {
 	hasher := sha256.NewSha256()
 	marshalizer := &marshal.GogoProtoMarshalizer{}
 
-	storageManagerArgs, options := storage.GetStorageManagerArgsAndOptions()
+	storageManagerArgs := storage.GetStorageManagerArgs()
 	storageManagerArgs.Marshalizer = marshalizer
 	storageManagerArgs.Hasher = hasher
 
-	trieFactoryManager, _ := trie.CreateTrieStorageManager(storageManagerArgs, options)
+	trieFactoryManager, _ := trie.CreateTrieStorageManager(storageManagerArgs, storage.GetStorageManagerOptions())
 	userAccountsDB := createAccountsDB(hasher, marshalizer, factory.NewAccountCreator(), trieFactoryManager)
 	shardCoordinator := mock.NewMultiShardsCoordinatorMock(2)
 	shardCoordinator.CurrentShard = core.MetachainShardId

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -910,13 +910,13 @@ func createAccountsDB(
 func createFullArgumentsForSystemSCProcessing(enableEpochsConfig config.EnableEpochs, trieStorer storage.Storer) (ArgsNewEpochStartSystemSCProcessing, vm.SystemSCContainer) {
 	hasher := sha256.NewSha256()
 	marshalizer := &marshal.GogoProtoMarshalizer{}
-	storageManagerArgs, options := stateMock.GetStorageManagerArgsAndOptions()
+	storageManagerArgs := stateMock.GetStorageManagerArgs()
 	storageManagerArgs.Marshalizer = marshalizer
 	storageManagerArgs.Hasher = hasher
 	storageManagerArgs.MainStorer = trieStorer
 	storageManagerArgs.CheckpointsStorer = trieStorer
 
-	trieFactoryManager, _ := trie.CreateTrieStorageManager(storageManagerArgs, options)
+	trieFactoryManager, _ := trie.CreateTrieStorageManager(storageManagerArgs, stateMock.GetStorageManagerOptions())
 	userAccountsDB := createAccountsDB(hasher, marshalizer, factory.NewAccountCreator(), trieFactoryManager)
 	peerAccountsDB := createAccountsDB(hasher, marshalizer, factory.NewPeerAccountCreator(), trieFactoryManager)
 	en := forking.NewGenericEpochNotifier()

--- a/factory/processing/blockProcessorCreator_test.go
+++ b/factory/processing/blockProcessorCreator_test.go
@@ -83,14 +83,14 @@ func Test_newBlockProcessorCreatorForMeta(t *testing.T) {
 	cryptoComponents := componentsMock.GetCryptoComponents(coreComponents)
 	networkComponents := componentsMock.GetNetworkComponents(cryptoComponents)
 
-	storageManagerArgs, options := storageManager.GetStorageManagerArgsAndOptions()
+	storageManagerArgs := storageManager.GetStorageManagerArgs()
 	storageManagerArgs.Marshalizer = coreComponents.InternalMarshalizer()
 	storageManagerArgs.Hasher = coreComponents.Hasher()
-	storageManagerUser, _ := trie.CreateTrieStorageManager(storageManagerArgs, options)
+	storageManagerUser, _ := trie.CreateTrieStorageManager(storageManagerArgs, storageManager.GetStorageManagerOptions())
 
 	storageManagerArgs.MainStorer = mock.NewMemDbMock()
 	storageManagerArgs.CheckpointsStorer = mock.NewMemDbMock()
-	storageManagerPeer, _ := trie.CreateTrieStorageManager(storageManagerArgs, options)
+	storageManagerPeer, _ := trie.CreateTrieStorageManager(storageManagerArgs, storageManager.GetStorageManagerOptions())
 
 	trieStorageManagers := make(map[string]common.StorageManager)
 	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = storageManagerUser

--- a/genesis/process/genesisBlockCreator_test.go
+++ b/genesis/process/genesisBlockCreator_test.go
@@ -52,8 +52,8 @@ func createMockArgument(
 	entireSupply *big.Int,
 ) ArgsGenesisBlockCreator {
 
-	storageManagerArgs, options := storageCommon.GetStorageManagerArgsAndOptions()
-	storageManager, _ := trie.CreateTrieStorageManager(storageManagerArgs, options)
+	storageManagerArgs := storageCommon.GetStorageManagerArgs()
+	storageManager, _ := trie.CreateTrieStorageManager(storageManagerArgs, storageCommon.GetStorageManagerOptions())
 
 	trieStorageManagers := make(map[string]common.StorageManager)
 	trieStorageManagers[dataRetriever.UserAccountsUnit.String()] = storageManager

--- a/integrationTests/benchmarks/loadFromTrie_test.go
+++ b/integrationTests/benchmarks/loadFromTrie_test.go
@@ -12,11 +12,10 @@ import (
 	"github.com/multiversx/mx-chain-core-go/hashing/blake2b"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
-	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/storage"
 	"github.com/multiversx/mx-chain-go/storage/database"
 	"github.com/multiversx/mx-chain-go/storage/storageunit"
-	"github.com/multiversx/mx-chain-go/testscommon"
+	testStorage "github.com/multiversx/mx-chain-go/testscommon/storage"
 	"github.com/multiversx/mx-chain-go/trie"
 	"github.com/multiversx/mx-chain-go/trie/hashesHolder/disabled"
 	"github.com/stretchr/testify/require"
@@ -163,20 +162,12 @@ func generateRandHexString(size int) string {
 }
 
 func getTrieStorageManager(store storage.Storer, marshaller marshal.Marshalizer, hasher hashing.Hasher) common.StorageManager {
-	generalCfg := config.TrieStorageManagerConfig{
-		PruningBufferLen:      1000,
-		SnapshotsBufferLen:    10,
-		SnapshotsGoroutineNum: 1,
-	}
-	args := trie.NewTrieStorageManagerArgs{
-		MainStorer:             store,
-		CheckpointsStorer:      database.NewMemDB(),
-		Marshalizer:            marshaller,
-		Hasher:                 hasher,
-		GeneralConfig:          generalCfg,
-		CheckpointHashesHolder: disabled.NewDisabledCheckpointHashesHolder(),
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
+	args := testStorage.GetStorageManagerArgs()
+	args.MainStorer = store
+	args.Marshalizer = marshaller
+	args.Hasher = hasher
+	args.CheckpointHashesHolder = disabled.NewDisabledCheckpointHashesHolder()
+
 	trieStorageManager, _ := trie.NewTrieStorageManager(args)
 
 	return trieStorageManager

--- a/integrationTests/longTests/storage/storage_test.go
+++ b/integrationTests/longTests/storage/storage_test.go
@@ -105,10 +105,12 @@ func TestWriteContinuouslyInTree(t *testing.T) {
 	nbTxsWrite := 1000000
 	testStorage := integrationTests.NewTestStorage()
 	store := testStorage.CreateStorageLevelDB()
-	storageManagerArgs, options := storage.GetStorageManagerArgsAndOptions()
+	storageManagerArgs := storage.GetStorageManagerArgs()
 	storageManagerArgs.MainStorer = store
 	storageManagerArgs.Marshalizer = &marshal.JsonMarshalizer{}
 	storageManagerArgs.Hasher = blake2b.NewBlake2b()
+
+	options := storage.GetStorageManagerOptions()
 	options.CheckpointsEnabled = false
 	options.PruningEnabled = false
 

--- a/integrationTests/state/stateTrie/stateTrie_test.go
+++ b/integrationTests/state/stateTrie/stateTrie_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/multiversx/mx-chain-go/storage/storageunit"
 	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/statusHandler"
-	trieMock "github.com/multiversx/mx-chain-go/testscommon/trie"
+	testStorage "github.com/multiversx/mx-chain-go/testscommon/storage"
 	"github.com/multiversx/mx-chain-go/trie"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/stretchr/testify/assert"
@@ -45,18 +45,6 @@ import (
 )
 
 const denomination = "000000000000000000"
-
-func getNewTrieStorageManagerArgs() trie.NewTrieStorageManagerArgs {
-	return trie.NewTrieStorageManagerArgs{
-		MainStorer:             integrationTests.CreateMemUnit(),
-		CheckpointsStorer:      integrationTests.CreateMemUnit(),
-		Marshalizer:            integrationTests.TestMarshalizer,
-		Hasher:                 integrationTests.TestHasher,
-		GeneralConfig:          config.TrieStorageManagerConfig{SnapshotsGoroutineNum: 1},
-		CheckpointHashesHolder: &trieMock.CheckpointHashesHolderStub{},
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
-}
 
 func TestAccountsDB_RetrieveDataWithSomeValuesShouldWork(t *testing.T) {
 	// test simulates creation of a new account, data trie retrieval,
@@ -269,7 +257,7 @@ func TestAccountsDB_CommitTwoOkAccountsShouldWork(t *testing.T) {
 func TestTrieDB_RecreateFromStorageShouldWork(t *testing.T) {
 	hasher := integrationTests.TestHasher
 	store := integrationTests.CreateMemUnit()
-	args := getNewTrieStorageManagerArgs()
+	args := testStorage.GetStorageManagerArgs()
 	args.MainStorer = store
 	args.Hasher = hasher
 	trieStorage, _ := trie.NewTrieStorageManager(args)
@@ -1054,7 +1042,7 @@ func createAccounts(
 		HashesSize:     evictionWaitListSize * 100,
 	}
 	ewl, _ := evictionWaitingList.NewMemoryEvictionWaitingList(ewlArgs)
-	args := getNewTrieStorageManagerArgs()
+	args := testStorage.GetStorageManagerArgs()
 	args.MainStorer = store
 	trieStorage, _ := trie.NewTrieStorageManager(args)
 	maxTrieLevelInMemory := uint(5)
@@ -2486,7 +2474,7 @@ func createAccountsDBTestSetup() *state.AccountsDB {
 		HashesSize:     evictionWaitListSize * 100,
 	}
 	ewl, _ := evictionWaitingList.NewMemoryEvictionWaitingList(ewlArgs)
-	args := getNewTrieStorageManagerArgs()
+	args := testStorage.GetStorageManagerArgs()
 	args.GeneralConfig = generalCfg
 	trieStorage, _ := trie.NewTrieStorageManager(args)
 	maxTrieLevelInMemory := uint(5)

--- a/integrationTests/state/stateTrieClose/stateTrieClose_test.go
+++ b/integrationTests/state/stateTrieClose/stateTrieClose_test.go
@@ -10,13 +10,10 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/errChan"
-	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/integrationTests"
-	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/goroutines"
-	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
+	"github.com/multiversx/mx-chain-go/testscommon/storage"
 	"github.com/multiversx/mx-chain-go/trie"
-	"github.com/multiversx/mx-chain-go/trie/hashesHolder"
 	"github.com/multiversx/mx-chain-go/trie/keyBuilder"
 	"github.com/stretchr/testify/assert"
 )
@@ -116,15 +113,7 @@ func TestPatriciaMerkleTrie_Close(t *testing.T) {
 }
 
 func TestTrieStorageManager_Close(t *testing.T) {
-	args := trie.NewTrieStorageManagerArgs{
-		MainStorer:             testscommon.CreateMemUnit(),
-		CheckpointsStorer:      testscommon.CreateMemUnit(),
-		Marshalizer:            &testscommon.MarshalizerMock{},
-		Hasher:                 &hashingMocks.HasherMock{},
-		GeneralConfig:          config.TrieStorageManagerConfig{SnapshotsGoroutineNum: 1},
-		CheckpointHashesHolder: hashesHolder.NewCheckpointHashesHolder(10, 32),
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
+	args := storage.GetStorageManagerArgs()
 
 	gc := goroutines.NewGoCounter(goroutines.TestsRelevantGoRoutines)
 	idxInitial, _ := gc.Snapshot()

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -62,6 +62,7 @@ import (
 	testStorage "github.com/multiversx/mx-chain-go/testscommon/state"
 	"github.com/multiversx/mx-chain-go/testscommon/statusHandler"
 	statusHandlerMock "github.com/multiversx/mx-chain-go/testscommon/statusHandler"
+	testcommonStorage "github.com/multiversx/mx-chain-go/testscommon/storage"
 	"github.com/multiversx/mx-chain-go/testscommon/txDataBuilder"
 	"github.com/multiversx/mx-chain-go/trie"
 	"github.com/multiversx/mx-chain-go/trie/hashesHolder"
@@ -396,12 +397,6 @@ func CreateStore(numOfShards uint32) dataRetriever.StorageService {
 
 // CreateTrieStorageManagerWithPruningStorer creates the trie storage manager for the tests
 func CreateTrieStorageManagerWithPruningStorer(coordinator sharding.Coordinator, notifier pruning.EpochStartNotifier) common.StorageManager {
-	generalCfg := config.TrieStorageManagerConfig{
-		PruningBufferLen:      1000,
-		SnapshotsBufferLen:    10,
-		SnapshotsGoroutineNum: 1,
-	}
-
 	mainStorer, _, err := testStorage.CreateTestingTriePruningStorer(coordinator, notifier)
 	if err != nil {
 		fmt.Println("err creating main storer" + err.Error())
@@ -410,15 +405,14 @@ func CreateTrieStorageManagerWithPruningStorer(coordinator sharding.Coordinator,
 	if err != nil {
 		fmt.Println("err creating checkpoints storer" + err.Error())
 	}
-	args := trie.NewTrieStorageManagerArgs{
-		MainStorer:             mainStorer,
-		CheckpointsStorer:      checkpointsStorer,
-		Marshalizer:            TestMarshalizer,
-		Hasher:                 TestHasher,
-		GeneralConfig:          generalCfg,
-		CheckpointHashesHolder: hashesHolder.NewCheckpointHashesHolder(10000000, uint64(TestHasher.Size())),
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
+
+	args := testcommonStorage.GetStorageManagerArgs()
+	args.MainStorer = mainStorer
+	args.CheckpointsStorer = checkpointsStorer
+	args.Marshalizer = TestMarshalizer
+	args.Hasher = TestHasher
+	args.CheckpointHashesHolder = hashesHolder.NewCheckpointHashesHolder(10000000, uint64(TestHasher.Size()))
+
 	trieStorageManager, _ := trie.NewTrieStorageManager(args)
 
 	return trieStorageManager
@@ -426,20 +420,12 @@ func CreateTrieStorageManagerWithPruningStorer(coordinator sharding.Coordinator,
 
 // CreateTrieStorageManager creates the trie storage manager for the tests
 func CreateTrieStorageManager(store storage.Storer) (common.StorageManager, storage.Storer) {
-	generalCfg := config.TrieStorageManagerConfig{
-		PruningBufferLen:      1000,
-		SnapshotsBufferLen:    10,
-		SnapshotsGoroutineNum: 1,
-	}
-	args := trie.NewTrieStorageManagerArgs{
-		MainStorer:             store,
-		CheckpointsStorer:      CreateMemUnit(),
-		Marshalizer:            TestMarshalizer,
-		Hasher:                 TestHasher,
-		GeneralConfig:          generalCfg,
-		CheckpointHashesHolder: hashesHolder.NewCheckpointHashesHolder(10000000, uint64(TestHasher.Size())),
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
+	args := testcommonStorage.GetStorageManagerArgs()
+	args.MainStorer = store
+	args.Marshalizer = TestMarshalizer
+	args.Hasher = TestHasher
+	args.CheckpointHashesHolder = hashesHolder.NewCheckpointHashesHolder(10000000, uint64(TestHasher.Size()))
+
 	trieStorageManager, _ := trie.NewTrieStorageManager(args)
 
 	return trieStorageManager, store
@@ -1024,20 +1010,11 @@ func CreateSimpleTxProcessor(accnts state.AccountsAdapter) process.TransactionPr
 
 // CreateNewDefaultTrie returns a new trie with test hasher and marsahalizer
 func CreateNewDefaultTrie() common.Trie {
-	generalCfg := config.TrieStorageManagerConfig{
-		PruningBufferLen:      1000,
-		SnapshotsBufferLen:    10,
-		SnapshotsGoroutineNum: 1,
-	}
-	args := trie.NewTrieStorageManagerArgs{
-		MainStorer:             CreateMemUnit(),
-		CheckpointsStorer:      CreateMemUnit(),
-		Marshalizer:            TestMarshalizer,
-		Hasher:                 TestHasher,
-		GeneralConfig:          generalCfg,
-		CheckpointHashesHolder: hashesHolder.NewCheckpointHashesHolder(10000000, uint64(TestHasher.Size())),
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
+	args := testcommonStorage.GetStorageManagerArgs()
+	args.Marshalizer = TestMarshalizer
+	args.Hasher = TestHasher
+	args.CheckpointHashesHolder = hashesHolder.NewCheckpointHashesHolder(10000000, uint64(TestHasher.Size()))
+
 	trieStorage, _ := trie.NewTrieStorageManager(args)
 
 	tr, _ := trie.NewTrie(trieStorage, TestMarshalizer, TestHasher, maxTrieLevelInMemory)

--- a/state/accountsDB_test.go
+++ b/state/accountsDB_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
 	stateMock "github.com/multiversx/mx-chain-go/testscommon/state"
 	"github.com/multiversx/mx-chain-go/testscommon/statusHandler"
+	"github.com/multiversx/mx-chain-go/testscommon/storage"
 	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	trieMock "github.com/multiversx/mx-chain-go/testscommon/trie"
 	"github.com/multiversx/mx-chain-go/trie"
@@ -109,15 +110,9 @@ func getDefaultStateComponents(
 	marshaller := &testscommon.MarshalizerMock{}
 	hasher := &hashingMocks.HasherMock{}
 
-	args := trie.NewTrieStorageManagerArgs{
-		MainStorer:             db,
-		CheckpointsStorer:      testscommon.NewSnapshotPruningStorerMock(),
-		Marshalizer:            marshaller,
-		Hasher:                 hasher,
-		GeneralConfig:          generalCfg,
-		CheckpointHashesHolder: hashesHolder,
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
+	args := storage.GetStorageManagerArgs()
+	args.MainStorer = db
+	args.CheckpointHashesHolder = hashesHolder
 	trieStorage, _ := trie.NewTrieStorageManager(args)
 	tr, _ := trie.NewTrie(trieStorage, marshaller, hasher, 5)
 	ewlArgs := evictionWaitingList.MemoryEvictionWaitingListArgs{
@@ -1736,15 +1731,7 @@ func TestAccountsDB_MainTrieAutomaticallyMarksCodeUpdatesForEviction(t *testing.
 	marshaller := &testscommon.MarshalizerMock{}
 	hasher := &hashingMocks.HasherMock{}
 	ewl := stateMock.NewEvictionWaitingListMock(100)
-	args := trie.NewTrieStorageManagerArgs{
-		MainStorer:             testscommon.CreateMemUnit(),
-		CheckpointsStorer:      testscommon.CreateMemUnit(),
-		Marshalizer:            marshaller,
-		Hasher:                 hasher,
-		GeneralConfig:          config.TrieStorageManagerConfig{SnapshotsGoroutineNum: 1},
-		CheckpointHashesHolder: &trieMock.CheckpointHashesHolderStub{},
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
+	args := storage.GetStorageManagerArgs()
 	storageManager, _ := trie.NewTrieStorageManager(args)
 	maxTrieLevelInMemory := uint(5)
 	tr, _ := trie.NewTrie(storageManager, marshaller, hasher, maxTrieLevelInMemory)
@@ -1821,15 +1808,7 @@ func TestAccountsDB_RemoveAccountMarksObsoleteHashesForEviction(t *testing.T) {
 	hasher := &hashingMocks.HasherMock{}
 
 	ewl := stateMock.NewEvictionWaitingListMock(100)
-	args := trie.NewTrieStorageManagerArgs{
-		MainStorer:             testscommon.CreateMemUnit(),
-		CheckpointsStorer:      testscommon.CreateMemUnit(),
-		Marshalizer:            marshaller,
-		Hasher:                 hasher,
-		GeneralConfig:          config.TrieStorageManagerConfig{SnapshotsGoroutineNum: 1},
-		CheckpointHashesHolder: &trieMock.CheckpointHashesHolderStub{},
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
+	args := storage.GetStorageManagerArgs()
 	storageManager, _ := trie.NewTrieStorageManager(args)
 	tr, _ := trie.NewTrie(storageManager, marshaller, hasher, maxTrieLevelInMemory)
 	spm, _ := storagePruningManager.NewStoragePruningManager(ewl, 5)
@@ -2249,15 +2228,7 @@ func TestAccountsDB_GetCode(t *testing.T) {
 	marshaller := &testscommon.MarshalizerMock{}
 	hasher := &hashingMocks.HasherMock{}
 
-	args := trie.NewTrieStorageManagerArgs{
-		MainStorer:             testscommon.CreateMemUnit(),
-		CheckpointsStorer:      testscommon.CreateMemUnit(),
-		Marshalizer:            marshaller,
-		Hasher:                 hasher,
-		GeneralConfig:          config.TrieStorageManagerConfig{SnapshotsGoroutineNum: 1},
-		CheckpointHashesHolder: &trieMock.CheckpointHashesHolderStub{},
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
+	args := storage.GetStorageManagerArgs()
 	storageManager, _ := trie.NewTrieStorageManager(args)
 	tr, _ := trie.NewTrie(storageManager, marshaller, hasher, maxTrieLevelInMemory)
 	spm := disabled.NewDisabledStoragePruningManager()
@@ -2639,15 +2610,7 @@ func BenchmarkAccountsDb_GetCodeEntry(b *testing.B) {
 	marshaller := &testscommon.MarshalizerMock{}
 	hasher := &hashingMocks.HasherMock{}
 
-	args := trie.NewTrieStorageManagerArgs{
-		MainStorer:             testscommon.CreateMemUnit(),
-		CheckpointsStorer:      testscommon.CreateMemUnit(),
-		Marshalizer:            marshaller,
-		Hasher:                 hasher,
-		GeneralConfig:          config.TrieStorageManagerConfig{SnapshotsGoroutineNum: 1},
-		CheckpointHashesHolder: &trieMock.CheckpointHashesHolderStub{},
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
+	args := storage.GetStorageManagerArgs()
 	storageManager, _ := trie.NewTrieStorageManager(args)
 	tr, _ := trie.NewTrie(storageManager, marshaller, hasher, maxTrieLevelInMemory)
 	spm := disabled.NewDisabledStoragePruningManager()

--- a/state/storagePruningManager/storagePruningManager_test.go
+++ b/state/storagePruningManager/storagePruningManager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/statusHandler"
+	"github.com/multiversx/mx-chain-go/testscommon/storage"
 	"github.com/multiversx/mx-chain-go/trie"
 	"github.com/multiversx/mx-chain-go/trie/hashesHolder"
 	"github.com/stretchr/testify/assert"
@@ -24,15 +25,8 @@ func getDefaultTrieAndAccountsDbAndStoragePruningManager() (common.Trie, *state.
 	}
 	marshaller := &testscommon.MarshalizerMock{}
 	hasher := &hashingMocks.HasherMock{}
-	args := trie.NewTrieStorageManagerArgs{
-		MainStorer:             testscommon.CreateMemUnit(),
-		CheckpointsStorer:      testscommon.CreateMemUnit(),
-		Marshalizer:            marshaller,
-		Hasher:                 hasher,
-		GeneralConfig:          generalCfg,
-		CheckpointHashesHolder: hashesHolder.NewCheckpointHashesHolder(10000000, testscommon.HashSize),
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
+	args := storage.GetStorageManagerArgs()
+	args.CheckpointHashesHolder = hashesHolder.NewCheckpointHashesHolder(10000000, testscommon.HashSize)
 	trieStorage, _ := trie.NewTrieStorageManager(args)
 	tr, _ := trie.NewTrie(trieStorage, marshaller, hasher, 5)
 	ewlArgs := evictionWaitingList.MemoryEvictionWaitingListArgs{

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"fmt"
+	"github.com/multiversx/mx-chain-go/testscommon/storage"
 	"math/big"
 	"testing"
 
@@ -36,11 +37,9 @@ import (
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/dblookupext"
-	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/shardingMocks"
 	statusHandlerMock "github.com/multiversx/mx-chain-go/testscommon/statusHandler"
 	"github.com/multiversx/mx-chain-go/trie"
-	"github.com/multiversx/mx-chain-go/trie/hashesHolder"
 	logger "github.com/multiversx/mx-chain-logger-go"
 	wasmConfig "github.com/multiversx/mx-chain-vm-v1_4-go/config"
 	"github.com/stretchr/testify/require"
@@ -319,23 +318,11 @@ func GetNetworkFactoryArgs() networkComp.NetworkComponentsFactoryArgs {
 	}
 }
 
-func getNewTrieStorageManagerArgs() trie.NewTrieStorageManagerArgs {
-	return trie.NewTrieStorageManagerArgs{
-		MainStorer:             testscommon.CreateMemUnit(),
-		CheckpointsStorer:      testscommon.CreateMemUnit(),
-		Marshalizer:            &mock.MarshalizerMock{},
-		Hasher:                 &hashingMocks.HasherMock{},
-		GeneralConfig:          config.TrieStorageManagerConfig{SnapshotsGoroutineNum: 1},
-		CheckpointHashesHolder: hashesHolder.NewCheckpointHashesHolder(10, 32),
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
-}
-
 // GetStateFactoryArgs -
 func GetStateFactoryArgs(coreComponents factory.CoreComponentsHolder) stateComp.StateComponentsFactoryArgs {
-	tsm, _ := trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+	tsm, _ := trie.NewTrieStorageManager(storage.GetStorageManagerArgs())
 	storageManagerUser, _ := trie.NewTrieStorageManagerWithoutPruning(tsm)
-	tsm, _ = trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+	tsm, _ = trie.NewTrieStorageManager(storage.GetStorageManagerArgs())
 	storageManagerPeer, _ := trie.NewTrieStorageManagerWithoutPruning(tsm)
 
 	trieStorageManagers := make(map[string]common.StorageManager)

--- a/testscommon/storage/storageManagerArgs.go
+++ b/testscommon/storage/storageManagerArgs.go
@@ -4,30 +4,33 @@ import (
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/genesis/mock"
 	"github.com/multiversx/mx-chain-go/testscommon"
-	"github.com/multiversx/mx-chain-go/testscommon/genericMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
 	trieMock "github.com/multiversx/mx-chain-go/testscommon/trie"
 	"github.com/multiversx/mx-chain-go/trie"
 )
 
-// GetStorageManagerArgsAndOptions returns mock args for trie storage manager creation
-func GetStorageManagerArgsAndOptions() (trie.NewTrieStorageManagerArgs, trie.StorageManagerOptions) {
-	storageManagerArgs := trie.NewTrieStorageManagerArgs{
-		MainStorer:        genericMocks.NewStorerMock(),
-		CheckpointsStorer: genericMocks.NewStorerMock(),
+// GetStorageManagerArgs returns mock args for trie storage manager creation
+func GetStorageManagerArgs() trie.NewTrieStorageManagerArgs {
+	return trie.NewTrieStorageManagerArgs{
+		MainStorer:        testscommon.NewSnapshotPruningStorerMock(),
+		CheckpointsStorer: testscommon.NewSnapshotPruningStorerMock(),
 		Marshalizer:       &mock.MarshalizerMock{},
 		Hasher:            &hashingMocks.HasherMock{},
 		GeneralConfig: config.TrieStorageManagerConfig{
+			PruningBufferLen:      1000,
+			SnapshotsBufferLen:    10,
 			SnapshotsGoroutineNum: 2,
 		},
 		CheckpointHashesHolder: &trieMock.CheckpointHashesHolderStub{},
 		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
 	}
-	options := trie.StorageManagerOptions{
+}
+
+// GetStorageManagerOptions returns default options for trie storage manager creation
+func GetStorageManagerOptions() trie.StorageManagerOptions {
+	return trie.StorageManagerOptions{
 		PruningEnabled:     true,
 		SnapshotsEnabled:   true,
 		CheckpointsEnabled: true,
 	}
-
-	return storageManagerArgs, options
 }

--- a/trie/branchNode_test.go
+++ b/trie/branchNode_test.go
@@ -12,11 +12,9 @@ import (
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
-	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/storage/cache"
 	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
-	"github.com/multiversx/mx-chain-go/trie/hashesHolder"
 	"github.com/multiversx/mx-chain-go/trie/statistics"
 	"github.com/stretchr/testify/assert"
 )
@@ -47,30 +45,12 @@ func getBnAndCollapsedBn(marshalizer marshal.Marshalizer, hasher hashing.Hasher)
 }
 
 func newEmptyTrie() (*patriciaMerkleTrie, *trieStorageManager) {
-	marsh, hsh := getTestMarshalizerAndHasher()
-
-	// TODO change this initialization of the persister  (and everywhere in this package)
-	// by using a persister factory
-	generalCfg := config.TrieStorageManagerConfig{
-		PruningBufferLen:      1000,
-		SnapshotsBufferLen:    10,
-		SnapshotsGoroutineNum: 1,
-	}
-
-	args := NewTrieStorageManagerArgs{
-		MainStorer:             createMemUnit(),
-		CheckpointsStorer:      createMemUnit(),
-		Marshalizer:            marsh,
-		Hasher:                 hsh,
-		GeneralConfig:          generalCfg,
-		CheckpointHashesHolder: hashesHolder.NewCheckpointHashesHolder(10000000, uint64(hsh.Size())),
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
+	args := GetDefaultTrieStorageManagerParameters()
 	trieStorage, _ := NewTrieStorageManager(args)
 	tr := &patriciaMerkleTrie{
 		trieStorage:          trieStorage,
-		marshalizer:          marsh,
-		hasher:               hsh,
+		marshalizer:          args.Marshalizer,
+		hasher:               args.Hasher,
 		oldHashes:            make([][]byte, 0),
 		oldRoot:              make([]byte, 0),
 		maxTrieLevelInMemory: 5,
@@ -185,26 +165,9 @@ func TestBranchNode_setRootHash(t *testing.T) {
 	t.Parallel()
 
 	marsh, hsh := getTestMarshalizerAndHasher()
-	args := NewTrieStorageManagerArgs{
-		MainStorer:             createMemUnit(),
-		CheckpointsStorer:      createMemUnit(),
-		Marshalizer:            marsh,
-		Hasher:                 hsh,
-		GeneralConfig:          config.TrieStorageManagerConfig{SnapshotsGoroutineNum: 1},
-		CheckpointHashesHolder: hashesHolder.NewCheckpointHashesHolder(10, uint64(hsh.Size())),
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
-	trieStorage1, _ := NewTrieStorageManager(args)
-	args = NewTrieStorageManagerArgs{
-		MainStorer:             createMemUnit(),
-		CheckpointsStorer:      createMemUnit(),
-		Marshalizer:            marsh,
-		Hasher:                 hsh,
-		GeneralConfig:          config.TrieStorageManagerConfig{SnapshotsGoroutineNum: 1},
-		CheckpointHashesHolder: hashesHolder.NewCheckpointHashesHolder(10, uint64(hsh.Size())),
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
-	trieStorage2, _ := NewTrieStorageManager(args)
+
+	trieStorage1, _ := NewTrieStorageManager(GetDefaultTrieStorageManagerParameters())
+	trieStorage2, _ := NewTrieStorageManager(GetDefaultTrieStorageManagerParameters())
 	maxTrieLevelInMemory := uint(5)
 
 	tr1, _ := NewTrie(trieStorage1, marsh, hsh, maxTrieLevelInMemory)

--- a/trie/doubleListSync_test.go
+++ b/trie/doubleListSync_test.go
@@ -10,13 +10,11 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-go/common"
-	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/storage"
 	"github.com/multiversx/mx-chain-go/storage/database"
 	"github.com/multiversx/mx-chain-go/storage/storageunit"
 	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
-	"github.com/multiversx/mx-chain-go/trie/hashesHolder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,20 +35,8 @@ func createMemUnit() storage.Storer {
 
 // CreateTrieStorageManager creates the trie storage manager for the tests
 func createTrieStorageManager(store storage.Storer) (common.StorageManager, storage.Storer) {
-	generalCfg := config.TrieStorageManagerConfig{
-		PruningBufferLen:      1000,
-		SnapshotsBufferLen:    10,
-		SnapshotsGoroutineNum: 1,
-	}
-	args := NewTrieStorageManagerArgs{
-		MainStorer:             store,
-		CheckpointsStorer:      store,
-		Marshalizer:            marshalizer,
-		Hasher:                 hasherMock,
-		GeneralConfig:          generalCfg,
-		CheckpointHashesHolder: hashesHolder.NewCheckpointHashesHolder(10000000, uint64(hasherMock.Size())),
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
+	args := GetDefaultTrieStorageManagerParameters()
+	args.MainStorer = store
 	tsm, _ := NewTrieStorageManager(args)
 
 	return tsm, store

--- a/trie/export_test.go
+++ b/trie/export_test.go
@@ -3,8 +3,12 @@ package trie
 import (
 	"time"
 
+	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
+	"github.com/multiversx/mx-chain-go/trie/hashesHolder"
 )
 
 func (ts *trieSyncer) trieNodeIntercepted(hash []byte, val interface{}) {
@@ -100,4 +104,23 @@ func IsTrieStorageManagerInEpoch(tsm common.StorageManager) bool {
 // NewBaseIterator -
 func NewBaseIterator(trie common.Trie) (*baseIterator, error) {
 	return newBaseIterator(trie)
+}
+
+// GetDefaultTrieStorageManagerParameters -
+func GetDefaultTrieStorageManagerParameters() NewTrieStorageManagerArgs {
+	generalCfg := config.TrieStorageManagerConfig{
+		PruningBufferLen:      1000,
+		SnapshotsBufferLen:    10,
+		SnapshotsGoroutineNum: 1,
+	}
+
+	return NewTrieStorageManagerArgs{
+		MainStorer:             testscommon.NewSnapshotPruningStorerMock(),
+		CheckpointsStorer:      testscommon.NewSnapshotPruningStorerMock(),
+		Marshalizer:            &marshal.GogoProtoMarshalizer{},
+		Hasher:                 &testscommon.KeccakMock{},
+		GeneralConfig:          generalCfg,
+		CheckpointHashesHolder: hashesHolder.NewCheckpointHashesHolder(10000000, testscommon.HashSize),
+		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
+	}
 }

--- a/trie/patriciaMerkleTrie_test.go
+++ b/trie/patriciaMerkleTrie_test.go
@@ -18,12 +18,9 @@ import (
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/errChan"
 	"github.com/multiversx/mx-chain-go/common/holders"
-	"github.com/multiversx/mx-chain-go/config"
-	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/storage"
 	trieMock "github.com/multiversx/mx-chain-go/testscommon/trie"
 	"github.com/multiversx/mx-chain-go/trie"
-	"github.com/multiversx/mx-chain-go/trie/hashesHolder"
 	"github.com/multiversx/mx-chain-go/trie/keyBuilder"
 	"github.com/multiversx/mx-chain-go/trie/mock"
 	"github.com/stretchr/testify/assert"
@@ -38,29 +35,8 @@ func emptyTrie() common.Trie {
 	return tr
 }
 
-func getDefaultTrieStorageManagerParameters() trie.NewTrieStorageManagerArgs {
-	marshalizer := &testscommon.ProtobufMarshalizerMock{}
-	hasher := &testscommon.KeccakMock{}
-
-	generalCfg := config.TrieStorageManagerConfig{
-		PruningBufferLen:      1000,
-		SnapshotsBufferLen:    10,
-		SnapshotsGoroutineNum: 1,
-	}
-
-	return trie.NewTrieStorageManagerArgs{
-		MainStorer:             testscommon.NewSnapshotPruningStorerMock(),
-		CheckpointsStorer:      testscommon.NewSnapshotPruningStorerMock(),
-		Marshalizer:            marshalizer,
-		Hasher:                 hasher,
-		GeneralConfig:          generalCfg,
-		CheckpointHashesHolder: hashesHolder.NewCheckpointHashesHolder(10000000, testscommon.HashSize),
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
-}
-
 func getDefaultTrieParameters() (common.StorageManager, marshal.Marshalizer, hashing.Hasher, uint) {
-	args := getDefaultTrieStorageManagerParameters()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	trieStorageManager, _ := trie.NewTrieStorageManager(args)
 	maxTrieLevelInMemory := uint(1)
 
@@ -1050,7 +1026,7 @@ func TestPatriciaMerkleTrie_ConcurrentOperations(t *testing.T) {
 func TestPatriciaMerkleTrie_GetSerializedNodesClose(t *testing.T) {
 	t.Parallel()
 
-	args := getDefaultTrieStorageManagerParameters()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	args.MainStorer = &storage.StorerStub{
 		GetCalled: func(key []byte) ([]byte, error) {
 			// gets take a long time

--- a/trie/snapshotTrieStorageManager_test.go
+++ b/trie/snapshotTrieStorageManager_test.go
@@ -16,7 +16,9 @@ import (
 func TestNewSnapshotTrieStorageManagerInvalidStorerType(t *testing.T) {
 	t.Parallel()
 
-	_, trieStorage := newEmptyTrie()
+	args := GetDefaultTrieStorageManagerParameters()
+	args.MainStorer = createMemUnit()
+	trieStorage, _ := NewTrieStorageManager(args)
 
 	stsm, err := newSnapshotTrieStorageManager(trieStorage, 0)
 	assert.True(t, check.IfNil(stsm))

--- a/trie/syncTrieStorageManager_test.go
+++ b/trie/syncTrieStorageManager_test.go
@@ -20,7 +20,9 @@ func TestNewSyncTrieStorageManagerNilTsm(t *testing.T) {
 func TestNewSyncTrieStorageManagerInvalidStorerType(t *testing.T) {
 	t.Parallel()
 
-	_, trieStorage := newEmptyTrie()
+	args := GetDefaultTrieStorageManagerParameters()
+	args.MainStorer = createMemUnit()
+	trieStorage, _ := NewTrieStorageManager(args)
 
 	stsm, err := NewSyncTrieStorageManager(trieStorage)
 	assert.Nil(t, stsm)

--- a/trie/trieStorageManagerFactory_test.go
+++ b/trie/trieStorageManagerFactory_test.go
@@ -26,7 +26,7 @@ func TestTrieFactory_CreateWithoutPruning(t *testing.T) {
 
 	options := getTrieStorageManagerOptions()
 	options.PruningEnabled = false
-	tsm, err := trie.CreateTrieStorageManager(getNewTrieStorageManagerArgs(), options)
+	tsm, err := trie.CreateTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters(), options)
 	assert.Nil(t, err)
 	assert.Equal(t, "*trie.trieStorageManagerWithoutPruning", fmt.Sprintf("%T", tsm))
 }
@@ -36,7 +36,7 @@ func TestTrieFactory_CreateWithoutSnapshot(t *testing.T) {
 
 	options := getTrieStorageManagerOptions()
 	options.SnapshotsEnabled = false
-	tsm, err := trie.CreateTrieStorageManager(getNewTrieStorageManagerArgs(), options)
+	tsm, err := trie.CreateTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters(), options)
 	assert.Nil(t, err)
 	assert.Equal(t, "*trie.trieStorageManagerWithoutSnapshot", fmt.Sprintf("%T", tsm))
 }
@@ -46,7 +46,7 @@ func TestTrieFactory_CreateWithoutCheckpoints(t *testing.T) {
 
 	options := getTrieStorageManagerOptions()
 	options.CheckpointsEnabled = false
-	tsm, err := trie.CreateTrieStorageManager(getNewTrieStorageManagerArgs(), options)
+	tsm, err := trie.CreateTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters(), options)
 	assert.Nil(t, err)
 	assert.Equal(t, "*trie.trieStorageManagerWithoutCheckpoints", fmt.Sprintf("%T", tsm))
 }
@@ -54,7 +54,7 @@ func TestTrieFactory_CreateWithoutCheckpoints(t *testing.T) {
 func TestTrieFactory_CreateNormal(t *testing.T) {
 	t.Parallel()
 
-	tsm, err := trie.CreateTrieStorageManager(getNewTrieStorageManagerArgs(), getTrieStorageManagerOptions())
+	tsm, err := trie.CreateTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters(), getTrieStorageManagerOptions())
 	assert.Nil(t, err)
 	assert.Equal(t, "*trie.trieStorageManager", fmt.Sprintf("%T", tsm))
 }
@@ -98,7 +98,7 @@ func TestTrieStorageManager_SerialFuncShadowingCallsExpectedImpl(t *testing.T) {
 			return true
 		},
 		GetBaseTrieStorageManagerCalled: func() common.StorageManager {
-			tsm, _ = trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+			tsm, _ = trie.NewTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters())
 			return tsm
 		},
 	}

--- a/trie/trieStorageManagerWithoutCheckpoints_test.go
+++ b/trie/trieStorageManagerWithoutCheckpoints_test.go
@@ -25,7 +25,7 @@ func TestNewTrieStorageManagerWithoutCheckpoints(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		tsm, _ := trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+		tsm, _ := trie.NewTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters())
 		ts, err := trie.NewTrieStorageManagerWithoutCheckpoints(tsm)
 		assert.Nil(t, err)
 		assert.NotNil(t, ts)
@@ -35,7 +35,7 @@ func TestNewTrieStorageManagerWithoutCheckpoints(t *testing.T) {
 func TestTrieStorageManagerWithoutCheckpoints_SetCheckpoint(t *testing.T) {
 	t.Parallel()
 
-	tsm, _ := trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+	tsm, _ := trie.NewTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters())
 	ts, _ := trie.NewTrieStorageManagerWithoutCheckpoints(tsm)
 
 	iteratorChannels := &common.TrieIteratorChannels{
@@ -62,7 +62,7 @@ func TestTrieStorageManagerWithoutCheckpoints_SetCheckpoint(t *testing.T) {
 func TestTrieStorageManagerWithoutCheckpoints_AddDirtyCheckpointHashes(t *testing.T) {
 	t.Parallel()
 
-	tsm, _ := trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+	tsm, _ := trie.NewTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters())
 	ts, _ := trie.NewTrieStorageManagerWithoutCheckpoints(tsm)
 
 	assert.False(t, ts.AddDirtyCheckpointHashes([]byte("rootHash"), nil))

--- a/trie/trieStorageManagerWithoutPruning_test.go
+++ b/trie/trieStorageManagerWithoutPruning_test.go
@@ -20,7 +20,7 @@ func TestNewTrieStorageManagerWithoutPruningWithNilStorage(t *testing.T) {
 func TestNewTrieStorageManagerWithoutPruning(t *testing.T) {
 	t.Parallel()
 
-	tsm, _ := trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+	tsm, _ := trie.NewTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters())
 	ts, err := trie.NewTrieStorageManagerWithoutPruning(tsm)
 	assert.Nil(t, err)
 	assert.NotNil(t, ts)
@@ -29,7 +29,7 @@ func TestNewTrieStorageManagerWithoutPruning(t *testing.T) {
 func TestTrieStorageManagerWithoutPruning_IsPruningEnabled(t *testing.T) {
 	t.Parallel()
 
-	tsm, _ := trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+	tsm, _ := trie.NewTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters())
 	ts, _ := trie.NewTrieStorageManagerWithoutPruning(tsm)
 	assert.False(t, ts.IsPruningEnabled())
 }

--- a/trie/trieStorageManagerWithoutSnapshot_test.go
+++ b/trie/trieStorageManagerWithoutSnapshot_test.go
@@ -25,7 +25,7 @@ func TestNewTrieStorageManagerWithoutSnapshot(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		tsm, _ := trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+		tsm, _ := trie.NewTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters())
 		ts, err := trie.NewTrieStorageManagerWithoutSnapshot(tsm)
 		assert.Nil(t, err)
 		assert.NotNil(t, ts)
@@ -35,7 +35,7 @@ func TestNewTrieStorageManagerWithoutSnapshot(t *testing.T) {
 func TestTrieStorageManagerWithoutSnapshot_GetFromCurrentEpoch(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	tsm, _ := trie.NewTrieStorageManager(args)
 	ts, _ := trie.NewTrieStorageManagerWithoutSnapshot(tsm)
 
@@ -51,7 +51,7 @@ func TestTrieStorageManagerWithoutSnapshot_GetFromCurrentEpoch(t *testing.T) {
 func TestTrieStorageManagerWithoutSnapshot_PutInEpoch(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	tsm, _ := trie.NewTrieStorageManager(args)
 	ts, _ := trie.NewTrieStorageManagerWithoutSnapshot(tsm)
 
@@ -68,7 +68,7 @@ func TestTrieStorageManagerWithoutSnapshot_PutInEpoch(t *testing.T) {
 func TestTrieStorageManagerWithoutSnapshot_PutInEpochWithoutCache(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	tsm, _ := trie.NewTrieStorageManager(args)
 	ts, _ := trie.NewTrieStorageManagerWithoutSnapshot(tsm)
 
@@ -85,7 +85,7 @@ func TestTrieStorageManagerWithoutSnapshot_PutInEpochWithoutCache(t *testing.T) 
 func TestTrieStorageManagerWithoutSnapshot_TakeSnapshot(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	tsm, _ := trie.NewTrieStorageManager(args)
 	ts, _ := trie.NewTrieStorageManagerWithoutSnapshot(tsm)
 
@@ -105,7 +105,7 @@ func TestTrieStorageManagerWithoutSnapshot_TakeSnapshot(t *testing.T) {
 func TestTrieStorageManagerWithoutSnapshot_GetLatestStorageEpoch(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	tsm, _ := trie.NewTrieStorageManager(args)
 	ts, _ := trie.NewTrieStorageManagerWithoutSnapshot(tsm)
 
@@ -117,7 +117,7 @@ func TestTrieStorageManagerWithoutSnapshot_GetLatestStorageEpoch(t *testing.T) {
 func TestTrieStorageManagerWithoutSnapshot_SetEpochForPutOperationDoesNotPanic(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	tsm, _ := trie.NewTrieStorageManager(args)
 	ts, _ := trie.NewTrieStorageManagerWithoutSnapshot(tsm)
 
@@ -127,7 +127,7 @@ func TestTrieStorageManagerWithoutSnapshot_SetEpochForPutOperationDoesNotPanic(t
 func TestTrieStorageManagerWithoutSnapshot_ShouldTakeSnapshot(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	tsm, _ := trie.NewTrieStorageManager(args)
 	ts, _ := trie.NewTrieStorageManagerWithoutSnapshot(tsm)
 
@@ -141,7 +141,7 @@ func TestTrieStorageManagerWithoutSnapshot_IsInterfaceNil(t *testing.T) {
 	var ts common.StorageManager
 	assert.True(t, check.IfNil(ts))
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	tsm, _ := trie.NewTrieStorageManager(args)
 	ts, _ = trie.NewTrieStorageManagerWithoutSnapshot(tsm)
 	assert.False(t, check.IfNil(ts))

--- a/trie/trieStorageManager_test.go
+++ b/trie/trieStorageManager_test.go
@@ -10,21 +10,14 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/errChan"
-	"github.com/multiversx/mx-chain-go/config"
 	storageMx "github.com/multiversx/mx-chain-go/storage"
 	"github.com/multiversx/mx-chain-go/testscommon"
-	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/storage"
 	"github.com/multiversx/mx-chain-go/testscommon/storageManager"
 	trieMock "github.com/multiversx/mx-chain-go/testscommon/trie"
 	"github.com/multiversx/mx-chain-go/trie"
-	"github.com/multiversx/mx-chain-go/trie/hashesHolder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-)
-
-const (
-	hashSize = 32
 )
 
 var (
@@ -32,18 +25,6 @@ var (
 	providedVal = []byte("value")
 	expectedErr = errorsGo.New("expected error")
 )
-
-func getNewTrieStorageManagerArgs() trie.NewTrieStorageManagerArgs {
-	return trie.NewTrieStorageManagerArgs{
-		MainStorer:             testscommon.CreateMemUnit(),
-		CheckpointsStorer:      testscommon.CreateMemUnit(),
-		Marshalizer:            &testscommon.MarshalizerMock{},
-		Hasher:                 &hashingMocks.HasherMock{},
-		GeneralConfig:          config.TrieStorageManagerConfig{SnapshotsGoroutineNum: 1},
-		CheckpointHashesHolder: hashesHolder.NewCheckpointHashesHolder(10, hashSize),
-		IdleProvider:           &testscommon.ProcessStatusHandlerStub{},
-	}
-}
 
 // errChanWithLen extends the BufferedErrChan interface with a Len method
 type errChanWithLen interface {
@@ -57,7 +38,7 @@ func TestNewTrieStorageManager(t *testing.T) {
 	t.Run("nil main storer", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = nil
 		ts, err := trie.NewTrieStorageManager(args)
 		assert.Nil(t, ts)
@@ -66,7 +47,7 @@ func TestNewTrieStorageManager(t *testing.T) {
 	t.Run("nil checkpoints storer", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.CheckpointsStorer = nil
 		ts, err := trie.NewTrieStorageManager(args)
 		assert.Nil(t, ts)
@@ -75,7 +56,7 @@ func TestNewTrieStorageManager(t *testing.T) {
 	t.Run("nil marshaller", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.Marshalizer = nil
 		ts, err := trie.NewTrieStorageManager(args)
 		assert.Nil(t, ts)
@@ -84,7 +65,7 @@ func TestNewTrieStorageManager(t *testing.T) {
 	t.Run("nil hasher", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.Hasher = nil
 		ts, err := trie.NewTrieStorageManager(args)
 		assert.Nil(t, ts)
@@ -93,7 +74,7 @@ func TestNewTrieStorageManager(t *testing.T) {
 	t.Run("nil checkpoint hashes holder", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.CheckpointHashesHolder = nil
 		ts, err := trie.NewTrieStorageManager(args)
 		assert.Nil(t, ts)
@@ -102,7 +83,7 @@ func TestNewTrieStorageManager(t *testing.T) {
 	t.Run("nil idle provider", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.IdleProvider = nil
 		ts, err := trie.NewTrieStorageManager(args)
 		assert.Nil(t, ts)
@@ -111,7 +92,7 @@ func TestNewTrieStorageManager(t *testing.T) {
 	t.Run("invalid config should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.GeneralConfig.SnapshotsGoroutineNum = 0
 		ts, err := trie.NewTrieStorageManager(args)
 		assert.Nil(t, ts)
@@ -120,7 +101,7 @@ func TestNewTrieStorageManager(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		ts, err := trie.NewTrieStorageManager(args)
 		assert.Nil(t, err)
 		assert.NotNil(t, ts)
@@ -159,7 +140,7 @@ func TestTrieCheckpoint(t *testing.T) {
 func TestTrieStorageManager_SetCheckpointNilErrorChan(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	ts, _ := trie.NewTrieStorageManager(args)
 
 	rootHash := []byte("rootHash")
@@ -178,7 +159,7 @@ func TestTrieStorageManager_SetCheckpointNilErrorChan(t *testing.T) {
 func TestTrieStorageManager_SetCheckpointClosedDb(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	ts, _ := trie.NewTrieStorageManager(args)
 	_ = ts.Close()
 
@@ -199,7 +180,7 @@ func TestTrieStorageManager_SetCheckpointClosedDb(t *testing.T) {
 func TestTrieStorageManager_SetCheckpointEmptyTrieRootHash(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	ts, _ := trie.NewTrieStorageManager(args)
 
 	rootHash := make([]byte, 32)
@@ -244,7 +225,7 @@ func TestTrieCheckpoint_DoesNotSaveToCheckpointStorageIfNotDirty(t *testing.T) {
 func TestTrieStorageManager_IsPruningEnabled(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	ts, _ := trie.NewTrieStorageManager(args)
 
 	assert.True(t, ts.IsPruningEnabled())
@@ -253,7 +234,7 @@ func TestTrieStorageManager_IsPruningEnabled(t *testing.T) {
 func TestTrieStorageManager_IsPruningBlocked(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	ts, _ := trie.NewTrieStorageManager(args)
 	ts.ExitPruningBufferingMode() // early exit
 
@@ -273,7 +254,7 @@ func TestTrieStorageManager_Remove(t *testing.T) {
 		t.Parallel()
 
 		wasCalled := false
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = &storage.StorerStub{
 			RemoveCalled: func(key []byte) error {
 				wasCalled = true
@@ -289,7 +270,7 @@ func TestTrieStorageManager_Remove(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = testscommon.NewSnapshotPruningStorerMock()
 		args.CheckpointsStorer = testscommon.NewSnapshotPruningStorerMock()
 		ts, _ := trie.NewTrieStorageManager(args)
@@ -321,7 +302,7 @@ func TestTrieStorageManager_RemoveFromCheckpointHashesHolder(t *testing.T) {
 	t.Parallel()
 
 	wasCalled := false
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	args.CheckpointHashesHolder = &trieMock.CheckpointHashesHolderStub{
 		RemoveCalled: func(bytes []byte) {
 			wasCalled = true
@@ -339,7 +320,7 @@ func TestTrieStorageManager_SetEpochForPutOperation(t *testing.T) {
 	t.Run("main storer not epochStorer should early exit", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = &storage.StorerStub{}
 		ts, _ := trie.NewTrieStorageManager(args)
 
@@ -350,7 +331,7 @@ func TestTrieStorageManager_SetEpochForPutOperation(t *testing.T) {
 
 		providedEpoch := uint32(100)
 		wasCalled := false
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = &storageManager.StorageManagerStub{
 			SetEpochForPutOperationCalled: func(u uint32) {
 				assert.Equal(t, providedEpoch, u)
@@ -367,7 +348,7 @@ func TestTrieStorageManager_SetEpochForPutOperation(t *testing.T) {
 func TestTrieStorageManager_PutInEpochClosedDb(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	ts, _ := trie.NewTrieStorageManager(args)
 	_ = ts.Close()
 
@@ -378,7 +359,8 @@ func TestTrieStorageManager_PutInEpochClosedDb(t *testing.T) {
 func TestTrieStorageManager_PutInEpochInvalidStorer(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
+	args.MainStorer = testscommon.CreateMemUnit()
 	ts, _ := trie.NewTrieStorageManager(args)
 
 	err := ts.PutInEpoch(providedKey, providedVal, 0)
@@ -389,7 +371,7 @@ func TestTrieStorageManager_PutInEpoch(t *testing.T) {
 	t.Parallel()
 
 	putInEpochCalled := false
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	args.MainStorer = &trieMock.SnapshotPruningStorerStub{
 		MemDbMock: testscommon.NewMemDbMock(),
 		PutInEpochCalled: func(key []byte, data []byte, epoch uint32) error {
@@ -407,7 +389,8 @@ func TestTrieStorageManager_PutInEpoch(t *testing.T) {
 func TestTrieStorageManager_GetLatestStorageEpochInvalidStorer(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
+	args.MainStorer = testscommon.CreateMemUnit()
 	ts, _ := trie.NewTrieStorageManager(args)
 
 	val, err := ts.GetLatestStorageEpoch()
@@ -419,7 +402,7 @@ func TestTrieStorageManager_GetLatestStorageEpoch(t *testing.T) {
 	t.Parallel()
 
 	getLatestSorageCalled := false
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	args.MainStorer = &trieMock.SnapshotPruningStorerStub{
 		MemDbMock: testscommon.NewMemDbMock(),
 		GetLatestStorageEpochCalled: func() (uint32, error) {
@@ -438,7 +421,7 @@ func TestTrieStorageManager_GetLatestStorageEpoch(t *testing.T) {
 func TestTrieStorageManager_TakeSnapshotNilErrorChan(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	ts, _ := trie.NewTrieStorageManager(args)
 
 	rootHash := []byte("rootHash")
@@ -457,7 +440,7 @@ func TestTrieStorageManager_TakeSnapshotNilErrorChan(t *testing.T) {
 func TestTrieStorageManager_TakeSnapshotClosedDb(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	ts, _ := trie.NewTrieStorageManager(args)
 	_ = ts.Close()
 
@@ -478,7 +461,7 @@ func TestTrieStorageManager_TakeSnapshotClosedDb(t *testing.T) {
 func TestTrieStorageManager_TakeSnapshotEmptyTrieRootHash(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	ts, _ := trie.NewTrieStorageManager(args)
 
 	rootHash := make([]byte, 32)
@@ -498,7 +481,7 @@ func TestTrieStorageManager_TakeSnapshotEmptyTrieRootHash(t *testing.T) {
 func TestTrieStorageManager_TakeSnapshotWithGetNodeFromDBError(t *testing.T) {
 	t.Parallel()
 
-	args := getNewTrieStorageManagerArgs()
+	args := trie.GetDefaultTrieStorageManagerParameters()
 	args.MainStorer = testscommon.NewSnapshotPruningStorerMock()
 	ts, _ := trie.NewTrieStorageManager(args)
 
@@ -525,7 +508,7 @@ func TestTrieStorageManager_ShouldTakeSnapshot(t *testing.T) {
 	t.Run("invalid storer should return false", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		ts, _ := trie.NewTrieStorageManager(args)
 
 		assert.False(t, ts.ShouldTakeSnapshot())
@@ -533,7 +516,7 @@ func TestTrieStorageManager_ShouldTakeSnapshot(t *testing.T) {
 	t.Run("trie synced should return false", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = &trieMock.SnapshotPruningStorerStub{
 			GetFromCurrentEpochCalled: func(key []byte) ([]byte, error) {
 				return []byte(common.TrieSyncedVal), nil
@@ -547,7 +530,7 @@ func TestTrieStorageManager_ShouldTakeSnapshot(t *testing.T) {
 	t.Run("GetFromOldEpochsWithoutAddingToCacheCalled error should return false", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = &trieMock.SnapshotPruningStorerStub{
 			GetFromCurrentEpochCalled: func(key []byte) ([]byte, error) {
 				return nil, expectedErr // isTrieSynced returns false
@@ -564,7 +547,7 @@ func TestTrieStorageManager_ShouldTakeSnapshot(t *testing.T) {
 	t.Run("GetFromOldEpochsWithoutAddingToCacheCalled returns non ActiveDBVal should return false", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = &trieMock.SnapshotPruningStorerStub{
 			GetFromCurrentEpochCalled: func(key []byte) ([]byte, error) {
 				return []byte("response"), nil
@@ -581,7 +564,7 @@ func TestTrieStorageManager_ShouldTakeSnapshot(t *testing.T) {
 	t.Run("GetFromOldEpochsWithoutAddingToCacheCalled returns ActiveDBVal should return true", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = &trieMock.SnapshotPruningStorerStub{
 			GetFromCurrentEpochCalled: func(key []byte) ([]byte, error) {
 				return nil, expectedErr // isTrieSynced returns false
@@ -603,7 +586,7 @@ func TestTrieStorageManager_Get(t *testing.T) {
 	t.Run("closed storage manager should error", func(t *testing.T) {
 		t.Parallel()
 
-		ts, _ := trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+		ts, _ := trie.NewTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters())
 		_ = ts.Close()
 
 		val, err := ts.Get(providedKey)
@@ -613,7 +596,7 @@ func TestTrieStorageManager_Get(t *testing.T) {
 	t.Run("main storer closing should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = &storage.StorerStub{
 			GetCalled: func(key []byte) ([]byte, error) {
 				return nil, storageMx.ErrDBIsClosed
@@ -628,7 +611,7 @@ func TestTrieStorageManager_Get(t *testing.T) {
 	t.Run("checkpoints storer closing should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.CheckpointsStorer = &storage.StorerStub{
 			GetCalled: func(key []byte) ([]byte, error) {
 				return nil, storageMx.ErrDBIsClosed
@@ -643,7 +626,7 @@ func TestTrieStorageManager_Get(t *testing.T) {
 	t.Run("should return from main storer", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		_ = args.MainStorer.Put(providedKey, providedVal)
 		ts, _ := trie.NewTrieStorageManager(args)
 
@@ -654,7 +637,7 @@ func TestTrieStorageManager_Get(t *testing.T) {
 	t.Run("should return from checkpoints storer", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		_ = args.CheckpointsStorer.Put(providedKey, providedVal)
 		ts, _ := trie.NewTrieStorageManager(args)
 
@@ -670,7 +653,7 @@ func TestNewSnapshotTrieStorageManager_GetFromCurrentEpoch(t *testing.T) {
 	t.Run("closed storage manager should error", func(t *testing.T) {
 		t.Parallel()
 
-		ts, _ := trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+		ts, _ := trie.NewTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters())
 		_ = ts.Close()
 
 		val, err := ts.GetFromCurrentEpoch(providedKey)
@@ -680,7 +663,7 @@ func TestNewSnapshotTrieStorageManager_GetFromCurrentEpoch(t *testing.T) {
 	t.Run("main storer not snapshotPruningStorer should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = &storage.StorerStub{}
 		ts, _ := trie.NewTrieStorageManager(args)
 
@@ -692,7 +675,7 @@ func TestNewSnapshotTrieStorageManager_GetFromCurrentEpoch(t *testing.T) {
 		t.Parallel()
 
 		getFromCurrentEpochCalled := false
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = &trieMock.SnapshotPruningStorerStub{
 			MemDbMock: testscommon.NewMemDbMock(),
 			GetFromCurrentEpochCalled: func(_ []byte) ([]byte, error) {
@@ -714,7 +697,7 @@ func TestTrieStorageManager_Put(t *testing.T) {
 	t.Run("closed storage manager should error", func(t *testing.T) {
 		t.Parallel()
 
-		ts, _ := trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+		ts, _ := trie.NewTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters())
 		_ = ts.Close()
 
 		err := ts.Put(providedKey, providedVal)
@@ -723,7 +706,7 @@ func TestTrieStorageManager_Put(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		ts, _ := trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+		ts, _ := trie.NewTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters())
 
 		_ = ts.Put(providedKey, providedVal)
 		val, err := ts.Get(providedKey)
@@ -738,7 +721,7 @@ func TestTrieStorageManager_PutInEpochWithoutCache(t *testing.T) {
 	t.Run("closed storage manager should error", func(t *testing.T) {
 		t.Parallel()
 
-		ts, _ := trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+		ts, _ := trie.NewTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters())
 		_ = ts.Close()
 
 		err := ts.PutInEpochWithoutCache(providedKey, providedVal, 0)
@@ -747,7 +730,7 @@ func TestTrieStorageManager_PutInEpochWithoutCache(t *testing.T) {
 	t.Run("main storer not snapshotPruningStorer should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = &storage.StorerStub{}
 		ts, _ := trie.NewTrieStorageManager(args)
 
@@ -757,7 +740,7 @@ func TestTrieStorageManager_PutInEpochWithoutCache(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = testscommon.NewSnapshotPruningStorerMock()
 		ts, _ := trie.NewTrieStorageManager(args)
 
@@ -772,7 +755,7 @@ func TestTrieStorageManager_Close(t *testing.T) {
 	t.Run("error on main storer close", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = &storage.StorerStub{
 			CloseCalled: func() error {
 				return expectedErr
@@ -786,7 +769,7 @@ func TestTrieStorageManager_Close(t *testing.T) {
 	t.Run("error on checkpoints storer close", func(t *testing.T) {
 		t.Parallel()
 
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.CheckpointsStorer = &storage.StorerStub{
 			CloseCalled: func() error {
 				return expectedErr
@@ -800,7 +783,7 @@ func TestTrieStorageManager_Close(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		ts, _ := trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+		ts, _ := trie.NewTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters())
 
 		err := ts.Close()
 		assert.NoError(t, err)
@@ -912,7 +895,7 @@ func TestTrieStorageManager_GetIdentifier(t *testing.T) {
 	t.Run("db without identifier", func(t *testing.T) {
 		t.Parallel()
 
-		ts, _ := trie.NewTrieStorageManager(getNewTrieStorageManagerArgs())
+		ts, _ := trie.NewTrieStorageManager(trie.GetDefaultTrieStorageManagerParameters())
 		id := ts.GetIdentifier()
 		assert.Equal(t, "", id)
 	})
@@ -921,7 +904,7 @@ func TestTrieStorageManager_GetIdentifier(t *testing.T) {
 		t.Parallel()
 
 		expectedIdentifier := "identifier"
-		args := getNewTrieStorageManagerArgs()
+		args := trie.GetDefaultTrieStorageManagerParameters()
 		args.MainStorer = &storage.StorerStub{
 			GetIdentifierCalled: func() string {
 				return expectedIdentifier


### PR DESCRIPTION
## Proposed changes
- Get identifier from trieStorageManager and not from storer.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
