### PR TITLE
Logs for non-executable transactions

### DIFF
--- a/factory/processing/blockProcessorCreator.go
+++ b/factory/processing/blockProcessorCreator.go
@@ -277,6 +277,7 @@ func (pcf *processComponentsFactory) newShardBlockProcessor(
 		EnableEpochsHandler: pcf.coreData.EnableEpochsHandler(),
 		GuardianChecker:     pcf.bootstrapComponents.GuardedAccountHandler(),
 		TxVersionChecker:    pcf.coreData.TxVersionChecker(),
+		TxLogsProcessor:     pcf.txLogsProcessor,
 	}
 	transactionProcessor, err := transaction.NewTxProcessor(argsNewTxProcessor)
 	if err != nil {

--- a/genesis/process/shardGenesisBlockCreator.go
+++ b/genesis/process/shardGenesisBlockCreator.go
@@ -577,6 +577,7 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, enableEpo
 		EnableEpochsHandler: enableEpochsHandler,
 		TxVersionChecker:    arg.Core.TxVersionChecker(),
 		GuardianChecker:     disabledGuardian.NewDisabledGuardedAccountHandler(),
+		TxLogsProcessor:     arg.TxLogsProcessor,
 	}
 	transactionProcessor, err := transaction.NewTxProcessor(argsNewTxProcessor)
 	if err != nil {

--- a/integrationTests/singleShard/block/executingMiniblocks/executingMiniblocks_test.go
+++ b/integrationTests/singleShard/block/executingMiniblocks/executingMiniblocks_test.go
@@ -87,7 +87,7 @@ func TestShardShouldNotProposeAndExecuteTwoBlocksInSameRound(t *testing.T) {
 // 2. proposer will have those 3 transactions in its pools and will propose a block
 // 3. another node will be able to sync the proposed block (and request - receive) the 2 transactions that
 //    will end up in the block (one valid and one invalid)
-// 4. the unexecutable transaction will be removed from the proposer's pool
+// 4. the non-executable transaction will be removed from the proposer's pool
 func TestShardShouldProposeBlockContainingInvalidTransactions(t *testing.T) {
 	if testing.Short() {
 		t.Skip("this is not a short test")

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -1007,6 +1007,7 @@ func CreateSimpleTxProcessor(accnts state.AccountsAdapter) process.TransactionPr
 		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
 		TxVersionChecker:    &testscommon.TxVersionCheckerStub{},
 		GuardianChecker:     &guardianMocks.GuardedAccountHandlerStub{},
+		TxLogsProcessor:     &mock.TxLogsProcessorStub{},
 	}
 	txProcessor, _ := txProc.NewTxProcessor(argsNewTxProcessor)
 

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -1514,6 +1514,7 @@ func (tpn *TestProcessorNode) initInnerProcessors(gasMap map[string]map[string]u
 		EnableEpochsHandler: tpn.EnableEpochsHandler,
 		GuardianChecker:     &guardianMocks.GuardedAccountHandlerStub{},
 		TxVersionChecker:    &testscommon.TxVersionCheckerStub{},
+		TxLogsProcessor:     tpn.TransactionLogProcessor,
 	}
 	tpn.TxProcessor, _ = transaction.NewTxProcessor(argsNewTxProcessor)
 	scheduledSCRsStorer, _ := tpn.Storage.GetStorer(dataRetriever.ScheduledSCRsUnit)
@@ -2312,7 +2313,7 @@ func (tpn *TestProcessorNode) initNode() {
 
 // SendTransaction can send a transaction (it does the dispatching)
 func (tpn *TestProcessorNode) SendTransaction(tx *dataTransaction.Transaction) (string, error) {
-	txArgs := &external.ArgsCreateTransaction{
+	createTxArgs := &external.ArgsCreateTransaction{
 		Nonce:            tx.Nonce,
 		Value:            tx.Value.String(),
 		Receiver:         TestAddressPubkeyConverter.Encode(tx.RcvAddr),
@@ -2329,7 +2330,7 @@ func (tpn *TestProcessorNode) SendTransaction(tx *dataTransaction.Transaction) (
 		Guardian:         TestAddressPubkeyConverter.Encode(tx.GuardianAddr),
 		GuardianSigHex:   hex.EncodeToString(tx.GuardianSignature),
 	}
-	tx, txHash, err := tpn.Node.CreateTransaction(txArgs)
+	tx, txHash, err := tpn.Node.CreateTransaction(createTxArgs)
 	if err != nil {
 		return "", err
 	}

--- a/integrationTests/vm/testInitializer.go
+++ b/integrationTests/vm/testInitializer.go
@@ -471,6 +471,7 @@ func CreateTxProcessorWithOneSCExecutorMockVM(
 		EnableEpochsHandler: enableEpochsHandler,
 		TxVersionChecker:    versioning.NewTxVersionChecker(minTransactionVersion),
 		GuardianChecker:     guardedAccountHandler,
+		TxLogsProcessor:     &mock.TxLogsProcessorStub{},
 	}
 
 	return transaction.NewTxProcessor(argsNewTxProcessor)
@@ -854,6 +855,7 @@ func CreateTxProcessorWithOneSCExecutorWithVMs(
 		EnableEpochsHandler: enableEpochsHandler,
 		TxVersionChecker:    versioning.NewTxVersionChecker(minTransactionVersion),
 		GuardianChecker:     guardianChecker,
+		TxLogsProcessor:     logProc,
 	}
 	txProcessor, err := transaction.NewTxProcessor(argsNewTxProcessor)
 	if err != nil {

--- a/integrationTests/vm/txsFee/relayedMoveBalance_test.go
+++ b/integrationTests/vm/txsFee/relayedMoveBalance_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	dataTransaction "github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-go/config"
@@ -326,6 +327,7 @@ func executeRelayedTransaction(
 	senderAddress []byte,
 	expectedReturnCode vmcommon.ReturnCode,
 ) {
+	testContext.TxsLogsProcessor.Clean()
 	relayerAccount := getAccount(tb, testContext, relayerAddress)
 	gasLimit := 1 + userTx.GasLimit + uint64(len(userTxPrepared))
 
@@ -335,6 +337,18 @@ func executeRelayedTransaction(
 
 	_, err := testContext.Accounts.Commit()
 	require.Nil(tb, err)
+
+	relayedTxHash, _ := core.CalculateHash(testContext.Marshalizer, integrationtests.TestHasher, relayedTx)
+
+	if expectedReturnCode == vmcommon.Ok {
+		return
+	}
+
+	logs, err := testContext.TxsLogsProcessor.GetLog(relayedTxHash)
+	assert.Nil(tb, err)
+	events := logs.GetLogEvents()
+	assert.Equal(tb, 1, len(events))
+	assert.Equal(tb, core.SignalErrorOperation, string(events[0].GetIdentifier()))
 }
 
 func getAccount(tb testing.TB, testContext *vm.VMTestContext, address []byte) vmcommon.UserAccountHandler {

--- a/integrationTests/vm/wasm/utils.go
+++ b/integrationTests/vm/wasm/utils.go
@@ -390,6 +390,7 @@ func (context *TestContext) initTxProcessorWithOneSCExecutorWithVMs() {
 		EnableEpochsHandler: context.EnableEpochsHandler,
 		TxVersionChecker:    &testscommon.TxVersionCheckerStub{},
 		GuardianChecker:     &guardianMocks.GuardedAccountHandlerStub{},
+		TxLogsProcessor:     logsProcessor,
 	}
 
 	context.TxProcessor, err = processTransaction.NewTxProcessor(argsNewTxProcessor)

--- a/integrationTests/vm/wasm/wasmvm/wasmVM_test.go
+++ b/integrationTests/vm/wasm/wasmvm/wasmVM_test.go
@@ -543,6 +543,7 @@ func TestExecuteTransactionAndTimeToProcessChange(t *testing.T) {
 		ArgsParser:          smartContract.NewArgumentParser(),
 		ScrForwarder:        &mock.IntermediateTransactionHandlerMock{},
 		EnableEpochsHandler: &testscommon.EnableEpochsHandlerStub{},
+		TxLogsProcessor:     &mock.TxLogsProcessorStub{},
 	}
 	txProc, _ := processTransaction.NewTxProcessor(argsNewTxProcessor)
 

--- a/process/transaction/export_test.go
+++ b/process/transaction/export_test.go
@@ -3,6 +3,7 @@ package transaction
 import (
 	"math/big"
 
+	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-go/process"
@@ -91,4 +92,9 @@ func (txProc *txProcessor) VerifyGuardian(tx *transaction.Transaction, account s
 // ShouldIncreaseNonce -
 func (txProc *txProcessor) ShouldIncreaseNonce(executionErr error) bool {
 	return txProc.shouldIncreaseNonce(executionErr)
+}
+
+// AddUnExecutableLog -
+func (txProc *txProcessor) AddUnExecutableLog(executionErr error, originalTxHash []byte, originalTx data.TransactionHandler) error {
+	return txProc.addUnExecutableLog(executionErr, originalTxHash, originalTx)
 }

--- a/process/transaction/export_test.go
+++ b/process/transaction/export_test.go
@@ -94,7 +94,7 @@ func (txProc *txProcessor) ShouldIncreaseNonce(executionErr error) bool {
 	return txProc.shouldIncreaseNonce(executionErr)
 }
 
-// AddUnExecutableLog -
-func (txProc *txProcessor) AddUnExecutableLog(executionErr error, originalTxHash []byte, originalTx data.TransactionHandler) error {
-	return txProc.addUnExecutableLog(executionErr, originalTxHash, originalTx)
+// AddNonExecutableLog -
+func (txProc *txProcessor) AddNonExecutableLog(executionErr error, originalTxHash []byte, originalTx data.TransactionHandler) error {
+	return txProc.addNonExecutableLog(executionErr, originalTxHash, originalTx)
 }

--- a/process/transaction/shardProcess.go
+++ b/process/transaction/shardProcess.go
@@ -714,7 +714,7 @@ func (txProc *txProcessor) removeValueAndConsumedFeeFromUser(
 		userAcnt.IncreaseNonce(1)
 	}
 
-	err = txProc.addUnExecutableLog(executionErr, originalTxHash, originalTx)
+	err = txProc.addNonExecutableLog(executionErr, originalTxHash, originalTx)
 	if err != nil {
 		return err
 	}
@@ -727,8 +727,8 @@ func (txProc *txProcessor) removeValueAndConsumedFeeFromUser(
 	return nil
 }
 
-func (txProc *txProcessor) addUnExecutableLog(executionErr error, originalTxHash []byte, originalTx data.TransactionHandler) error {
-	if !isUnExecutableError(executionErr) {
+func (txProc *txProcessor) addNonExecutableLog(executionErr error, originalTxHash []byte, originalTx data.TransactionHandler) error {
+	if !isNonExecutableError(executionErr) {
 		return nil
 	}
 
@@ -985,14 +985,14 @@ func (txProc *txProcessor) shouldIncreaseNonce(executionErr error) bool {
 		return true
 	}
 
-	if isUnExecutableError(executionErr) {
+	if isNonExecutableError(executionErr) {
 		return false
 	}
 
 	return true
 }
 
-func isUnExecutableError(executionErr error) bool {
+func isNonExecutableError(executionErr error) bool {
 	return errors.Is(executionErr, process.ErrLowerNonceInTransaction) ||
 		errors.Is(executionErr, process.ErrHigherNonceInTransaction) ||
 		errors.Is(executionErr, process.ErrTransactionNotExecutable)

--- a/process/transaction/shardProcess_test.go
+++ b/process/transaction/shardProcess_test.go
@@ -3303,7 +3303,7 @@ func TestTxProcessor_AddNonExecutableLog(t *testing.T) {
 	originalTxHash, err := core.CalculateHash(args.Marshalizer, args.Hasher, originalTx)
 	assert.Nil(t, err)
 
-	t.Run("not an non-executable error should not add", func(t *testing.T) {
+	t.Run("not a non-executable error should not record log", func(t *testing.T) {
 		t.Parallel()
 
 		argsLocal := args
@@ -3318,7 +3318,7 @@ func TestTxProcessor_AddNonExecutableLog(t *testing.T) {
 		err = txProc.AddNonExecutableLog(errors.New("random error"), originalTxHash, originalTx)
 		assert.Nil(t, err)
 	})
-	t.Run("is execution error should record log", func(t *testing.T) {
+	t.Run("is non executable tx error should record log", func(t *testing.T) {
 		t.Parallel()
 
 		argsLocal := args

--- a/process/transaction/shardProcess_test.go
+++ b/process/transaction/shardProcess_test.go
@@ -3290,7 +3290,7 @@ func TestTxProcessor_shouldIncreaseNonce(t *testing.T) {
 	})
 }
 
-func TestTxProcessor_AddUnExecutableLog(t *testing.T) {
+func TestTxProcessor_AddNonExecutableLog(t *testing.T) {
 	t.Parallel()
 
 	args := createArgsForTxProcessor()
@@ -3303,7 +3303,7 @@ func TestTxProcessor_AddUnExecutableLog(t *testing.T) {
 	originalTxHash, err := core.CalculateHash(args.Marshalizer, args.Hasher, originalTx)
 	assert.Nil(t, err)
 
-	t.Run("not an un-executable error should not add", func(t *testing.T) {
+	t.Run("not an non-executable error should not add", func(t *testing.T) {
 		t.Parallel()
 
 		argsLocal := args
@@ -3315,7 +3315,7 @@ func TestTxProcessor_AddUnExecutableLog(t *testing.T) {
 			},
 		}
 		txProc, _ := txproc.NewTxProcessor(argsLocal)
-		err = txProc.AddUnExecutableLog(errors.New("random error"), originalTxHash, originalTx)
+		err = txProc.AddNonExecutableLog(errors.New("random error"), originalTxHash, originalTx)
 		assert.Nil(t, err)
 	})
 	t.Run("is execution error should record log", func(t *testing.T) {
@@ -3340,13 +3340,13 @@ func TestTxProcessor_AddUnExecutableLog(t *testing.T) {
 		}
 
 		txProc, _ := txproc.NewTxProcessor(argsLocal)
-		err = txProc.AddUnExecutableLog(process.ErrLowerNonceInTransaction, originalTxHash, originalTx)
+		err = txProc.AddNonExecutableLog(process.ErrLowerNonceInTransaction, originalTxHash, originalTx)
 		assert.Nil(t, err)
 
-		err = txProc.AddUnExecutableLog(process.ErrHigherNonceInTransaction, originalTxHash, originalTx)
+		err = txProc.AddNonExecutableLog(process.ErrHigherNonceInTransaction, originalTxHash, originalTx)
 		assert.Nil(t, err)
 
-		err = txProc.AddUnExecutableLog(process.ErrTransactionNotExecutable, originalTxHash, originalTx)
+		err = txProc.AddNonExecutableLog(process.ErrTransactionNotExecutable, originalTxHash, originalTx)
 		assert.Nil(t, err)
 
 		assert.Equal(t, 3, numLogsSaved)

--- a/process/transaction/shardProcess_test.go
+++ b/process/transaction/shardProcess_test.go
@@ -91,6 +91,7 @@ func createArgsForTxProcessor() txproc.ArgsNewTxProcessor {
 		},
 		GuardianChecker:  &guardianMocks.GuardedAccountHandlerStub{},
 		TxVersionChecker: &testscommon.TxVersionCheckerStub{},
+		TxLogsProcessor:  &mock.TxLogsProcessorStub{},
 	}
 	return args
 }
@@ -264,6 +265,17 @@ func TestNewTxProcessor_NilEnableEpochsHandlerShouldErr(t *testing.T) {
 	txProc, err := txproc.NewTxProcessor(args)
 
 	assert.Equal(t, process.ErrNilEnableEpochsHandler, err)
+	assert.Nil(t, txProc)
+}
+
+func TestNewTxProcessor_NilTxLogsProcessorShouldErr(t *testing.T) {
+	t.Parallel()
+
+	args := createArgsForTxProcessor()
+	args.TxLogsProcessor = nil
+	txProc, err := txproc.NewTxProcessor(args)
+
+	assert.Equal(t, process.ErrNilTxLogsProcessor, err)
 	assert.Nil(t, txProc)
 }
 
@@ -3275,5 +3287,68 @@ func TestTxProcessor_shouldIncreaseNonce(t *testing.T) {
 		assert.False(t, txProc.ShouldIncreaseNonce(process.ErrLowerNonceInTransaction))
 		assert.False(t, txProc.ShouldIncreaseNonce(process.ErrHigherNonceInTransaction))
 		assert.False(t, txProc.ShouldIncreaseNonce(process.ErrTransactionNotExecutable))
+	})
+}
+
+func TestTxProcessor_AddUnExecutableLog(t *testing.T) {
+	t.Parallel()
+
+	args := createArgsForTxProcessor()
+	sender := []byte("sender")
+	relayer := []byte("relayer")
+	originalTx := &transaction.Transaction{
+		SndAddr: relayer,
+		RcvAddr: sender,
+	}
+	originalTxHash, err := core.CalculateHash(args.Marshalizer, args.Hasher, originalTx)
+	assert.Nil(t, err)
+
+	t.Run("not an un-executable error should not add", func(t *testing.T) {
+		t.Parallel()
+
+		argsLocal := args
+		argsLocal.TxLogsProcessor = &mock.TxLogsProcessorStub{
+			SaveLogCalled: func(txHash []byte, tx data.TransactionHandler, vmLogs []*vmcommon.LogEntry) error {
+				assert.Fail(t, "should have not called SaveLog")
+
+				return nil
+			},
+		}
+		txProc, _ := txproc.NewTxProcessor(argsLocal)
+		err = txProc.AddUnExecutableLog(errors.New("random error"), originalTxHash, originalTx)
+		assert.Nil(t, err)
+	})
+	t.Run("is execution error should record log", func(t *testing.T) {
+		t.Parallel()
+
+		argsLocal := args
+		numLogsSaved := 0
+		argsLocal.TxLogsProcessor = &mock.TxLogsProcessorStub{
+			SaveLogCalled: func(txHash []byte, tx data.TransactionHandler, vmLogs []*vmcommon.LogEntry) error {
+				assert.Equal(t, originalTxHash, txHash)
+				assert.Equal(t, originalTx, tx)
+				assert.Equal(t, 1, len(vmLogs))
+				firstLog := vmLogs[0]
+				assert.Equal(t, core.SignalErrorOperation, string(firstLog.Identifier))
+				assert.Equal(t, sender, firstLog.Address)
+				assert.Empty(t, firstLog.Data)
+				assert.Empty(t, firstLog.Topics)
+				numLogsSaved++
+
+				return nil
+			},
+		}
+
+		txProc, _ := txproc.NewTxProcessor(argsLocal)
+		err = txProc.AddUnExecutableLog(process.ErrLowerNonceInTransaction, originalTxHash, originalTx)
+		assert.Nil(t, err)
+
+		err = txProc.AddUnExecutableLog(process.ErrHigherNonceInTransaction, originalTxHash, originalTx)
+		assert.Nil(t, err)
+
+		err = txProc.AddUnExecutableLog(process.ErrTransactionNotExecutable, originalTxHash, originalTx)
+		assert.Nil(t, err)
+
+		assert.Equal(t, 3, numLogsSaved)
 	})
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- It is harder now to figure out the status of a failed relayed transaction only by querying the REST API routes
  
## Proposed changes
- added logs for the non-executable relayed transactions

## Testing procedure
- standard system test + failed relayed v1 & v2 transactions. `signalError` logs should appear for those transactions

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
