### PR TITLE
fix snapshot after restart

### DIFF
--- a/common/interface.go
+++ b/common/interface.go
@@ -83,6 +83,7 @@ type StorageManager interface {
 	ExitPruningBufferingMode()
 	AddDirtyCheckpointHashes([]byte, ModifiedHashes) bool
 	Remove(hash []byte) error
+	RemoveFromAllEpochs(hash []byte) error
 	SetEpochForPutOperation(uint32)
 	ShouldTakeSnapshot() bool
 	GetBaseTrieStorageManager() StorageManager

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -28,7 +28,7 @@ import (
 const (
 	leavesChannelSize       = 100
 	missingNodesChannelSize = 100
-	lastSnapshotStarted     = "lastSnapshot"
+	lastSnapshot            = "lastSnapshot"
 	userTrieSnapshotMsg     = "snapshotState user trie"
 	peerTrieSnapshotMsg     = "snapshotState peer trie"
 )
@@ -202,7 +202,7 @@ func startSnapshotAfterRestart(adb AccountsAdapter, tsm common.StorageManager, p
 		return
 	}
 
-	rootHash, err := tsm.Get([]byte(lastSnapshotStarted))
+	rootHash, err := tsm.GetFromCurrentEpoch([]byte(lastSnapshot))
 	if err != nil {
 		log.Debug("startSnapshotAfterRestart root hash", "error", err)
 		return
@@ -1183,6 +1183,11 @@ func (adb *AccountsDB) prepareSnapshot(rootHash []byte) (common.StorageManager, 
 		return nil, 0, false
 	}
 
+	defer func() {
+		err = trieStorageManager.PutInEpoch([]byte(lastSnapshot), rootHash, epoch)
+		handleLoggingWhenError("could not set lastSnapshot", err, "rootHash", rootHash)
+	}()
+
 	if !adb.shouldTakeSnapshot(trieStorageManager, rootHash, epoch) {
 		log.Debug("skipping snapshot",
 			"last snapshot rootHash", adb.lastSnapshot.rootHash,
@@ -1197,8 +1202,6 @@ func (adb *AccountsDB) prepareSnapshot(rootHash []byte) (common.StorageManager, 
 	adb.isSnapshotInProgress.SetValue(true)
 	adb.lastSnapshot.rootHash = rootHash
 	adb.lastSnapshot.epoch = epoch
-	err = trieStorageManager.Put([]byte(lastSnapshotStarted), rootHash)
-	handleLoggingWhenError("could not set lastSnapshotStarted", err, "rootHash", rootHash)
 	trieStorageManager.EnterPruningBufferingMode()
 
 	return trieStorageManager, epoch, true
@@ -1282,8 +1285,8 @@ func (adb *AccountsDB) processSnapshotCompletion(
 		return
 	}
 
-	err := trieStorageManager.Remove([]byte(lastSnapshotStarted))
-	handleLoggingWhenError("could not remove lastSnapshotStarted", err, "rootHash", rootHash)
+	err := trieStorageManager.RemoveFromAllEpochs([]byte(lastSnapshot))
+	handleLoggingWhenError("could not remove lastSnapshot", err, "rootHash", rootHash)
 
 	log.Debug("set activeDB in epoch", "epoch", epoch)
 	errPut := trieStorageManager.PutInEpochWithoutCache([]byte(common.ActiveDBKey), []byte(common.ActiveDBVal), epoch)

--- a/state/accountsDB_test.go
+++ b/state/accountsDB_test.go
@@ -981,22 +981,16 @@ func TestAccountsDB_SnapshotStateOnAClosedStorageManagerShouldNotMarkActiveDB(t 
 				IsClosedCalled: func() bool {
 					return true
 				},
-				PutCalled: func(key []byte, val []byte) error {
-					mut.Lock()
-					defer mut.Unlock()
-
-					if string(key) == state.LastSnapshotStarted {
-						lastSnapshotStartedWasPut = true
-					}
-
-					return nil
-				},
 				PutInEpochCalled: func(key []byte, val []byte, epoch uint32) error {
 					mut.Lock()
 					defer mut.Unlock()
 
 					if string(key) == common.ActiveDBKey {
 						activeDBWasPut = true
+					}
+
+					if string(key) == state.LastSnapshotStarted {
+						lastSnapshotStartedWasPut = true
 					}
 
 					return nil
@@ -1035,22 +1029,16 @@ func TestAccountsDB_SnapshotStateWithErrorsShouldNotMarkActiveDB(t *testing.T) {
 				IsClosedCalled: func() bool {
 					return false
 				},
-				PutCalled: func(key []byte, val []byte) error {
-					mut.Lock()
-					defer mut.Unlock()
-
-					if string(key) == state.LastSnapshotStarted {
-						lastSnapshotStartedWasPut = true
-					}
-
-					return nil
-				},
 				PutInEpochCalled: func(key []byte, val []byte, epoch uint32) error {
 					mut.Lock()
 					defer mut.Unlock()
 
 					if string(key) == common.ActiveDBKey {
 						activeDBWasPut = true
+					}
+
+					if string(key) == state.LastSnapshotStarted {
+						lastSnapshotStartedWasPut = true
 					}
 
 					return nil

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // LastSnapshotStarted -
-const LastSnapshotStarted = lastSnapshotStarted
+const LastSnapshotStarted = lastSnapshot
 
 // NewEmptyBaseAccount -
 func NewEmptyBaseAccount(address []byte, tracker DataTrieTracker) *baseAccount {

--- a/state/peerAccountsDB_test.go
+++ b/state/peerAccountsDB_test.go
@@ -453,22 +453,16 @@ func TestPeerAccountsDB_SnapshotStateOnAClosedStorageManagerShouldNotMarkActiveD
 				IsClosedCalled: func() bool {
 					return true
 				},
-				PutCalled: func(key []byte, val []byte) error {
-					mut.Lock()
-					defer mut.Unlock()
-
-					if string(key) == state.LastSnapshotStarted {
-						lastSnapshotStartedWasPut = true
-					}
-
-					return nil
-				},
 				PutInEpochCalled: func(key []byte, val []byte, epoch uint32) error {
 					mut.Lock()
 					defer mut.Unlock()
 
 					if string(key) == common.ActiveDBKey {
 						activeDBWasPut = true
+					}
+
+					if string(key) == state.LastSnapshotStarted {
+						lastSnapshotStartedWasPut = true
 					}
 
 					return nil

--- a/storage/pruning/triePruningStorer.go
+++ b/storage/pruning/triePruningStorer.go
@@ -164,6 +164,23 @@ func (ps *triePruningStorer) GetLatestStorageEpoch() (uint32, error) {
 	return ps.activePersisters[currentEpochIndex].epoch, nil
 }
 
+// RemoveFromAllEpochs removes the data associated to the given key from both cache and epochs storers
+func (ps *triePruningStorer) RemoveFromAllEpochs(key []byte) error {
+	var err error
+	ps.cacher.Remove(key)
+
+	ps.lock.RLock()
+	defer ps.lock.RUnlock()
+	for _, pd := range ps.activePersisters {
+		err = pd.persister.Remove(key)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (ps *triePruningStorer) IsInterfaceNil() bool {
 	return ps == nil

--- a/testscommon/snapshotPruningStorerMock.go
+++ b/testscommon/snapshotPruningStorerMock.go
@@ -49,6 +49,11 @@ func (spsm *SnapshotPruningStorerMock) GetLatestStorageEpoch() (uint32, error) {
 	return 0, nil
 }
 
+// RemoveFromAllEpochs -
+func (spsm *SnapshotPruningStorerMock) RemoveFromAllEpochs(_ []byte) error {
+	return nil
+}
+
 // RemoveFromCurrentEpoch -
 func (spsm *SnapshotPruningStorerMock) RemoveFromCurrentEpoch(key []byte) error {
 	return spsm.Remove(key)

--- a/testscommon/storageManagerStub.go
+++ b/testscommon/storageManagerStub.go
@@ -28,6 +28,7 @@ type StorageManagerStub struct {
 	IsClosedCalled                         func() bool
 	RemoveFromCheckpointHashesHolderCalled func([]byte)
 	GetBaseTrieStorageManagerCalled        func() common.StorageManager
+	RemoveFromAllEpochsCalled              func(hash []byte) error
 }
 
 // Put -
@@ -209,6 +210,15 @@ func (sms *StorageManagerStub) RemoveFromCheckpointHashesHolder(hash []byte) {
 func (sms *StorageManagerStub) GetBaseTrieStorageManager() common.StorageManager {
 	if sms.GetBaseTrieStorageManagerCalled != nil {
 		return sms.GetBaseTrieStorageManagerCalled()
+	}
+
+	return nil
+}
+
+// RemoveFromAllEpochs -
+func (sms *StorageManagerStub) RemoveFromAllEpochs(hash []byte) error {
+	if sms.RemoveFromAllEpochsCalled != nil {
+		return sms.RemoveFromAllEpochsCalled(hash)
 	}
 
 	return nil

--- a/testscommon/trie/snapshotPruningStorerStub.go
+++ b/testscommon/trie/snapshotPruningStorerStub.go
@@ -16,6 +16,7 @@ type SnapshotPruningStorerStub struct {
 	PutInEpochWithoutCacheCalled               func(key []byte, data []byte, epoch uint32) error
 	GetLatestStorageEpochCalled                func() (uint32, error)
 	RemoveFromCurrentEpochCalled               func(key []byte) error
+	RemoveFromAllEpochsCalled                  func(key []byte) error
 }
 
 // GetFromOldEpochsWithoutAddingToCache -
@@ -86,5 +87,14 @@ func (spss *SnapshotPruningStorerStub) RemoveFromCurrentEpoch(key []byte) error 
 	if spss.RemoveFromCurrentEpochCalled != nil {
 		return spss.RemoveFromCurrentEpochCalled(key)
 	}
+	return spss.Remove(key)
+}
+
+// RemoveFromAllEpochs -
+func (spss *SnapshotPruningStorerStub) RemoveFromAllEpochs(key []byte) error {
+	if spss.RemoveFromAllEpochsCalled != nil {
+		return spss.RemoveFromAllEpochsCalled(key)
+	}
+	
 	return spss.Remove(key)
 }

--- a/trie/interface.go
+++ b/trie/interface.go
@@ -105,6 +105,7 @@ type snapshotPruningStorer interface {
 	GetFromCurrentEpoch(key []byte) ([]byte, error)
 	GetFromEpoch(key []byte, epoch uint32) ([]byte, error)
 	RemoveFromCurrentEpoch(key []byte) error
+	RemoveFromAllEpochs(key []byte) error
 }
 
 // EpochNotifier can notify upon an epoch change and provide the current epoch

--- a/trie/trieStorageManager.go
+++ b/trie/trieStorageManager.go
@@ -567,6 +567,20 @@ func (tsm *trieStorageManager) Remove(hash []byte) error {
 	return storer.RemoveFromCurrentEpoch(hash)
 }
 
+// RemoveFromAllEpochs removes the given hash from all epochs
+func (tsm *trieStorageManager) RemoveFromAllEpochs(hash []byte) error {
+	tsm.storageOperationMutex.Lock()
+	defer tsm.storageOperationMutex.Unlock()
+
+	tsm.checkpointHashesHolder.Remove(hash)
+	storer, ok := tsm.mainStorer.(snapshotPruningStorer)
+	if !ok {
+		return fmt.Errorf("trie storage manager: main storer does not implement snapshotPruningStorer interface: %T", tsm.mainStorer)
+	}
+
+	return storer.RemoveFromAllEpochs(hash)
+}
+
 // RemoveFromCheckpointHashesHolder removes the given hash from the checkpointHashesHolder
 func (tsm *trieStorageManager) RemoveFromCheckpointHashesHolder(hash []byte) {
 	//TODO check if the mutex is really needed here

--- a/trie/trieStorageManager_test.go
+++ b/trie/trieStorageManager_test.go
@@ -254,6 +254,32 @@ func TestTrieStorageManager_Remove(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestTrieStorageManager_RemoveFromAllEpochs(t *testing.T) {
+	t.Parallel()
+
+	removeFromAllEpochsCalled := false
+	removeFromCheckpointCalled := false
+	args := getNewTrieStorageManagerArgs()
+	args.MainStorer = &trieMock.SnapshotPruningStorerStub{
+		MemDbMock: testscommon.NewMemDbMock(),
+		RemoveFromAllEpochsCalled: func(key []byte) error {
+			removeFromAllEpochsCalled = true
+			return nil
+		},
+	}
+	args.CheckpointHashesHolder = &trieMock.CheckpointHashesHolderStub{
+		RemoveCalled: func(bytes []byte) {
+			removeFromCheckpointCalled = true
+		},
+	}
+	ts, _ := trie.NewTrieStorageManager(args)
+
+	err := ts.RemoveFromAllEpochs([]byte("key"))
+	assert.Nil(t, err)
+	assert.True(t, removeFromAllEpochsCalled)
+	assert.True(t, removeFromCheckpointCalled)
+}
+
 func TestTrieStorageManager_PutInEpochClosedDb(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Reasoning behind the pull request
- When a snapshot starts, the root hash of that snapshot is saved in storage at a special key. After that snapshot is finished, that key is removed from storage. If a node restarts before that snapshot is finished, when the node restarts that snapshot will be also restarted.
- If a snapshot takes more than one epoch and the node restarts before the snapshot is finished, the snapshot will restart in the new epoch but with the old root hash (that was saved at the special key in storage) 

  
## Proposed changes
- Save the root hash of the snapshot in storage even if the snapshot is skipped. This way, when a restart occurs, the snapshot that will start after the restart will be of the latest snapshot root hash
- After a snapshot is finished, remove that special key (which holds the last snapshot root hash) from all the epochs. This way, when a node restarts, it will not restart an old snapshot

## Testing procedure
- Normal testing procedure
- Add a delay during snapshots that will force the snapshots to last more than one epoch, and then restart. Check that the correct snapshot is started after the node restarts.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
