### PR TITLE
Separate package for data trie tracker

### DIFF
--- a/factory/processing/blockProcessorCreator_test.go
+++ b/factory/processing/blockProcessorCreator_test.go
@@ -127,7 +127,7 @@ func Test_newBlockProcessorCreatorForMeta(t *testing.T) {
 					return nil
 				},
 				LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
-					return accounts.NewEmptyPeerAccount(), nil
+					return accounts.NewPeerAccount(address)
 				},
 			}
 		},

--- a/genesis/process/genesisBlockCreator_test.go
+++ b/genesis/process/genesisBlockCreator_test.go
@@ -181,7 +181,7 @@ func createMockArgument(
 			return nil
 		},
 		LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
-			return accounts.NewEmptyPeerAccount(), nil
+			return accounts.NewPeerAccount(address)
 		},
 	}
 

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -52,6 +52,7 @@ import (
 	"github.com/multiversx/mx-chain-go/state/parsers"
 	"github.com/multiversx/mx-chain-go/state/storagePruningManager"
 	"github.com/multiversx/mx-chain-go/state/storagePruningManager/evictionWaitingList"
+	"github.com/multiversx/mx-chain-go/state/trackableDataTrie"
 	"github.com/multiversx/mx-chain-go/storage"
 	"github.com/multiversx/mx-chain-go/storage/database"
 	"github.com/multiversx/mx-chain-go/storage/pruning"
@@ -932,7 +933,7 @@ func GenerateAddressJournalAccountAccountsDB() ([]byte, state.UserAccountHandler
 	adb, _ := CreateAccountsDB(UserAccount, trieStorage)
 
 	dtlp, _ := parsers.NewDataTrieLeafParser(adr, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
-	dtt, _ := state.NewTrackableDataTrie(adr, &testscommon.HasherStub{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	dtt, _ := trackableDataTrie.NewTrackableDataTrie(adr, &testscommon.HasherStub{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	account, _ := accounts.NewUserAccount(adr, dtt, dtlp)
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/state/accounts"
 	"github.com/multiversx/mx-chain-go/state/parsers"
+	"github.com/multiversx/mx-chain-go/state/trackableDataTrie"
 	"github.com/multiversx/mx-chain-go/storage"
 	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/bootstrapMocks"
@@ -96,7 +97,7 @@ func createMockPubkeyConverter() *testscommon.PubkeyConverterMock {
 
 func createAcc(address []byte) state.UserAccountHandler {
 	dtlp, _ := parsers.NewDataTrieLeafParser(address, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
-	dtt, _ := state.NewTrackableDataTrie(address, &testscommon.HasherStub{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	dtt, _ := trackableDataTrie.NewTrackableDataTrie(address, &testscommon.HasherStub{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 	acc, _ := accounts.NewUserAccount(address, dtt, dtlp)
 
 	return acc

--- a/process/peer/process.go
+++ b/process/peer/process.go
@@ -443,7 +443,7 @@ func (vs *validatorStatistics) getValidatorDataFromLeaves(
 	validators[core.MetachainShardId] = make([]*state.ValidatorInfo, 0)
 
 	for pa := range leavesChannels.LeavesChan {
-		peerAccount, err := vs.unmarshalPeer(pa.Value())
+		peerAccount, err := vs.unmarshalPeer(pa)
 		if err != nil {
 			return nil, err
 		}
@@ -548,9 +548,12 @@ func (vs *validatorStatistics) jailValidatorIfBadRatingAndInactive(validatorAcco
 	validatorAccount.SetListAndIndex(validatorAccount.GetShardId(), string(common.JailedList), validatorAccount.GetIndexInList())
 }
 
-func (vs *validatorStatistics) unmarshalPeer(pa []byte) (state.PeerAccountHandler, error) {
-	peerAccount := accounts.NewEmptyPeerAccount()
-	err := vs.marshalizer.Unmarshal(peerAccount, pa)
+func (vs *validatorStatistics) unmarshalPeer(peerAccountData core.KeyValueHolder) (state.PeerAccountHandler, error) {
+	peerAccount, err := accounts.NewPeerAccount(peerAccountData.Key())
+	if err != nil {
+		return nil, err
+	}
+	err = vs.marshalizer.Unmarshal(peerAccount, peerAccountData.Value())
 	if err != nil {
 		return nil, err
 	}

--- a/process/peer/process_test.go
+++ b/process/peer/process_test.go
@@ -2420,7 +2420,7 @@ func TestValidatorsProvider_PeerAccoutToValidatorInfo(t *testing.T) {
 		UnStakedEpoch:              common.DefaultUnstakedEpoch,
 	}
 
-	peerAccount := accounts.NewEmptyPeerAccount()
+	peerAccount, _ := accounts.NewPeerAccount([]byte("mock address"))
 	peerAccount.PeerAccountData = pad
 
 	validatorStatistics, _ := peer.NewValidatorStatisticsProcessor(arguments)
@@ -2611,7 +2611,7 @@ func TestValidatorStatisticsProcessor_SaveNodesCoordinatorUpdates(t *testing.T) 
 	arguments.PeerAdapter = peerAdapter
 
 	peerAdapter.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
-		peerAcc := accounts.NewEmptyPeerAccount()
+		peerAcc, _ := accounts.NewPeerAccount(address)
 		peerAcc.List = string(common.LeavingList)
 		return peerAcc, nil
 	}
@@ -2630,7 +2630,7 @@ func TestValidatorStatisticsProcessor_SaveNodesCoordinatorUpdates(t *testing.T) 
 	assert.True(t, nodeForcedToRemain)
 
 	peerAdapter.LoadAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
-		return accounts.NewEmptyPeerAccount(), nil
+		return accounts.NewPeerAccount(address)
 	}
 	nodeForcedToRemain, err = validatorStatistics.SaveNodesCoordinatorUpdates(0)
 	assert.Nil(t, err)

--- a/process/rewardTransaction/process_test.go
+++ b/process/rewardTransaction/process_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/mock"
 	"github.com/multiversx/mx-chain-go/process/rewardTransaction"
-	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/state/accounts"
+	"github.com/multiversx/mx-chain-go/state/trackableDataTrie"
 	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
@@ -260,7 +260,7 @@ func TestRewardTxProcessor_ProcessRewardTransactionToASmartContractShouldWork(t 
 
 	address := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6}
 
-	dtt, _ := state.NewTrackableDataTrie(address, &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	dtt, _ := trackableDataTrie.NewTrackableDataTrie(address, &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 	userAccount, _ := accounts.NewUserAccount(address, dtt, &trie.TrieLeafParserStub{})
 	accountsDb := &stateMock.AccountsStub{
 		LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {

--- a/process/scToProtocol/stakingToPeer_test.go
+++ b/process/scToProtocol/stakingToPeer_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/multiversx/mx-chain-go/process/mock"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/state/accounts"
+	"github.com/multiversx/mx-chain-go/state/trackableDataTrie"
 	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
@@ -63,7 +64,7 @@ func createBlockBody() *block.Body {
 }
 
 func createStakingScAccount() state.UserAccountHandler {
-	dtt, _ := state.NewTrackableDataTrie(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	dtt, _ := trackableDataTrie.NewTrackableDataTrie(vm.StakingSCAddress, &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	userAcc, _ := accounts.NewUserAccount(vm.StakingSCAddress, dtt, &trie.TrieLeafParserStub{})
 	return userAcc

--- a/process/sync/trieIterators/tokensSuppliesProcessor_test.go
+++ b/process/sync/trieIterators/tokensSuppliesProcessor_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	coreEsdt "github.com/multiversx/mx-chain-go/dblookupext/esdtSupply"
-	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/state/accounts"
 	"github.com/multiversx/mx-chain-go/state/parsers"
+	"github.com/multiversx/mx-chain-go/state/trackableDataTrie"
 	chainStorage "github.com/multiversx/mx-chain-go/storage"
 	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 	"github.com/multiversx/mx-chain-go/testscommon/genericMocks"
@@ -196,7 +196,7 @@ func TestTokensSuppliesProcessor_HandleTrieAccountIteration(t *testing.T) {
 		args := getTokensSuppliesProcessorArgs()
 		tsp, _ := NewTokensSuppliesProcessor(args)
 
-		dtt, _ := state.NewTrackableDataTrie([]byte("addr"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		dtt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("addr"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		dtlp, _ := parsers.NewDataTrieLeafParser([]byte("addr"), &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		userAcc, _ := accounts.NewUserAccount([]byte("addr"), dtt, dtlp)
 		userAcc.SetRootHash([]byte("rootHash"))

--- a/process/sync/trieIterators/trieAccountsIterator_test.go
+++ b/process/sync/trieIterators/trieAccountsIterator_test.go
@@ -213,7 +213,7 @@ func TestTrieAccountsIterator_Process(t *testing.T) {
 				return nil
 			},
 			GetExistingAccountCalled: func(addressContainer []byte) (vmcommon.AccountHandler, error) {
-				return accounts.NewEmptyPeerAccount(), nil
+				return accounts.NewPeerAccount(addressContainer)
 			},
 		}
 		tai, _ := NewTrieAccountsIterator(args)

--- a/state/accounts/peerAccount.go
+++ b/state/accounts/peerAccount.go
@@ -14,18 +14,6 @@ type peerAccount struct {
 	PeerAccountData
 }
 
-// TODO: replace NewEmptyPeerAccount with GetPeerAccountFromBytes
-
-// NewEmptyPeerAccount returns an empty peerAccount
-func NewEmptyPeerAccount() *peerAccount {
-	return &peerAccount{
-		PeerAccountData: PeerAccountData{
-			AccumulatedFees: big.NewInt(0),
-			UnStakedEpoch:   common.DefaultUnstakedEpoch,
-		},
-	}
-}
-
 // NewPeerAccount creates a new instance of peerAccount
 func NewPeerAccount(address []byte) (*peerAccount, error) {
 	if len(address) == 0 {

--- a/state/accounts/peerAccount_test.go
+++ b/state/accounts/peerAccount_test.go
@@ -10,15 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewEmptyPeerAccount(t *testing.T) {
-	t.Parallel()
-
-	acc := accounts.NewEmptyPeerAccount()
-
-	assert.NotNil(t, acc)
-	assert.Equal(t, big.NewInt(0), acc.AccumulatedFees)
-}
-
 func TestNewPeerAccount_NilAddressContainerShouldErr(t *testing.T) {
 	t.Parallel()
 

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
@@ -69,24 +68,4 @@ func (accountsDB *accountsDBApi) SetCurrentBlockInfo(blockInfo common.BlockInfo)
 // EmptyErrChanReturningHadContained -
 func EmptyErrChanReturningHadContained(errChan chan error) bool {
 	return emptyErrChanReturningHadContained(errChan)
-}
-
-// DirtyData -
-type DirtyData struct {
-	Value      []byte
-	NewVersion core.TrieNodeVersion
-}
-
-// DirtyData -
-func (tdaw *trackableDataTrie) DirtyData() map[string]DirtyData {
-	dd := make(map[string]DirtyData, len(tdaw.dirtyData))
-
-	for key, value := range tdaw.dirtyData {
-		dd[key] = DirtyData{
-			Value:      value.value,
-			NewVersion: value.newVersion,
-		}
-	}
-
-	return dd
 }

--- a/state/factory/accountCreator.go
+++ b/state/factory/accountCreator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/state/accounts"
 	"github.com/multiversx/mx-chain-go/state/parsers"
+	"github.com/multiversx/mx-chain-go/state/trackableDataTrie"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
@@ -47,7 +48,7 @@ func NewAccountCreator(args ArgsAccountCreator) (state.AccountFactory, error) {
 
 // CreateAccount calls the new Account creator and returns the result
 func (ac *accountCreator) CreateAccount(address []byte) (vmcommon.AccountHandler, error) {
-	trackableDataTrie, err := state.NewTrackableDataTrie(address, ac.hasher, ac.marshaller, ac.enableEpochsHandler)
+	tdt, err := trackableDataTrie.NewTrackableDataTrie(address, ac.hasher, ac.marshaller, ac.enableEpochsHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +58,7 @@ func (ac *accountCreator) CreateAccount(address []byte) (vmcommon.AccountHandler
 		return nil, err
 	}
 
-	return accounts.NewUserAccount(address, trackableDataTrie, dataTrieLeafParser)
+	return accounts.NewUserAccount(address, tdt, dataTrieLeafParser)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/state/interface.go
+++ b/state/interface.go
@@ -144,7 +144,8 @@ type AccountsAdapterAPI interface {
 	GetCodeWithBlockInfo(codeHash []byte, options common.RootHashHolder) ([]byte, common.BlockInfo, error)
 }
 
-type dataTrie interface {
+// DataTrie defines the behavior of a data trie
+type DataTrie interface {
 	common.Trie
 
 	UpdateWithVersion(key []byte, value []byte, version core.TrieNodeVersion) error

--- a/state/journalEntries.go
+++ b/state/journalEntries.go
@@ -188,7 +188,7 @@ func NewJournalEntryDataTrieUpdates(trieUpdates []core.TrieData, account baseAcc
 
 // Revert applies undo operation
 func (jedtu *journalEntryDataTrieUpdates) Revert() (vmcommon.AccountHandler, error) {
-	trie, ok := jedtu.account.DataTrie().(dataTrie)
+	trie, ok := jedtu.account.DataTrie().(DataTrie)
 	if !ok {
 		return nil, fmt.Errorf("invalid trie, type is %T", jedtu.account.DataTrie())
 	}

--- a/state/trackableDataTrie/export_test.go
+++ b/state/trackableDataTrie/export_test.go
@@ -1,0 +1,23 @@
+package trackableDataTrie
+
+import "github.com/multiversx/mx-chain-core-go/core"
+
+// DirtyData -
+type DirtyData struct {
+	Value      []byte
+	NewVersion core.TrieNodeVersion
+}
+
+// DirtyData -
+func (tdaw *trackableDataTrie) DirtyData() map[string]DirtyData {
+	dd := make(map[string]DirtyData, len(tdaw.dirtyData))
+
+	for key, value := range tdaw.dirtyData {
+		dd[key] = DirtyData{
+			Value:      value.value,
+			NewVersion: value.newVersion,
+		}
+	}
+
+	return dd
+}

--- a/state/trackableDataTrie/export_test.go
+++ b/state/trackableDataTrie/export_test.go
@@ -9,10 +9,10 @@ type DirtyData struct {
 }
 
 // DirtyData -
-func (tdaw *trackableDataTrie) DirtyData() map[string]DirtyData {
-	dd := make(map[string]DirtyData, len(tdaw.dirtyData))
+func (tdt *trackableDataTrie) DirtyData() map[string]DirtyData {
+	dd := make(map[string]DirtyData, len(tdt.dirtyData))
 
-	for key, value := range tdaw.dirtyData {
+	for key, value := range tdt.dirtyData {
 		dd[key] = DirtyData{
 			Value:      value.value,
 			NewVersion: value.newVersion,

--- a/state/trackableDataTrie/trackableDataTrie.go
+++ b/state/trackableDataTrie/trackableDataTrie.go
@@ -63,60 +63,60 @@ func NewTrackableDataTrie(
 // RetrieveValue fetches the value from a particular key searching the account data store
 // The search starts with dirty map, continues with original map and ends with the trie
 // Data must have been retrieved from its trie
-func (tdaw *trackableDataTrie) RetrieveValue(key []byte) ([]byte, uint32, error) {
+func (tdt *trackableDataTrie) RetrieveValue(key []byte) ([]byte, uint32, error) {
 	// search in dirty data cache
-	if dataEntry, found := tdaw.dirtyData[string(key)]; found {
-		log.Trace("retrieve value from dirty data", "key", key, "value", dataEntry.value, "account", tdaw.identifier)
+	if dataEntry, found := tdt.dirtyData[string(key)]; found {
+		log.Trace("retrieve value from dirty data", "key", key, "value", dataEntry.value, "account", tdt.identifier)
 		return dataEntry.value, 0, nil
 	}
 
 	// ok, not in cache, retrieve from trie
-	if check.IfNil(tdaw.tr) {
+	if check.IfNil(tdt.tr) {
 		return nil, 0, state.ErrNilTrie
 	}
-	trieValue, depth, err := tdaw.retrieveValueFromTrie(key)
+	trieValue, depth, err := tdt.retrieveValueFromTrie(key)
 	if err != nil {
 		return nil, depth, err
 	}
 
-	val, err := tdaw.getValueWithoutMetadata(key, trieValue)
+	val, err := tdt.getValueWithoutMetadata(key, trieValue)
 	if err != nil {
 		return nil, depth, err
 	}
 
-	log.Trace("retrieve value from trie", "key", key, "value", val, "account", tdaw.identifier)
+	log.Trace("retrieve value from trie", "key", key, "value", val, "account", tdt.identifier)
 
 	return val, depth, nil
 }
 
 // SaveKeyValue stores in dirtyData the data keys "touched"
 // It does not care if the data is really dirty as calling this check here will be sub-optimal
-func (tdaw *trackableDataTrie) SaveKeyValue(key []byte, value []byte) error {
+func (tdt *trackableDataTrie) SaveKeyValue(key []byte, value []byte) error {
 	if uint64(len(value)) > core.MaxLeafSize {
 		return data.ErrLeafSizeTooBig
 	}
 
 	dataEntry := dirtyData{
 		value:      value,
-		newVersion: core.GetVersionForNewData(tdaw.enableEpochsHandler),
+		newVersion: core.GetVersionForNewData(tdt.enableEpochsHandler),
 	}
 
-	tdaw.dirtyData[string(key)] = dataEntry
+	tdt.dirtyData[string(key)] = dataEntry
 	return nil
 }
 
 // MigrateDataTrieLeaves migrates the data trie leaves from oldVersion to newVersion
-func (tdaw *trackableDataTrie) MigrateDataTrieLeaves(args vmcommon.ArgsMigrateDataTrieLeaves) error {
-	if check.IfNil(tdaw.tr) {
+func (tdt *trackableDataTrie) MigrateDataTrieLeaves(args vmcommon.ArgsMigrateDataTrieLeaves) error {
+	if check.IfNil(tdt.tr) {
 		return state.ErrNilTrie
 	}
 	if check.IfNil(args.TrieMigrator) {
 		return errorsCommon.ErrNilTrieMigrator
 	}
 
-	dtr, ok := tdaw.tr.(state.DataTrie)
+	dtr, ok := tdt.tr.(state.DataTrie)
 	if !ok {
-		return fmt.Errorf("invalid trie, type is %T", tdaw.tr)
+		return fmt.Errorf("invalid trie, type is %T", tdt.tr)
 	}
 
 	err := dtr.CollectLeavesForMigration(args)
@@ -131,21 +131,21 @@ func (tdaw *trackableDataTrie) MigrateDataTrieLeaves(args vmcommon.ArgsMigrateDa
 			newVersion: args.NewVersion,
 		}
 
-		originalKey, err := tdaw.getOriginalKeyFromTrieData(leafData)
+		originalKey, err := tdt.getOriginalKeyFromTrieData(leafData)
 		if err != nil {
 			return err
 		}
 
-		tdaw.dirtyData[string(originalKey)] = dataEntry
+		tdt.dirtyData[string(originalKey)] = dataEntry
 	}
 
 	return nil
 }
 
-func (tdaw *trackableDataTrie) getOriginalKeyFromTrieData(trieData core.TrieData) ([]byte, error) {
+func (tdt *trackableDataTrie) getOriginalKeyFromTrieData(trieData core.TrieData) ([]byte, error) {
 	if trieData.Version == core.AutoBalanceEnabled {
 		valWithMetadata := &dataTrieValue.TrieLeafData{}
-		err := tdaw.marshaller.Unmarshal(valWithMetadata, trieData.Value)
+		err := tdt.marshaller.Unmarshal(valWithMetadata, trieData.Value)
 		if err != nil {
 			return nil, err
 		}
@@ -156,15 +156,15 @@ func (tdaw *trackableDataTrie) getOriginalKeyFromTrieData(trieData core.TrieData
 	return trieData.Key, nil
 }
 
-func (tdaw *trackableDataTrie) getKeyForVersion(key []byte, version core.TrieNodeVersion) []byte {
+func (tdt *trackableDataTrie) getKeyForVersion(key []byte, version core.TrieNodeVersion) []byte {
 	if version == core.AutoBalanceEnabled {
-		return tdaw.hasher.Compute(string(key))
+		return tdt.hasher.Compute(string(key))
 	}
 
 	return key
 }
 
-func (tdaw *trackableDataTrie) getValueForVersion(key []byte, value []byte, version core.TrieNodeVersion) ([]byte, error) {
+func (tdt *trackableDataTrie) getValueForVersion(key []byte, value []byte, version core.TrieNodeVersion) ([]byte, error) {
 	if len(value) == 0 {
 		return nil, nil
 	}
@@ -173,68 +173,68 @@ func (tdaw *trackableDataTrie) getValueForVersion(key []byte, value []byte, vers
 		trieVal := &dataTrieValue.TrieLeafData{
 			Value:   value,
 			Key:     key,
-			Address: tdaw.identifier,
+			Address: tdt.identifier,
 		}
 
-		return tdaw.marshaller.Marshal(trieVal)
+		return tdt.marshaller.Marshal(trieVal)
 	}
 
-	identifier := append(key, tdaw.identifier...)
+	identifier := append(key, tdt.identifier...)
 	valueWithAppendedData := append(value, identifier...)
 
 	return valueWithAppendedData, nil
 }
 
 // SetDataTrie sets the internal data trie
-func (tdaw *trackableDataTrie) SetDataTrie(tr common.Trie) {
-	tdaw.tr = tr
+func (tdt *trackableDataTrie) SetDataTrie(tr common.Trie) {
+	tdt.tr = tr
 }
 
 // DataTrie sets the internal data trie
-func (tdaw *trackableDataTrie) DataTrie() common.DataTrieHandler {
-	return tdaw.tr
+func (tdt *trackableDataTrie) DataTrie() common.DataTrieHandler {
+	return tdt.tr
 }
 
 // SaveDirtyData saved the dirty data to the trie
-func (tdaw *trackableDataTrie) SaveDirtyData(mainTrie common.Trie) ([]core.TrieData, error) {
-	if len(tdaw.dirtyData) == 0 {
+func (tdt *trackableDataTrie) SaveDirtyData(mainTrie common.Trie) ([]core.TrieData, error) {
+	if len(tdt.dirtyData) == 0 {
 		return make([]core.TrieData, 0), nil
 	}
 
-	if check.IfNil(tdaw.tr) {
+	if check.IfNil(tdt.tr) {
 		newDataTrie, err := mainTrie.Recreate(make([]byte, 0))
 		if err != nil {
 			return nil, err
 		}
 
-		tdaw.tr = newDataTrie
+		tdt.tr = newDataTrie
 	}
 
-	dtr, ok := tdaw.tr.(state.DataTrie)
+	dtr, ok := tdt.tr.(state.DataTrie)
 	if !ok {
-		return nil, fmt.Errorf("invalid trie, type is %T", tdaw.tr)
+		return nil, fmt.Errorf("invalid trie, type is %T", tdt.tr)
 	}
 
-	return tdaw.updateTrie(dtr)
+	return tdt.updateTrie(dtr)
 }
 
-func (tdaw *trackableDataTrie) updateTrie(dtr state.DataTrie) ([]core.TrieData, error) {
-	oldValues := make([]core.TrieData, len(tdaw.dirtyData))
+func (tdt *trackableDataTrie) updateTrie(dtr state.DataTrie) ([]core.TrieData, error) {
+	oldValues := make([]core.TrieData, len(tdt.dirtyData))
 
 	index := 0
-	for key, dataEntry := range tdaw.dirtyData {
-		oldVal, _, err := tdaw.retrieveValueFromTrie([]byte(key))
+	for key, dataEntry := range tdt.dirtyData {
+		oldVal, _, err := tdt.retrieveValueFromTrie([]byte(key))
 		if err != nil {
 			return nil, err
 		}
 		oldValues[index] = oldVal
 
-		err = tdaw.deleteOldEntryIfMigrated([]byte(key), dataEntry, oldVal)
+		err = tdt.deleteOldEntryIfMigrated([]byte(key), dataEntry, oldVal)
 		if err != nil {
 			return nil, err
 		}
 
-		err = tdaw.modifyTrie([]byte(key), dataEntry, oldVal, dtr)
+		err = tdt.modifyTrie([]byte(key), dataEntry, oldVal, dtr)
 		if err != nil {
 			return nil, err
 		}
@@ -242,15 +242,15 @@ func (tdaw *trackableDataTrie) updateTrie(dtr state.DataTrie) ([]core.TrieData, 
 		index++
 	}
 
-	tdaw.dirtyData = make(map[string]dirtyData)
+	tdt.dirtyData = make(map[string]dirtyData)
 
 	return oldValues, nil
 }
 
-func (tdaw *trackableDataTrie) retrieveValueFromTrie(key []byte) (core.TrieData, uint32, error) {
-	if tdaw.enableEpochsHandler.IsAutoBalanceDataTriesEnabled() {
-		hashedKey := tdaw.hasher.Compute(string(key))
-		valWithMetadata, depth, err := tdaw.tr.Get(hashedKey)
+func (tdt *trackableDataTrie) retrieveValueFromTrie(key []byte) (core.TrieData, uint32, error) {
+	if tdt.enableEpochsHandler.IsAutoBalanceDataTriesEnabled() {
+		hashedKey := tdt.hasher.Compute(string(key))
+		valWithMetadata, depth, err := tdt.tr.Get(hashedKey)
 		if err != nil {
 			return core.TrieData{}, 0, err
 		}
@@ -265,7 +265,7 @@ func (tdaw *trackableDataTrie) retrieveValueFromTrie(key []byte) (core.TrieData,
 		}
 	}
 
-	valWithMetadata, depth, err := tdaw.tr.Get(key)
+	valWithMetadata, depth, err := tdt.tr.Get(key)
 	if err != nil {
 		return core.TrieData{}, 0, err
 	}
@@ -279,8 +279,8 @@ func (tdaw *trackableDataTrie) retrieveValueFromTrie(key []byte) (core.TrieData,
 		return trieValue, depth, nil
 	}
 
-	newDataVersion := core.GetVersionForNewData(tdaw.enableEpochsHandler)
-	keyForTrie := tdaw.getKeyForVersion(key, newDataVersion)
+	newDataVersion := core.GetVersionForNewData(tdt.enableEpochsHandler)
+	keyForTrie := tdt.getKeyForVersion(key, newDataVersion)
 
 	trieValue := core.TrieData{
 		Key:     keyForTrie,
@@ -291,21 +291,21 @@ func (tdaw *trackableDataTrie) retrieveValueFromTrie(key []byte) (core.TrieData,
 	return trieValue, depth, nil
 }
 
-func (tdaw *trackableDataTrie) getValueWithoutMetadata(key []byte, trieData core.TrieData) ([]byte, error) {
+func (tdt *trackableDataTrie) getValueWithoutMetadata(key []byte, trieData core.TrieData) ([]byte, error) {
 	if len(trieData.Value) == 0 {
 		return nil, nil
 	}
 
 	if trieData.Version == core.AutoBalanceEnabled {
-		return tdaw.getValueAutoBalanceVersion(trieData.Value)
+		return tdt.getValueAutoBalanceVersion(trieData.Value)
 	}
 
-	return tdaw.getValueNotSpecifiedVersion(key, trieData.Value)
+	return tdt.getValueNotSpecifiedVersion(key, trieData.Value)
 }
 
-func (tdaw *trackableDataTrie) getValueAutoBalanceVersion(val []byte) ([]byte, error) {
+func (tdt *trackableDataTrie) getValueAutoBalanceVersion(val []byte) ([]byte, error) {
 	dataTrieVal := &dataTrieValue.TrieLeafData{}
-	err := tdaw.marshaller.Unmarshal(dataTrieVal, val)
+	err := tdt.marshaller.Unmarshal(dataTrieVal, val)
 	if err != nil {
 		return nil, err
 	}
@@ -313,34 +313,34 @@ func (tdaw *trackableDataTrie) getValueAutoBalanceVersion(val []byte) ([]byte, e
 	return dataTrieVal.Value, nil
 }
 
-func (tdaw *trackableDataTrie) getValueNotSpecifiedVersion(key []byte, val []byte) ([]byte, error) {
-	tailLength := len(key) + len(tdaw.identifier)
+func (tdt *trackableDataTrie) getValueNotSpecifiedVersion(key []byte, val []byte) ([]byte, error) {
+	tailLength := len(key) + len(tdt.identifier)
 	trimmedValue, _ := common.TrimSuffixFromValue(val, tailLength)
 
 	return trimmedValue, nil
 }
 
-func (tdaw *trackableDataTrie) deleteOldEntryIfMigrated(key []byte, newData dirtyData, oldEntry core.TrieData) error {
-	if !tdaw.enableEpochsHandler.IsAutoBalanceDataTriesEnabled() {
+func (tdt *trackableDataTrie) deleteOldEntryIfMigrated(key []byte, newData dirtyData, oldEntry core.TrieData) error {
+	if !tdt.enableEpochsHandler.IsAutoBalanceDataTriesEnabled() {
 		return nil
 	}
 
 	isMigration := oldEntry.Version == core.NotSpecified && newData.newVersion == core.AutoBalanceEnabled
 	if isMigration && len(newData.value) != 0 {
-		return tdaw.tr.Delete(key)
+		return tdt.tr.Delete(key)
 	}
 
 	return nil
 }
 
-func (tdaw *trackableDataTrie) modifyTrie(key []byte, dataEntry dirtyData, oldVal core.TrieData, dtr state.DataTrie) error {
+func (tdt *trackableDataTrie) modifyTrie(key []byte, dataEntry dirtyData, oldVal core.TrieData, dtr state.DataTrie) error {
 	if len(dataEntry.value) == 0 {
-		return tdaw.deleteFromTrie(oldVal, key, dtr)
+		return tdt.deleteFromTrie(oldVal, key, dtr)
 	}
 
 	version := dataEntry.newVersion
-	newKey := tdaw.getKeyForVersion(key, version)
-	value, err := tdaw.getValueForVersion(key, dataEntry.value, version)
+	newKey := tdt.getKeyForVersion(key, version)
+	value, err := tdt.getValueForVersion(key, dataEntry.value, version)
 	if err != nil {
 		return err
 	}
@@ -348,13 +348,13 @@ func (tdaw *trackableDataTrie) modifyTrie(key []byte, dataEntry dirtyData, oldVa
 	return dtr.UpdateWithVersion(newKey, value, version)
 }
 
-func (tdaw *trackableDataTrie) deleteFromTrie(oldVal core.TrieData, key []byte, dtr state.DataTrie) error {
+func (tdt *trackableDataTrie) deleteFromTrie(oldVal core.TrieData, key []byte, dtr state.DataTrie) error {
 	if len(oldVal.Value) == 0 {
 		return nil
 	}
 
 	if oldVal.Version == core.AutoBalanceEnabled {
-		return dtr.Delete(tdaw.hasher.Compute(string(key)))
+		return dtr.Delete(tdt.hasher.Compute(string(key)))
 	}
 
 	if oldVal.Version == core.NotSpecified {
@@ -365,6 +365,6 @@ func (tdaw *trackableDataTrie) deleteFromTrie(oldVal core.TrieData, key []byte, 
 }
 
 // IsInterfaceNil returns true if there is no value under the interface
-func (tdaw *trackableDataTrie) IsInterfaceNil() bool {
-	return tdaw == nil
+func (tdt *trackableDataTrie) IsInterfaceNil() bool {
+	return tdt == nil
 }

--- a/state/trackableDataTrie/trackableDataTrie_test.go
+++ b/state/trackableDataTrie/trackableDataTrie_test.go
@@ -1,4 +1,4 @@
-package state_test
+package trackableDataTrie_test
 
 import (
 	"bytes"
@@ -11,6 +11,7 @@ import (
 	errorsCommon "github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/state/dataTrieValue"
+	"github.com/multiversx/mx-chain-go/state/trackableDataTrie"
 	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
@@ -26,7 +27,7 @@ func TestNewTrackableDataTrie(t *testing.T) {
 	t.Run("create with nil hasher", func(t *testing.T) {
 		t.Parallel()
 
-		tdt, err := state.NewTrackableDataTrie([]byte("identifier"), nil, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, err := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), nil, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		assert.Equal(t, state.ErrNilHasher, err)
 		assert.True(t, check.IfNil(tdt))
 	})
@@ -34,7 +35,7 @@ func TestNewTrackableDataTrie(t *testing.T) {
 	t.Run("create with nil marshaller", func(t *testing.T) {
 		t.Parallel()
 
-		tdt, err := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, nil, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, err := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, nil, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		assert.Equal(t, state.ErrNilMarshalizer, err)
 		assert.True(t, check.IfNil(tdt))
 	})
@@ -42,7 +43,7 @@ func TestNewTrackableDataTrie(t *testing.T) {
 	t.Run("create with nil enableEpochsHandler", func(t *testing.T) {
 		t.Parallel()
 
-		tdt, err := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, nil)
+		tdt, err := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, nil)
 		assert.Equal(t, state.ErrNilEnableEpochsHandler, err)
 		assert.True(t, check.IfNil(tdt))
 	})
@@ -50,7 +51,7 @@ func TestNewTrackableDataTrie(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		tdt, err := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, err := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		assert.Nil(t, err)
 		assert.False(t, check.IfNil(tdt))
 	})
@@ -62,7 +63,7 @@ func TestTrackableDataTrie_SaveKeyValue(t *testing.T) {
 	t.Run("data too large", func(t *testing.T) {
 		t.Parallel()
 
-		tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 		err := tdt.SaveKeyValue([]byte("key"), make([]byte, core.MaxLeafSize+1))
 		assert.Equal(t, err, data.ErrLeafSizeTooBig)
@@ -83,7 +84,7 @@ func TestTrackableDataTrie_SaveKeyValue(t *testing.T) {
 				return nil, 0, nil
 			},
 		}
-		tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		assert.NotNil(t, tdt)
 		tdt.SetDataTrie(trie)
 
@@ -116,7 +117,7 @@ func TestTrackableDataTrie_RetrieveValue(t *testing.T) {
 				return nil, 0, nil
 			},
 		}
-		tdt, _ := state.NewTrackableDataTrie(identifier, &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		assert.NotNil(t, tdt)
 		tdt.SetDataTrie(trie)
 
@@ -133,7 +134,7 @@ func TestTrackableDataTrie_RetrieveValue(t *testing.T) {
 	t.Run("nil data trie should err", func(t *testing.T) {
 		t.Parallel()
 
-		tdt, err := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, err := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		assert.Nil(t, err)
 		assert.NotNil(t, tdt)
 
@@ -161,7 +162,7 @@ func TestTrackableDataTrie_RetrieveValue(t *testing.T) {
 		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
 			IsAutoBalanceDataTriesEnabledField: true,
 		}
-		tdt, _ := state.NewTrackableDataTrie(identifier, &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, enableEpochsHandler)
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, enableEpochsHandler)
 		assert.NotNil(t, tdt)
 		tdt.SetDataTrie(trie)
 
@@ -194,7 +195,7 @@ func TestTrackableDataTrie_RetrieveValue(t *testing.T) {
 		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
 			IsAutoBalanceDataTriesEnabledField: false,
 		}
-		tdt, _ := state.NewTrackableDataTrie(identifier, &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, enableEpochsHandler)
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, enableEpochsHandler)
 		assert.NotNil(t, tdt)
 		tdt.SetDataTrie(trie)
 
@@ -231,7 +232,7 @@ func TestTrackableDataTrie_RetrieveValue(t *testing.T) {
 		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
 			IsAutoBalanceDataTriesEnabledField: true,
 		}
-		tdt, _ := state.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
 		assert.NotNil(t, tdt)
 		tdt.SetDataTrie(trie)
 
@@ -250,7 +251,7 @@ func TestTrackableDataTrie_RetrieveValue(t *testing.T) {
 				return nil, 0, errExpected
 			},
 		}
-		tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		assert.NotNil(t, tdt)
 		tdt.SetDataTrie(trie)
 
@@ -278,7 +279,7 @@ func TestTrackableDataTrie_RetrieveValue(t *testing.T) {
 		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
 			IsAutoBalanceDataTriesEnabledField: true,
 		}
-		tdt, _ := state.NewTrackableDataTrie(
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(
 			identifier,
 			hasher,
 			marshaller,
@@ -311,7 +312,7 @@ func TestTrackableDataTrie_RetrieveValue(t *testing.T) {
 		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
 			IsAutoBalanceDataTriesEnabledField: false,
 		}
-		tdt, _ := state.NewTrackableDataTrie(
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(
 			identifier,
 			hasher,
 			marshaller,
@@ -332,7 +333,7 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 	t.Run("no dirty data", func(t *testing.T) {
 		t.Parallel()
 
-		tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 		oldValues, err := tdt.SaveDirtyData(&trieMock.TrieStub{})
 		assert.Nil(t, err)
@@ -356,7 +357,7 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 				}, nil
 			},
 		}
-		tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 		key := []byte("key")
 		_ = tdt.SaveKeyValue(key, []byte("val"))
@@ -411,7 +412,7 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
 			IsAutoBalanceDataTriesEnabledField: true,
 		}
-		tdt, _ := state.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
 		tdt.SetDataTrie(trie)
 
 		_ = tdt.SaveKeyValue(expectedKey, expectedVal)
@@ -458,7 +459,7 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
 			IsAutoBalanceDataTriesEnabledField: false,
 		}
-		tdt, _ := state.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
 		tdt.SetDataTrie(trie)
 
 		_ = tdt.SaveKeyValue(expectedKey, val)
@@ -517,7 +518,7 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
 			IsAutoBalanceDataTriesEnabledField: true,
 		}
-		tdt, _ := state.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
 		tdt.SetDataTrie(trie)
 
 		_ = tdt.SaveKeyValue(expectedKey, newVal)
@@ -565,7 +566,7 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
 			IsAutoBalanceDataTriesEnabledField: true,
 		}
-		tdt, _ := state.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
 		tdt.SetDataTrie(trie)
 
 		_ = tdt.SaveKeyValue(expectedKey, newVal)
@@ -592,7 +593,7 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 			},
 		}
 
-		tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		tdt.SetDataTrie(trie)
 
 		_ = tdt.SaveKeyValue(expectedKey, val)
@@ -617,7 +618,7 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 			},
 		}
 
-		tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		tdt.SetDataTrie(trie)
 
 		_ = tdt.SaveKeyValue(expectedKey, nil)
@@ -643,7 +644,7 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 			},
 		}
 
-		tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		tdt.SetDataTrie(trie)
 
 		_ = tdt.SaveKeyValue(expectedKey, nil)
@@ -677,7 +678,7 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		enableEpchs := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
 			IsAutoBalanceDataTriesEnabledField: true,
 		}
-		tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, enableEpchs)
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, enableEpchs)
 		tdt.SetDataTrie(trie)
 
 		_ = tdt.SaveKeyValue(expectedKey, nil)
@@ -710,7 +711,7 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		enableEpchs := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
 			IsAutoBalanceDataTriesEnabledField: true,
 		}
-		tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, enableEpchs)
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, enableEpchs)
 		tdt.SetDataTrie(trie)
 
 		_ = tdt.SaveKeyValue(expectedKey, nil)
@@ -751,7 +752,7 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
 			IsAutoBalanceDataTriesEnabledField: false,
 		}
-		tdt, _ := state.NewTrackableDataTrie(
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(
 			identifier,
 			hasher,
 			marshaller,
@@ -775,7 +776,7 @@ func TestTrackableDataTrie_MigrateDataTrieLeaves(t *testing.T) {
 	t.Run("nil trie", func(t *testing.T) {
 		t.Parallel()
 
-		tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		args := vmcommon.ArgsMigrateDataTrieLeaves{
 			OldVersion:   core.NotSpecified,
 			NewVersion:   core.AutoBalanceEnabled,
@@ -788,7 +789,7 @@ func TestTrackableDataTrie_MigrateDataTrieLeaves(t *testing.T) {
 	t.Run("nil trie migrator", func(t *testing.T) {
 		t.Parallel()
 
-		tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		tdt.SetDataTrie(&trieMock.TrieStub{})
 
 		args := vmcommon.ArgsMigrateDataTrieLeaves{
@@ -810,7 +811,7 @@ func TestTrackableDataTrie_MigrateDataTrieLeaves(t *testing.T) {
 			},
 		}
 
-		tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		tdt.SetDataTrie(tr)
 		args := vmcommon.ArgsMigrateDataTrieLeaves{
 			OldVersion:   core.NotSpecified,
@@ -855,7 +856,7 @@ func TestTrackableDataTrie_MigrateDataTrieLeaves(t *testing.T) {
 			IsAutoBalanceDataTriesEnabledField: true,
 		}
 
-		tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, enableEpchs)
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, enableEpchs)
 		tdt.SetDataTrie(tr)
 		args := vmcommon.ArgsMigrateDataTrieLeaves{
 			OldVersion:   core.NotSpecified,
@@ -878,7 +879,7 @@ func TestTrackableDataTrie_MigrateDataTrieLeaves(t *testing.T) {
 func TestTrackableDataTrie_SetAndGetDataTrie(t *testing.T) {
 	t.Parallel()
 
-	tdt, _ := state.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	tdt, _ := trackableDataTrie.NewTrackableDataTrie([]byte("identifier"), &hashingMocks.HasherMock{}, &marshallerMock.MarshalizerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	newTrie := &trieMock.TrieStub{}
 	tdt.SetDataTrie(newTrie)

--- a/testscommon/state/accountWrapperMock.go
+++ b/testscommon/state/accountWrapperMock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/state"
+	"github.com/multiversx/mx-chain-go/state/trackableDataTrie"
 	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
@@ -40,7 +41,7 @@ var errInsufficientBalance = fmt.Errorf("insufficient balance")
 
 // NewAccountWrapMock -
 func NewAccountWrapMock(adr []byte) *AccountWrapMock {
-	tdt, _ := state.NewTrackableDataTrie(
+	tdt, _ := trackableDataTrie.NewTrackableDataTrie(
 		[]byte("identifier"),
 		&hashingMocks.HasherMock{},
 		&marshallerMock.MarshalizerMock{},

--- a/update/genesis/common.go
+++ b/update/genesis/common.go
@@ -25,7 +25,7 @@ func getValidatorDataFromLeaves(
 	validators[core.MetachainShardId] = make([]*state.ValidatorInfo, 0)
 
 	for pa := range leavesChannels.LeavesChan {
-		peerAccount, err := unmarshalPeer(pa.Value(), marshalizer)
+		peerAccount, err := unmarshalPeer(pa, marshalizer)
 		if err != nil {
 			return nil, err
 		}
@@ -43,9 +43,12 @@ func getValidatorDataFromLeaves(
 	return validators, nil
 }
 
-func unmarshalPeer(pa []byte, marshalizer marshal.Marshalizer) (state.PeerAccountHandler, error) {
-	peerAccount := accounts.NewEmptyPeerAccount()
-	err := marshalizer.Unmarshal(peerAccount, pa)
+func unmarshalPeer(peerAccountData core.KeyValueHolder, marshalizer marshal.Marshalizer) (state.PeerAccountHandler, error) {
+	peerAccount, err := accounts.NewPeerAccount(peerAccountData.Key())
+	if err != nil {
+		return nil, err
+	}
+	err = marshalizer.Unmarshal(peerAccount, peerAccountData.Value())
 	if err != nil {
 		return nil, err
 	}

--- a/vm/systemSmartContracts/eei_test.go
+++ b/vm/systemSmartContracts/eei_test.go
@@ -244,7 +244,7 @@ func TestVmContext_IsValidator(t *testing.T) {
 			GetExistingAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
 				assert.Equal(t, blsKey, address)
 
-				acnt := accounts.NewEmptyPeerAccount()
+				acnt, _ := accounts.NewPeerAccount(address)
 				acnt.List = string(tio.peerType)
 
 				return acnt, nil

--- a/vm/systemSmartContracts/staking_test.go
+++ b/vm/systemSmartContracts/staking_test.go
@@ -643,7 +643,7 @@ func TestStakingSC_ExecuteUnBoundStillValidator(t *testing.T) {
 		JailedRound:   math.MaxUint64,
 	}
 
-	peerAccount := accounts.NewEmptyPeerAccount()
+	peerAccount, _ := accounts.NewPeerAccount([]byte("validator"))
 	peerAccount.List = string(common.EligibleList)
 	stakeValue := big.NewInt(100)
 	marshalizedRegData, _ := json.Marshal(&registrationData)
@@ -1627,7 +1627,7 @@ func Test_NoActionAllowedForBadRatingOrJailed(t *testing.T) {
 	doStake(t, stakingSmartContract, stakingAccessAddress, stakerAddress, []byte("firsstKey"))
 	doStake(t, stakingSmartContract, stakingAccessAddress, stakerAddress, []byte("secondKey"))
 
-	peerAccount := accounts.NewEmptyPeerAccount()
+	peerAccount, _ := accounts.NewPeerAccount(stakerAddress)
 	accountsStub.GetExistingAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return peerAccount, nil
 	}
@@ -1683,7 +1683,7 @@ func Test_UnJailNotAllowedIfJailed(t *testing.T) {
 	doStake(t, stakingSmartContract, stakingAccessAddress, stakerAddress, []byte("firsstKey"))
 	doStake(t, stakingSmartContract, stakingAccessAddress, stakerAddress, []byte("secondKey"))
 
-	peerAccount := accounts.NewEmptyPeerAccount()
+	peerAccount, _ := accounts.NewPeerAccount(stakerAddress)
 	accountsStub.GetExistingAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
 		return peerAccount, nil
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- Move data trie tracker in a separate package, and remove NewEmptyPeerAccount()

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
