### PR TITLE
Allow set same guardian

### DIFF
--- a/process/guardian/guardedAccount.go
+++ b/process/guardian/guardedAccount.go
@@ -230,12 +230,7 @@ func (agc *guardedAccount) updateGuardians(newGuardian *guardians.Guardian, acco
 		// no active guardian, do not replace the already pending guardian
 		return nil, fmt.Errorf("%w in updateGuardians, with %d configured guardians", err, numSetGuardians)
 	}
-
-	if bytes.Equal(activeGuardian.Address, newGuardian.Address) {
-		accountGuardians.Slice = []*guardians.Guardian{activeGuardian}
-	} else {
-		accountGuardians.Slice = []*guardians.Guardian{activeGuardian, newGuardian}
-	}
+	accountGuardians.Slice = []*guardians.Guardian{activeGuardian, newGuardian}
 
 	return accountGuardians, nil
 }

--- a/process/guardian/guardedAccount_test.go
+++ b/process/guardian/guardedAccount_test.go
@@ -314,19 +314,17 @@ func TestGuardedAccount_setAccountGuardian(t *testing.T) {
 		err := ga.setAccountGuardian(ua, newGuardian)
 		require.True(t, errors.Is(err, process.ErrAccountHasNoActiveGuardian))
 	})
-	t.Run("setGuardian same guardian ok, not changing existing config", func(t *testing.T) {
+	t.Run("setGuardian same guardian ok, changing existing config", func(t *testing.T) {
 		existingGuardian := &guardians.Guardian{
 			Address:         []byte("guardian address"),
 			ActivationEpoch: 9,
 		}
 		newGuardian := newGuardian
 		newGuardian.Address = existingGuardian.Address
-		configuredGuardians := &guardians.Guardians{Slice: []*guardians.Guardian{existingGuardian}}
-
 		expectedValue := []byte(nil)
 		ua := &stateMocks.UserAccountStub{
 			RetrieveValueCalled: func(key []byte) ([]byte, uint32, error) {
-				expectedValue, _ = ga.marshaller.Marshal(configuredGuardians)
+				expectedValue, _ = ga.marshaller.Marshal(&guardians.Guardians{Slice: []*guardians.Guardian{existingGuardian, newGuardian}})
 				return expectedValue, 0, nil
 			},
 			AccountDataHandlerCalled: func() vmcommon.AccountDataHandler {

--- a/process/transaction/baseProcess.go
+++ b/process/transaction/baseProcess.go
@@ -222,12 +222,20 @@ func (txProc *baseTxProcessor) VerifyTransaction(tx *transaction.Transaction) er
 
 // Setting a guardian is allowed with regular transactions on a guarded account
 // but in this case is set with the default epochs delay
-func (txProc *baseTxProcessor) checkOperationAllowedToBypassGuardian(tx data.TransactionHandler) error {
+func (txProc *baseTxProcessor) checkOperationAllowedToBypassGuardian(tx *transaction.Transaction) error {
 	if !process.IsSetGuardianCall(tx.GetData()) {
 		return fmt.Errorf("%w, not allowed to bypass guardian", process.ErrTransactionNotExecutable)
 	}
 
-	return txProc.CheckSetGuardianExecutable(tx)
+	err := txProc.CheckSetGuardianExecutable(tx)
+	if err != nil {
+		return err
+	}
+	if len(tx.GetRcvUserName()) > 0 || len(tx.GetSndUserName()) > 0 {
+		return fmt.Errorf("%w, SetGuardian does not support usernames", process.ErrTransactionNotExecutable)
+	}
+
+	return nil
 }
 
 // CheckSetGuardianExecutable checks if the setGuardian builtin function is executable

--- a/process/transaction/baseProcess_test.go
+++ b/process/transaction/baseProcess_test.go
@@ -94,6 +94,34 @@ func Test_checkOperationAllowedToBypassGuardian(t *testing.T) {
 		require.True(t, errors.Is(err, process.ErrTransactionNotExecutable))
 		require.True(t, strings.Contains(err.Error(), expectedError.Error()))
 	})
+	t.Run("set guardian builtin call not allowed to bypass if transaction has sender username", func(t *testing.T) {
+		txCopy := *tx
+		baseProc := createMockBaseTxProcessor()
+		baseProc.scProcessor = &testscommon.SCProcessorMock{
+			CheckBuiltinFunctionIsExecutableCalled: func(expectedBuiltinFunction string, tx data.TransactionHandler) error {
+				return nil
+			},
+		}
+		txCopy.Data = []byte("SetGuardian@")
+		txCopy.SndUserName = []byte("someUsername")
+		err := baseProc.checkOperationAllowedToBypassGuardian(&txCopy)
+		require.ErrorIs(t, err, process.ErrTransactionNotExecutable)
+		require.True(t, strings.Contains(err.Error(), "username"))
+	})
+	t.Run("set guardian builtin call not allowed to bypass if transaction has receiver username address", func(t *testing.T) {
+		txCopy := *tx
+		baseProc := createMockBaseTxProcessor()
+		baseProc.scProcessor = &testscommon.SCProcessorMock{
+			CheckBuiltinFunctionIsExecutableCalled: func(expectedBuiltinFunction string, tx data.TransactionHandler) error {
+				return nil
+			},
+		}
+		txCopy.Data = []byte("SetGuardian@")
+		txCopy.RcvUserName = []byte("someUsername")
+		err := baseProc.checkOperationAllowedToBypassGuardian(&txCopy)
+		require.ErrorIs(t, err, process.ErrTransactionNotExecutable)
+		require.True(t, strings.Contains(err.Error(), "username"))
+	})
 	t.Run("set guardian builtin call ok", func(t *testing.T) {
 		txCopy := *tx
 		baseProc := createMockBaseTxProcessor()


### PR DESCRIPTION
## Reasoning behind the pull request
Improvements for set guardian

## Proposed changes
- allow setting of pending guardian the active guardian - increases protection time 2x.
- reject txs with usernames from pending set guardian - simplifies checks before execution

## Testing procedure

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
