### PR TITLE
[DO NOT MERGE] Mx 14197 epochs fast forwarder [DO NOT MERGE]

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -637,7 +637,7 @@
    Type = "json"
 
 [EpochStartConfig]
-    MinRoundsBetweenEpochs = 20
+    MinRoundsBetweenEpochs = 4
     RoundsPerEpoch         = 200
     # Min and Max ShuffledOutRestartThreshold represents the minimum and maximum duration of an epoch (in percentage) after a node which
     # has been shuffled out has to restart its process in order to start in a new shard

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -392,7 +392,7 @@ func (mp *metaProcessor) ProcessBlock(
 		return err
 	}
 
-	mp.ForceStart(header)
+	mp.TryForceEpochStart(header)
 
 	return nil
 }
@@ -749,7 +749,7 @@ func (mp *metaProcessor) CreateBlock(
 
 	mp.requestHandler.SetEpoch(metaHdr.GetEpoch())
 
-	mp.ForceStart(metaHdr)
+	mp.TryForceEpochStart(metaHdr)
 
 	return metaHdr, body, nil
 }

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -42,6 +42,8 @@ type metaProcessor struct {
 	shardBlockFinality           uint32
 	chRcvAllHdrs                 chan bool
 	headersCounter               *headersCounter
+	nrEpochsChanges              int
+	roundsModulus                uint64
 }
 
 // NewMetaProcessor creates a new metaProcessor object
@@ -389,6 +391,8 @@ func (mp *metaProcessor) ProcessBlock(
 	if err != nil {
 		return err
 	}
+
+	mp.ForceStart(header)
 
 	return nil
 }
@@ -744,6 +748,8 @@ func (mp *metaProcessor) CreateBlock(
 	}
 
 	mp.requestHandler.SetEpoch(metaHdr.GetEpoch())
+
+	mp.ForceStart(metaHdr)
 
 	return metaHdr, body, nil
 }

--- a/process/block/metablockExtras.go
+++ b/process/block/metablockExtras.go
@@ -1,0 +1,59 @@
+package block
+
+import (
+	"bytes"
+	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-go/update"
+	"github.com/multiversx/mx-chain-go/vm"
+	"strconv"
+	"strings"
+)
+
+const minRoundModulus = uint64(4)
+
+func (mp *metaProcessor) ForceStart(metaHdr *block.MetaBlock) {
+	forceEpochTrigger := mp.epochStartTrigger.(update.EpochHandler)
+
+	txBlockTxs := mp.txCoordinator.GetAllCurrentUsedTxs(block.TxBlock)
+
+	for _, tx := range txBlockTxs {
+		if bytes.Compare(tx.GetRcvAddr(), vm.ValidatorSCAddress) == 0 {
+			tokens := strings.Split(string(tx.GetData()), "@")
+			if len(tokens) != 3 {
+				log.Info("epochfastforward", "invalid data", string(tx.GetData()))
+				continue
+			}
+			epochs, err := strconv.ParseInt(tokens[1], 10, 64)
+			if err != nil {
+				log.Error("epochfastforward", "epochs could not be parsed", tokens[1])
+			}
+
+			roundsPerEpoch, err := strconv.ParseInt(tokens[2], 10, 64)
+			if err != nil {
+				log.Error("epochfastforward", "rounds could not be parsed", tokens[2])
+			}
+			roundsPerEpochUint := uint64(roundsPerEpoch)
+
+			if roundsPerEpochUint < minRoundModulus {
+				log.Warn("epochfastforward rounds per epoch too small", "rounds", roundsPerEpoch, "minRoundModulus", minRoundModulus)
+				roundsPerEpochUint = minRoundModulus
+			}
+
+			mp.nrEpochsChanges = int(epochs)
+			mp.roundsModulus = roundsPerEpochUint
+
+			log.Warn("forcing epoch start", "round", metaHdr.GetRound(), "epoch", metaHdr.GetEpoch(), "still remaining epoch changes", mp.nrEpochsChanges, "rounds modulus", mp.roundsModulus)
+
+			break
+		}
+	}
+
+	if !check.IfNil(forceEpochTrigger) {
+		if metaHdr.GetRound()%mp.roundsModulus == 0 && mp.nrEpochsChanges > 0 {
+			forceEpochTrigger.ForceEpochStart(metaHdr.GetRound())
+			mp.nrEpochsChanges--
+			log.Debug("forcing epoch start", "round", metaHdr.GetRound(), "epoch", metaHdr.GetEpoch(), "still remaining epoch changes", mp.nrEpochsChanges, "rounds modulus", mp.roundsModulus)
+		}
+	}
+}

--- a/process/block/metablockExtras.go
+++ b/process/block/metablockExtras.go
@@ -3,6 +3,7 @@ package block
 import (
 	"bytes"
 	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-go/update"
 	"github.com/multiversx/mx-chain-go/vm"
@@ -13,47 +14,61 @@ import (
 const minRoundModulus = uint64(4)
 
 func (mp *metaProcessor) ForceStart(metaHdr *block.MetaBlock) {
-	forceEpochTrigger := mp.epochStartTrigger.(update.EpochHandler)
-
 	txBlockTxs := mp.txCoordinator.GetAllCurrentUsedTxs(block.TxBlock)
 
 	for _, tx := range txBlockTxs {
-		if bytes.Compare(tx.GetRcvAddr(), vm.ValidatorSCAddress) == 0 {
-			tokens := strings.Split(string(tx.GetData()), "@")
-			if len(tokens) != 3 {
-				log.Info("epochfastforward", "invalid data", string(tx.GetData()))
-				continue
+		if isEpochsFastForwardTx(tx) {
+			epochs, roundsPerEpochUint := parseFastForwardArguments(tx)
+			if epochs > 0 && roundsPerEpochUint > 0 {
+				mp.nrEpochsChanges = epochs
+				mp.roundsModulus = roundsPerEpochUint
+
+				log.Warn("forcing epoch start", "round", metaHdr.GetRound(), "epoch", metaHdr.GetEpoch(), "still remaining epoch changes", mp.nrEpochsChanges, "rounds modulus", mp.roundsModulus)
+				break
 			}
-			epochs, err := strconv.ParseInt(tokens[1], 10, 64)
-			if err != nil {
-				log.Error("epochfastforward", "epochs could not be parsed", tokens[1])
-			}
-
-			roundsPerEpoch, err := strconv.ParseInt(tokens[2], 10, 64)
-			if err != nil {
-				log.Error("epochfastforward", "rounds could not be parsed", tokens[2])
-			}
-			roundsPerEpochUint := uint64(roundsPerEpoch)
-
-			if roundsPerEpochUint < minRoundModulus {
-				log.Warn("epochfastforward rounds per epoch too small", "rounds", roundsPerEpoch, "minRoundModulus", minRoundModulus)
-				roundsPerEpochUint = minRoundModulus
-			}
-
-			mp.nrEpochsChanges = int(epochs)
-			mp.roundsModulus = roundsPerEpochUint
-
-			log.Warn("forcing epoch start", "round", metaHdr.GetRound(), "epoch", metaHdr.GetEpoch(), "still remaining epoch changes", mp.nrEpochsChanges, "rounds modulus", mp.roundsModulus)
-
-			break
 		}
 	}
 
-	if !check.IfNil(forceEpochTrigger) {
-		if metaHdr.GetRound()%mp.roundsModulus == 0 && mp.nrEpochsChanges > 0 {
-			forceEpochTrigger.ForceEpochStart(metaHdr.GetRound())
-			mp.nrEpochsChanges--
-			log.Debug("forcing epoch start", "round", metaHdr.GetRound(), "epoch", metaHdr.GetEpoch(), "still remaining epoch changes", mp.nrEpochsChanges, "rounds modulus", mp.roundsModulus)
-		}
+	mp.tryFastForwardEpoch(metaHdr)
+}
+
+func isEpochsFastForwardTx(tx data.TransactionHandler) bool {
+	return bytes.Compare(tx.GetRcvAddr(), vm.ValidatorSCAddress) == 0 &&
+		strings.HasPrefix(string(tx.GetData()), "epochFastForward")
+}
+
+func parseFastForwardArguments(tx data.TransactionHandler) (int, uint64) {
+	tokens := strings.Split(string(tx.GetData()), "@")
+	if len(tokens) != 3 {
+		log.Error("epochFastForward", "invalid data", string(tx.GetData()))
+		return 0, 0
+	}
+	epochs, err := strconv.ParseInt(tokens[1], 10, 64)
+	if err != nil {
+		log.Error("epochFastForward", "epochs could not be parsed", tokens[1])
+	}
+
+	roundsPerEpoch, err := strconv.ParseInt(tokens[2], 10, 64)
+	if err != nil {
+		log.Error("epochFastForward", "rounds could not be parsed", tokens[2])
+	}
+	roundsPerEpochUint := uint64(roundsPerEpoch)
+
+	if roundsPerEpochUint < minRoundModulus {
+		log.Warn("epochFastForward rounds per epoch too small", "rounds", roundsPerEpoch, "minRoundModulus", minRoundModulus)
+		roundsPerEpochUint = minRoundModulus
+	}
+	return int(epochs), roundsPerEpochUint
+}
+
+func (mp *metaProcessor) tryFastForwardEpoch(metaHdr *block.MetaBlock) {
+	forceEpochTrigger := mp.epochStartTrigger.(update.EpochHandler)
+
+	correctRoundsAndEpochs := mp.roundsModulus > 0 && metaHdr.GetRound()%mp.roundsModulus == 0 && mp.nrEpochsChanges > 0
+
+	if !check.IfNil(forceEpochTrigger) && correctRoundsAndEpochs {
+		forceEpochTrigger.ForceEpochStart(metaHdr.GetRound())
+		mp.nrEpochsChanges--
+		log.Debug("forcing epoch start", "round", metaHdr.GetRound(), "epoch", metaHdr.GetEpoch(), "still remaining epoch changes", mp.nrEpochsChanges, "rounds modulus", mp.roundsModulus)
 	}
 }


### PR DESCRIPTION
## This needs to be done through seds/replaces for the testnets not through actual changes in the metablock processor

## Reasoning behind the pull request
- for internal testnets a faster way to advance through epochs is needed
  

## Proposed changes
- added functionality to force epoch changes on metachain


## Testing procedure
- create a transaction towards the validatorSCAddress erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l with the dataField "epochFastForward@10@6" -> do 10 epochChanges, where every epoch has 6 rounds

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
