### PR TITLE
fix GitHub workflow docker login

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -27,9 +27,14 @@ jobs:
         run: |
           TAG_VERSION=${{ steps.get_version.outputs.VERSION }}
           cd ${GITHUB_WORKSPACE} && docker build -t "${REGISTRY_HOSTNAME}/${IMAGE_NODE}:${TAG_VERSION}" -f ./docker/multiversx/Dockerfile .
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Push image
         run: |
-          docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_TOKEN }}
           TAG_VERSION=${{ steps.get_version.outputs.VERSION }}
           docker push "${REGISTRY_HOSTNAME}/${IMAGE_NODE}:${TAG_VERSION}"
-          docker logout


### PR DESCRIPTION
## Reasoning behind the pull request
Currently, all executions are failing/red at https://github.com/multiversx/mx-chain-go/actions/workflows/deploy-docker.yml
  
## Proposed changes
Use the official docker action to log in so that images can be automatically published to Docker hub after releasing+building.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- [x] was the PR targeted to the correct branch?
