### PR TITLE
Update vm-common and `upgradeProperties` log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/multiversx/mx-chain-logger-go v1.0.11
 	github.com/multiversx/mx-chain-p2p-go v1.0.14
 	github.com/multiversx/mx-chain-storage-go v1.0.7
-	github.com/multiversx/mx-chain-vm-common-go v1.4.4-0.20230614131748-e022f38797ac
+	github.com/multiversx/mx-chain-vm-common-go v1.3.42
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.54
 	github.com/multiversx/mx-chain-vm-v1_3-go v1.3.55
 	github.com/multiversx/mx-chain-vm-v1_4-go v1.4.81

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/multiversx/mx-chain-logger-go v1.0.11
 	github.com/multiversx/mx-chain-p2p-go v1.0.14
 	github.com/multiversx/mx-chain-storage-go v1.0.7
-	github.com/multiversx/mx-chain-vm-common-go v1.3.41
+	github.com/multiversx/mx-chain-vm-common-go v1.4.4-0.20230613071024-e22c1e6ac6b4
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.54
 	github.com/multiversx/mx-chain-vm-v1_3-go v1.3.55
 	github.com/multiversx/mx-chain-vm-v1_4-go v1.4.81

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/multiversx/mx-chain-logger-go v1.0.11
 	github.com/multiversx/mx-chain-p2p-go v1.0.14
 	github.com/multiversx/mx-chain-storage-go v1.0.7
-	github.com/multiversx/mx-chain-vm-common-go v1.4.4-0.20230613071024-e22c1e6ac6b4
+	github.com/multiversx/mx-chain-vm-common-go v1.4.4-0.20230614131748-e022f38797ac
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.54
 	github.com/multiversx/mx-chain-vm-v1_3-go v1.3.55
 	github.com/multiversx/mx-chain-vm-v1_4-go v1.4.81

--- a/go.sum
+++ b/go.sum
@@ -630,8 +630,8 @@ github.com/multiversx/mx-chain-storage-go v1.0.7 h1:UqLo/OLTD3IHiE/TB/SEdNRV1GG2
 github.com/multiversx/mx-chain-storage-go v1.0.7/go.mod h1:gtKoV32Cg2Uy8deHzF8Ud0qAl0zv92FvWgPSYIP0Zmg=
 github.com/multiversx/mx-chain-vm-common-go v1.3.40/go.mod h1:r+aILrY07ue89PH+D+B+Pp0viO1U3kN98t1pXneSgkE=
 github.com/multiversx/mx-chain-vm-common-go v1.3.41/go.mod h1:r+aILrY07ue89PH+D+B+Pp0viO1U3kN98t1pXneSgkE=
-github.com/multiversx/mx-chain-vm-common-go v1.4.4-0.20230613071024-e22c1e6ac6b4 h1:+WyrdSZXwjxtYTEB3OK1s0Lu/xHpEtNDAgziewlZ1DA=
-github.com/multiversx/mx-chain-vm-common-go v1.4.4-0.20230613071024-e22c1e6ac6b4/go.mod h1:r+aILrY07ue89PH+D+B+Pp0viO1U3kN98t1pXneSgkE=
+github.com/multiversx/mx-chain-vm-common-go v1.4.4-0.20230614131748-e022f38797ac h1:Jjlsw3fMqAFsjwzo/jnqQYEf55wK5xHoV+/JqqImfvc=
+github.com/multiversx/mx-chain-vm-common-go v1.4.4-0.20230614131748-e022f38797ac/go.mod h1:r+aILrY07ue89PH+D+B+Pp0viO1U3kN98t1pXneSgkE=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.54 h1:c+S0xhfOMtwWEJHMqoPf8plF3sLnz3euPj4Rd/wN2UQ=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.54/go.mod h1:iuM50SqgelbKYNEm9s4BZcWczIgyCJIGFKajGUCDVm0=
 github.com/multiversx/mx-chain-vm-v1_3-go v1.3.55 h1:hmo/QQ/qY+WgsMQeBODIX+tEnM/XIf7izNs9+WbKg4Y=

--- a/go.sum
+++ b/go.sum
@@ -630,8 +630,8 @@ github.com/multiversx/mx-chain-storage-go v1.0.7 h1:UqLo/OLTD3IHiE/TB/SEdNRV1GG2
 github.com/multiversx/mx-chain-storage-go v1.0.7/go.mod h1:gtKoV32Cg2Uy8deHzF8Ud0qAl0zv92FvWgPSYIP0Zmg=
 github.com/multiversx/mx-chain-vm-common-go v1.3.40/go.mod h1:r+aILrY07ue89PH+D+B+Pp0viO1U3kN98t1pXneSgkE=
 github.com/multiversx/mx-chain-vm-common-go v1.3.41/go.mod h1:r+aILrY07ue89PH+D+B+Pp0viO1U3kN98t1pXneSgkE=
-github.com/multiversx/mx-chain-vm-common-go v1.4.4-0.20230614131748-e022f38797ac h1:Jjlsw3fMqAFsjwzo/jnqQYEf55wK5xHoV+/JqqImfvc=
-github.com/multiversx/mx-chain-vm-common-go v1.4.4-0.20230614131748-e022f38797ac/go.mod h1:r+aILrY07ue89PH+D+B+Pp0viO1U3kN98t1pXneSgkE=
+github.com/multiversx/mx-chain-vm-common-go v1.3.42 h1:avhgUwi6f+wpHqaBk76j6islLzUlSRBXwisKoZnUXpk=
+github.com/multiversx/mx-chain-vm-common-go v1.3.42/go.mod h1:r+aILrY07ue89PH+D+B+Pp0viO1U3kN98t1pXneSgkE=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.54 h1:c+S0xhfOMtwWEJHMqoPf8plF3sLnz3euPj4Rd/wN2UQ=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.54/go.mod h1:iuM50SqgelbKYNEm9s4BZcWczIgyCJIGFKajGUCDVm0=
 github.com/multiversx/mx-chain-vm-v1_3-go v1.3.55 h1:hmo/QQ/qY+WgsMQeBODIX+tEnM/XIf7izNs9+WbKg4Y=

--- a/go.sum
+++ b/go.sum
@@ -629,8 +629,9 @@ github.com/multiversx/mx-chain-p2p-go v1.0.14/go.mod h1:64lqBWpQa/sDwdmzzHb2waT2
 github.com/multiversx/mx-chain-storage-go v1.0.7 h1:UqLo/OLTD3IHiE/TB/SEdNRV1GG2f1R6vIP5ehHwCNw=
 github.com/multiversx/mx-chain-storage-go v1.0.7/go.mod h1:gtKoV32Cg2Uy8deHzF8Ud0qAl0zv92FvWgPSYIP0Zmg=
 github.com/multiversx/mx-chain-vm-common-go v1.3.40/go.mod h1:r+aILrY07ue89PH+D+B+Pp0viO1U3kN98t1pXneSgkE=
-github.com/multiversx/mx-chain-vm-common-go v1.3.41 h1:jIgv5PvTUNx96v+0a0W+qIulyUYT9bbaTdBlMxwQbOQ=
 github.com/multiversx/mx-chain-vm-common-go v1.3.41/go.mod h1:r+aILrY07ue89PH+D+B+Pp0viO1U3kN98t1pXneSgkE=
+github.com/multiversx/mx-chain-vm-common-go v1.4.4-0.20230613071024-e22c1e6ac6b4 h1:+WyrdSZXwjxtYTEB3OK1s0Lu/xHpEtNDAgziewlZ1DA=
+github.com/multiversx/mx-chain-vm-common-go v1.4.4-0.20230613071024-e22c1e6ac6b4/go.mod h1:r+aILrY07ue89PH+D+B+Pp0viO1U3kN98t1pXneSgkE=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.54 h1:c+S0xhfOMtwWEJHMqoPf8plF3sLnz3euPj4Rd/wN2UQ=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.54/go.mod h1:iuM50SqgelbKYNEm9s4BZcWczIgyCJIGFKajGUCDVm0=
 github.com/multiversx/mx-chain-vm-v1_3-go v1.3.55 h1:hmo/QQ/qY+WgsMQeBODIX+tEnM/XIf7izNs9+WbKg4Y=

--- a/vm/systemSmartContracts/esdt.go
+++ b/vm/systemSmartContracts/esdt.go
@@ -694,7 +694,19 @@ func (e *esdt) upgradeProperties(tokenIdentifier []byte, token *ESDTDataV2, args
 		mintBurnable = false
 	}
 
+	topics := make([][]byte, 0)
+	nonce := big.NewInt(0)
+	topics = append(topics, tokenIdentifier, nonce.Bytes())
+	logEntry := &vmcommon.LogEntry{
+		Identifier: []byte(upgradeProperties),
+		Address:    callerAddr,
+	}
+
 	if len(args) == 0 {
+		topics = append(topics, []byte(upgradable), boolToSlice(token.Upgradable), []byte(canAddSpecialRoles), boolToSlice(token.CanAddSpecialRoles))
+		logEntry.Topics = topics
+		e.eei.AddLogEntry(logEntry)
+
 		return nil
 	}
 	if len(args)%2 != 0 {
@@ -752,11 +764,7 @@ func (e *esdt) upgradeProperties(tokenIdentifier []byte, token *ESDTDataV2, args
 		}
 	}
 
-	topics := make([][]byte, 0)
-	nonce := big.NewInt(0)
-	topics = append(topics, tokenIdentifier, nonce.Bytes())
 	topics = append(topics, args...)
-
 	if !isUpgradablePropertyInArgs {
 		topics = append(topics, []byte(upgradable), boolToSlice(token.Upgradable))
 	}
@@ -764,11 +772,7 @@ func (e *esdt) upgradeProperties(tokenIdentifier []byte, token *ESDTDataV2, args
 		topics = append(topics, []byte(canAddSpecialRoles), boolToSlice(token.CanAddSpecialRoles))
 	}
 
-	logEntry := &vmcommon.LogEntry{
-		Identifier: []byte(upgradeProperties),
-		Address:    callerAddr,
-		Topics:     topics,
-	}
+	logEntry.Topics = topics
 	e.eei.AddLogEntry(logEntry)
 
 	return nil

--- a/vm/systemSmartContracts/esdt.go
+++ b/vm/systemSmartContracts/esdt.go
@@ -701,6 +701,8 @@ func (e *esdt) upgradeProperties(tokenIdentifier []byte, token *ESDTDataV2, args
 		return vm.ErrInvalidNumOfArguments
 	}
 
+	isUpgradablePropertyInArgs := false
+	isCanAddSpecialRolePropertyInArgs := false
 	for i := 0; i < len(args); i += 2 {
 		optionalArg := string(args[i])
 		val, err := checkAndGetSetting(string(args[i+1]))
@@ -726,10 +728,12 @@ func (e *esdt) upgradeProperties(tokenIdentifier []byte, token *ESDTDataV2, args
 			token.CanWipe = val
 		case upgradable:
 			token.Upgradable = val
+			isUpgradablePropertyInArgs = true
 		case canChangeOwner:
 			token.CanChangeOwner = val
 		case canAddSpecialRoles:
 			token.CanAddSpecialRoles = val
+			isCanAddSpecialRolePropertyInArgs = true
 		case canTransferNFTCreateRole:
 			token.CanTransferNFTCreateRole = val
 		case canCreateMultiShard:
@@ -752,6 +756,14 @@ func (e *esdt) upgradeProperties(tokenIdentifier []byte, token *ESDTDataV2, args
 	nonce := big.NewInt(0)
 	topics = append(topics, tokenIdentifier, nonce.Bytes())
 	topics = append(topics, args...)
+
+	if !isUpgradablePropertyInArgs {
+		topics = append(topics, []byte(upgradable), boolToSlice(token.Upgradable))
+	}
+	if !isCanAddSpecialRolePropertyInArgs {
+		topics = append(topics, []byte(canAddSpecialRoles), boolToSlice(token.CanAddSpecialRoles))
+	}
+
 	logEntry := &vmcommon.LogEntry{
 		Identifier: []byte(upgradeProperties),
 		Address:    callerAddr,

--- a/vm/systemSmartContracts/esdt_test.go
+++ b/vm/systemSmartContracts/esdt_test.go
@@ -220,6 +220,14 @@ func TestEsdt_ExecuteIssueWithMultiNFTCreate(t *testing.T) {
 	returnCode = e.Execute(vmInput)
 	assert.Equal(t, vmcommon.Ok, returnCode)
 
+	upgradePropertiesLog := eei.logs[0]
+	expectedTopics := [][]byte{[]byte("TICKER-75fd57"), big.NewInt(0).Bytes(), []byte(canCreateMultiShard), boolToSlice(true), []byte(upgradable), boolToSlice(true), []byte(canAddSpecialRoles), boolToSlice(true)}
+	assert.Equal(t, &vmcommon.LogEntry{
+		Identifier: []byte(upgradeProperties),
+		Address:    []byte("addr"),
+		Topics:     expectedTopics,
+	}, upgradePropertiesLog)
+
 	lastOutput := eei.output[len(eei.output)-1]
 	token, _ := e.getExistingToken(lastOutput)
 	assert.True(t, token.CanCreateMultiShard)
@@ -252,10 +260,20 @@ func TestEsdt_ExecuteIssue(t *testing.T) {
 
 	vmInput.Arguments = append(vmInput.Arguments, big.NewInt(100).Bytes())
 	vmInput.Arguments = append(vmInput.Arguments, big.NewInt(10).Bytes())
+	vmInput.Arguments = append(vmInput.Arguments, []byte(upgradable), boolToSlice(false))
+	vmInput.Arguments = append(vmInput.Arguments, []byte(canAddSpecialRoles), boolToSlice(false))
 	vmInput.CallValue, _ = big.NewInt(0).SetString(args.ESDTSCConfig.BaseIssuingCost, 10)
 	vmInput.GasProvided = args.GasCost.MetaChainSystemSCsCost.ESDTIssue
 	output = e.Execute(vmInput)
 	assert.Equal(t, vmcommon.Ok, output)
+
+	upgradePropertiesLog := eei.logs[0]
+	expectedTopics := [][]byte{[]byte("TICKER-75fd57"), big.NewInt(0).Bytes(), []byte(upgradable), boolToSlice(false), []byte(canAddSpecialRoles), boolToSlice(false)}
+	assert.Equal(t, &vmcommon.LogEntry{
+		Identifier: []byte(upgradeProperties),
+		Address:    []byte("addr"),
+		Topics:     expectedTopics,
+	}, upgradePropertiesLog)
 
 	vmInput.Arguments[0] = []byte("01234567891&*@")
 	output = e.Execute(vmInput)


### PR DESCRIPTION
## Reasoning behind the pull request
- Updated the version of mx-chain-vm-common` modules
- Bug-fix: fixed the log that is generated with the identifier `upgradeProperties`
  
## Proposed changes
- PR from the `mx-chain-vm-common`: https://github.com/multiversx/mx-chain-vm-common-go/pull/211

## Testing procedure
- Make a transaction with `SetGuardian` and check in the Elasticsearch database that the field `operation` is set.
- Do an `issue` ESDT transaction and check that properties `canUpgrade` and `canSetSpecialRole` are true in the log with the `upgradeProperties` identifier

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
