### PR TITLE
Multiple instances HostDriver

### DIFF
--- a/cmd/node/config/external.toml
+++ b/cmd/node/config/external.toml
@@ -41,7 +41,7 @@
     # marshalled structures in block events data
     MarshallerType = "json"
 
-[HostDriverConfig]
+[[HostDriversConfig]]
     # This flag shall only be used for observer nodes
     Enabled = false
     # This flag will start the WebSocket connector as server or client (can be "client" or "server")

--- a/config/externalConfig.go
+++ b/config/externalConfig.go
@@ -4,7 +4,7 @@ package config
 type ExternalConfig struct {
 	ElasticSearchConnector ElasticSearchConfig
 	EventNotifierConnector EventNotifierConfig
-	HostDriverConfig       HostDriverConfig
+	HostDriversConfig      []HostDriversConfig
 }
 
 // ElasticSearchConfig will hold the configuration for the elastic search
@@ -38,8 +38,8 @@ type CovalentConfig struct {
 	RouteAcknowledgeData string
 }
 
-// HostDriverConfig will hold the configuration for WebSocket driver
-type HostDriverConfig struct {
+// HostDriversConfig will hold the configuration for WebSocket driver
+type HostDriversConfig struct {
 	Enabled                    bool
 	WithAcknowledge            bool
 	BlockingAckOnError         bool

--- a/factory/status/export_test.go
+++ b/factory/status/export_test.go
@@ -3,6 +3,7 @@ package status
 import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-go/epochStart"
+	outportDriverFactory "github.com/multiversx/mx-chain-go/outport/factory"
 	"github.com/multiversx/mx-chain-go/p2p"
 )
 
@@ -25,4 +26,9 @@ func ComputeConnectedPeers(
 	netMessenger p2p.Messenger,
 ) {
 	computeConnectedPeers(appStatusHandler, netMessenger)
+}
+
+// MakeHostDriversArgs -
+func (scf *statusComponentsFactory) MakeHostDriversArgs() ([]outportDriverFactory.ArgsHostDriverFactory, error) {
+	return scf.makeHostDriversArgs()
 }

--- a/factory/status/statusComponents.go
+++ b/factory/status/statusComponents.go
@@ -255,7 +255,7 @@ func (scf *statusComponentsFactory) makeHostDriversArgs() ([]outportDriverFactor
 	for idx := 0; idx < len(scf.externalConfig.HostDriversConfig); idx++ {
 		hostConfig := scf.externalConfig.HostDriversConfig[idx]
 		if !hostConfig.Enabled {
-			return argsHostDriverFactorySlice, nil
+			continue
 		}
 
 		marshaller, err := factoryMarshalizer.NewMarshalizer(hostConfig.MarshallerType)

--- a/factory/status/statusComponents.go
+++ b/factory/status/statusComponents.go
@@ -190,7 +190,7 @@ func (pc *statusComponents) Close() error {
 // createOutportDriver creates a new outport.OutportHandler which is used to register outport drivers
 // once a driver is subscribed it will receive data through the implemented outport.Driver methods
 func (scf *statusComponentsFactory) createOutportDriver() (outport.OutportHandler, error) {
-	hostDriverArgs, err := scf.makeHostDriverArgs()
+	hostDriversArgs, err := scf.makeHostDriversArgs()
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (scf *statusComponentsFactory) createOutportDriver() (outport.OutportHandle
 		RetrialInterval:           common.RetrialIntervalForOutportDriver,
 		ElasticIndexerFactoryArgs: scf.makeElasticIndexerArgs(),
 		EventNotifierFactoryArgs:  eventNotifierArgs,
-		HostDriverArgs:            hostDriverArgs,
+		HostDriversArgs:           hostDriversArgs,
 		IsImportDB:                scf.isInImportMode,
 	}
 
@@ -250,18 +250,24 @@ func (scf *statusComponentsFactory) makeEventNotifierArgs() (*outportDriverFacto
 	}, nil
 }
 
-func (scf *statusComponentsFactory) makeHostDriverArgs() (outportDriverFactory.ArgsHostDriverFactory, error) {
-	if !scf.externalConfig.HostDriverConfig.Enabled {
-		return outportDriverFactory.ArgsHostDriverFactory{}, nil
+func (scf *statusComponentsFactory) makeHostDriversArgs() ([]outportDriverFactory.ArgsHostDriverFactory, error) {
+	argsHostDriverFactorySlice := make([]outportDriverFactory.ArgsHostDriverFactory, 0, len(scf.externalConfig.HostDriversConfig))
+	for idx := 0; idx < len(scf.externalConfig.HostDriversConfig); idx++ {
+		hostConfig := scf.externalConfig.HostDriversConfig[idx]
+		if !hostConfig.Enabled {
+			return argsHostDriverFactorySlice, nil
+		}
+
+		marshaller, err := factoryMarshalizer.NewMarshalizer(hostConfig.MarshallerType)
+		if err != nil {
+			return argsHostDriverFactorySlice, err
+		}
+
+		argsHostDriverFactorySlice = append(argsHostDriverFactorySlice, outportDriverFactory.ArgsHostDriverFactory{
+			Marshaller: marshaller,
+			HostConfig: hostConfig,
+		})
 	}
 
-	marshaller, err := factoryMarshalizer.NewMarshalizer(scf.externalConfig.HostDriverConfig.MarshallerType)
-	if err != nil {
-		return outportDriverFactory.ArgsHostDriverFactory{}, err
-	}
-
-	return outportDriverFactory.ArgsHostDriverFactory{
-		Marshaller: marshaller,
-		HostConfig: scf.externalConfig.HostDriverConfig,
-	}, nil
+	return argsHostDriverFactorySlice, nil
 }

--- a/factory/status/statusComponents_test.go
+++ b/factory/status/statusComponents_test.go
@@ -286,5 +286,4 @@ func TestMakeHostDriversArgs(t *testing.T) {
 	res, err := scf.MakeHostDriversArgs()
 	require.Nil(t, err)
 	require.Equal(t, 1, len(res))
-
 }

--- a/factory/status/statusComponents_test.go
+++ b/factory/status/statusComponents_test.go
@@ -30,8 +30,10 @@ func createMockStatusComponentsFactoryArgs() statusComp.StatusComponentsFactoryA
 				Password:       "pass",
 				EnabledIndexes: []string{"transactions", "blocks"},
 			},
-			HostDriverConfig: config.HostDriverConfig{
-				MarshallerType: "json",
+			HostDriversConfig: []config.HostDriversConfig{
+				{
+					MarshallerType: "json",
+				},
 			},
 			EventNotifierConnector: config.EventNotifierConfig{
 				MarshallerType: "json",
@@ -187,8 +189,8 @@ func TestStatusComponentsFactory_Create(t *testing.T) {
 		t.Parallel()
 
 		args := createMockStatusComponentsFactoryArgs()
-		args.ExternalConfig.HostDriverConfig.Enabled = true
-		args.ExternalConfig.HostDriverConfig.MarshallerType = "invalid type"
+		args.ExternalConfig.HostDriversConfig[0].Enabled = true
+		args.ExternalConfig.HostDriversConfig[0].MarshallerType = "invalid type"
 		scf, _ := statusComp.NewStatusComponentsFactory(args)
 		require.NotNil(t, scf)
 
@@ -204,7 +206,7 @@ func TestStatusComponentsFactory_Create(t *testing.T) {
 			return core.MetachainShardId // coverage
 		}
 		args, _ := componentsMock.GetStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator)
-		args.ExternalConfig.HostDriverConfig.Enabled = true // coverage
+		args.ExternalConfig.HostDriversConfig[0].Enabled = true // coverage
 		scf, err := statusComp.NewStatusComponentsFactory(args)
 		require.Nil(t, err)
 

--- a/factory/status/statusComponents_test.go
+++ b/factory/status/statusComponents_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/multiversx/mx-chain-communication-go/websocket/data"
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-go/config"
 	errorsMx "github.com/multiversx/mx-chain-go/errors"
@@ -259,4 +260,31 @@ func TestStatusComponents_Close(t *testing.T) {
 
 	err = cc.Close()
 	require.NoError(t, err)
+}
+
+func TestMakeHostDriversArgs(t *testing.T) {
+	t.Parallel()
+
+	args := createMockStatusComponentsFactoryArgs()
+	args.ExternalConfig.HostDriversConfig = []config.HostDriversConfig{
+		{
+			Enabled:            false,
+			URL:                "localhost",
+			RetryDurationInSec: 1,
+			MarshallerType:     "json",
+			Mode:               data.ModeClient,
+		},
+		{
+			Enabled:            true,
+			URL:                "localhost",
+			RetryDurationInSec: 1,
+			MarshallerType:     "json",
+			Mode:               data.ModeClient,
+		},
+	}
+	scf, _ := statusComp.NewStatusComponentsFactory(args)
+	res, err := scf.MakeHostDriversArgs()
+	require.Nil(t, err)
+	require.Equal(t, 1, len(res))
+
 }

--- a/outport/factory/hostDriverFactory.go
+++ b/outport/factory/hostDriverFactory.go
@@ -11,7 +11,7 @@ import (
 )
 
 type ArgsHostDriverFactory struct {
-	HostConfig config.HostDriverConfig
+	HostConfig config.HostDriversConfig
 	Marshaller marshal.Marshalizer
 }
 

--- a/outport/factory/hostDriverFactory_test.go
+++ b/outport/factory/hostDriverFactory_test.go
@@ -14,7 +14,7 @@ func TestCreateHostDriver(t *testing.T) {
 	t.Parallel()
 
 	args := ArgsHostDriverFactory{
-		HostConfig: config.HostDriverConfig{
+		HostConfig: config.HostDriversConfig{
 			URL:                "localhost",
 			RetryDurationInSec: 1,
 			MarshallerType:     "json",

--- a/outport/factory/outportFactory.go
+++ b/outport/factory/outportFactory.go
@@ -1,6 +1,7 @@
 package factory
 
 import (
+	"fmt"
 	"time"
 
 	outportcore "github.com/multiversx/mx-chain-core-go/data/outport"
@@ -55,8 +56,7 @@ func createAndSubscribeDrivers(outport outport.OutportHandler, args *OutportFact
 	for idx := 0; idx < len(args.HostDriversArgs); idx++ {
 		err = createAndSubscribeHostDriverIfNeeded(outport, args.HostDriversArgs[idx])
 		if err != nil {
-			log.Error("createAndSubscribeHostDriverIfNeeded", "host index", idx, "error", err)
-			return err
+			return fmt.Errorf("%w when calling createAndSubscribeHostDriverIfNeeded, host driver index %d", err, idx)
 		}
 	}
 

--- a/outport/factory/outportFactory.go
+++ b/outport/factory/outportFactory.go
@@ -55,6 +55,7 @@ func createAndSubscribeDrivers(outport outport.OutportHandler, args *OutportFact
 	for idx := 0; idx < len(args.HostDriversArgs); idx++ {
 		err = createAndSubscribeHostDriverIfNeeded(outport, args.HostDriversArgs[idx])
 		if err != nil {
+			log.Error("createAndSubscribeHostDriverIfNeeded", "host index", idx, "error", err)
 			return err
 		}
 	}

--- a/outport/factory/outportFactory.go
+++ b/outport/factory/outportFactory.go
@@ -14,7 +14,7 @@ type OutportFactoryArgs struct {
 	RetrialInterval           time.Duration
 	ElasticIndexerFactoryArgs indexerFactory.ArgsIndexerFactory
 	EventNotifierFactoryArgs  *EventNotifierFactoryArgs
-	HostDriverArgs            ArgsHostDriverFactory
+	HostDriversArgs           []ArgsHostDriverFactory
 }
 
 // CreateOutport will create a new instance of OutportHandler
@@ -52,7 +52,14 @@ func createAndSubscribeDrivers(outport outport.OutportHandler, args *OutportFact
 		return err
 	}
 
-	return createAndSubscribeHostDriverIfNeeded(outport, args.HostDriverArgs)
+	for idx := 0; idx < len(args.HostDriversArgs); idx++ {
+		err = createAndSubscribeHostDriverIfNeeded(outport, args.HostDriversArgs[idx])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func createAndSubscribeElasticDriverIfNeeded(

--- a/outport/factory/outportFactory_test.go
+++ b/outport/factory/outportFactory_test.go
@@ -131,6 +131,16 @@ func TestCreateOutport_SubscribeMultipleHostDrivers(t *testing.T) {
 			{
 				Marshaller: &testscommon.MarshalizerMock{},
 				HostConfig: config.HostDriversConfig{
+					Enabled:            false,
+					URL:                "localhost",
+					RetryDurationInSec: 1,
+					MarshallerType:     "json",
+					Mode:               data.ModeClient,
+				},
+			},
+			{
+				Marshaller: &testscommon.MarshalizerMock{},
+				HostConfig: config.HostDriversConfig{
 					Enabled:            true,
 					URL:                "localhost",
 					RetryDurationInSec: 1,

--- a/outport/factory/outportFactory_test.go
+++ b/outport/factory/outportFactory_test.go
@@ -160,3 +160,31 @@ func TestCreateOutport_SubscribeMultipleHostDrivers(t *testing.T) {
 
 	require.True(t, outPort.HasDrivers())
 }
+
+func TestCreateAndSubscribeDriversShouldReturnError(t *testing.T) {
+	args := &factory.OutportFactoryArgs{
+		RetrialInterval: time.Second,
+		EventNotifierFactoryArgs: &notifierFactory.EventNotifierFactoryArgs{
+			Enabled: false,
+		},
+		ElasticIndexerFactoryArgs: indexerFactory.ArgsIndexerFactory{
+			Enabled: false,
+		},
+		HostDriversArgs: []notifierFactory.ArgsHostDriverFactory{
+			{
+				Marshaller: &testscommon.MarshalizerMock{},
+				HostConfig: config.HostDriversConfig{
+					Enabled:            true,
+					URL:                "localhost",
+					RetryDurationInSec: 1,
+					MarshallerType:     "json",
+					Mode:               "wrong mode",
+				},
+			},
+		},
+	}
+
+	outPort, err := factory.CreateOutport(args)
+	require.Nil(t, outPort)
+	require.ErrorIs(t, err, data.ErrInvalidWebSocketHostMode)
+}

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -648,11 +648,13 @@ func GetStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator shardin
 				RequestTimeoutSec: 30,
 				MarshallerType:    "json",
 			},
-			HostDriverConfig: config.HostDriverConfig{
-				MarshallerType:     "json",
-				Mode:               "client",
-				URL:                "localhost:12345",
-				RetryDurationInSec: 1,
+			HostDriversConfig: []config.HostDriversConfig{
+				{
+					MarshallerType:     "json",
+					Mode:               "client",
+					URL:                "localhost:12345",
+					RetryDurationInSec: 1,
+				},
 			},
 		},
 		EconomicsConfig:      config.EconomicsConfig{},


### PR DESCRIPTION
## Reasoning behind the pull request
-  The configuration for the HostDriver has to support multiple instances.
  
## Proposed changes
- Extended the `external.toml` config file in order to have multiple instances of `HostDriversConfig`. 
- This change is needed because we want to have multiple host drivers on the same node. ( we need an instance of the host driver for the Elastic indexer and one instance for the Event notifier)

## Testing procedure
- Do a system test with multiple instances of the host driver on the same node. 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
