### PR TITLE
Put back snapshot-less config in config.toml

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -675,6 +675,7 @@
 [StateTriesConfig]
     CheckpointRoundsModulus = 100
     CheckpointsEnabled = false
+    SnapshotsEnabled = true
     AccountsStatePruningEnabled = false
     PeerStatePruningEnabled = true
     MaxStateTrieLevelInMemory = 5

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -477,7 +477,6 @@ func getFlagsConfig(ctx *cli.Context, log logger.Logger) *config.ContextFlagsCon
 	flagsConfig.DisableConsensusWatchdog = ctx.GlobalBool(disableConsensusWatchdog.Name)
 	flagsConfig.SerializeSnapshots = ctx.GlobalBool(serializeSnapshots.Name)
 	flagsConfig.NoKeyProvided = ctx.GlobalBool(noKey.Name)
-	flagsConfig.SnapshotsEnabled = ctx.GlobalBool(snapshotsEnabled.Name)
 	flagsConfig.OperationMode = ctx.GlobalString(operationMode.Name)
 	flagsConfig.RepopulateTokensSupplies = ctx.GlobalBool(repopulateTokensSupplies.Name)
 
@@ -515,6 +514,9 @@ func applyFlags(ctx *cli.Context, cfgs *config.Configs, flagsConfig *config.Cont
 		cfgs.GeneralConfig.Health.MemoryUsageToCreateProfiles = int(ctx.GlobalUint64(memoryUsageToCreateProfiles.Name))
 		log.Info("setting a new value for the memoryUsageToCreateProfiles option",
 			"new value", cfgs.GeneralConfig.Health.MemoryUsageToCreateProfiles)
+	}
+	if ctx.IsSet(snapshotsEnabled.Name) {
+		cfgs.GeneralConfig.StateTriesConfig.SnapshotsEnabled = ctx.GlobalBool(snapshotsEnabled.Name)
 	}
 
 	importDbDirectoryValue := ctx.GlobalString(importDbDirectory.Name)
@@ -657,12 +659,12 @@ func processDbLookupExtensionMode(log logger.Logger, configs *config.Configs) {
 
 func processLiteObserverMode(log logger.Logger, configs *config.Configs) {
 	configs.GeneralConfig.StoragePruning.ObserverCleanOldEpochsData = true
-	configs.FlagsConfig.SnapshotsEnabled = false
+	configs.GeneralConfig.StateTriesConfig.SnapshotsEnabled = false
 	configs.GeneralConfig.StateTriesConfig.AccountsStatePruningEnabled = true
 
 	log.Warn("the node is in snapshotless observer mode! Will auto-set some config values",
 		"StoragePruning.ObserverCleanOldEpochsData", configs.GeneralConfig.StoragePruning.ObserverCleanOldEpochsData,
-		"FlagsConfig.SnapshotsEnabled", configs.FlagsConfig.SnapshotsEnabled,
+		"StateTriesConfig.SnapshotsEnabled", configs.GeneralConfig.StateTriesConfig.SnapshotsEnabled,
 		"StateTriesConfig.AccountsStatePruningEnabled", configs.GeneralConfig.StateTriesConfig.AccountsStatePruningEnabled,
 	)
 }

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -617,9 +617,9 @@ func applyCompatibleConfigs(log logger.Logger, configs *config.Configs) error {
 		processDbLookupExtensionMode(log, configs)
 	}
 
-	isInLiteObserverMode := operationmodes.SliceContainsElement(operationModes, operationmodes.OperationModeSnapshotlessObserver)
-	if isInLiteObserverMode {
-		processLiteObserverMode(log, configs)
+	isInSnapshotLessObserverMode := operationmodes.SliceContainsElement(operationModes, operationmodes.OperationModeSnapshotlessObserver)
+	if isInSnapshotLessObserverMode {
+		processSnapshotLessObserverMode(log, configs)
 	}
 
 	return nil
@@ -657,7 +657,7 @@ func processDbLookupExtensionMode(log logger.Logger, configs *config.Configs) {
 	)
 }
 
-func processLiteObserverMode(log logger.Logger, configs *config.Configs) {
+func processSnapshotLessObserverMode(log logger.Logger, configs *config.Configs) {
 	configs.GeneralConfig.StoragePruning.ObserverCleanOldEpochsData = true
 	configs.GeneralConfig.StateTriesConfig.SnapshotsEnabled = false
 	configs.GeneralConfig.StateTriesConfig.AccountsStatePruningEnabled = true

--- a/config/config.go
+++ b/config/config.go
@@ -294,6 +294,7 @@ type FacadeConfig struct {
 type StateTriesConfig struct {
 	CheckpointRoundsModulus     uint
 	CheckpointsEnabled          bool
+	SnapshotsEnabled            bool
 	AccountsStatePruningEnabled bool
 	PeerStatePruningEnabled     bool
 	MaxStateTrieLevelInMemory   uint

--- a/config/contextFlagsConfig.go
+++ b/config/contextFlagsConfig.go
@@ -26,7 +26,6 @@ type ContextFlagsConfig struct {
 	DisableConsensusWatchdog     bool
 	SerializeSnapshots           bool
 	NoKeyProvided                bool
-	SnapshotsEnabled             bool
 	OperationMode                string
 	RepopulateTokensSupplies     bool
 }

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -133,6 +133,15 @@ func TestTomlParser(t *testing.T) {
 				DoProfileOnShuffleOut:   true,
 			},
 		},
+		StateTriesConfig: StateTriesConfig{
+			CheckpointRoundsModulus:     37,
+			CheckpointsEnabled:          true,
+			SnapshotsEnabled:            true,
+			AccountsStatePruningEnabled: true,
+			PeerStatePruningEnabled:     true,
+			MaxStateTrieLevelInMemory:   38,
+			MaxPeerTrieLevelInMemory:    39,
+		},
 	}
 	testString := `
 [MiniBlocksStorage]
@@ -218,6 +227,15 @@ func TestTomlParser(t *testing.T) {
         CallGCWhenShuffleOut = true
         ExtraPrintsOnShuffleOut = true
         DoProfileOnShuffleOut = true
+
+[StateTriesConfig]
+    CheckpointRoundsModulus = 37
+    CheckpointsEnabled = true
+    SnapshotsEnabled = true
+    AccountsStatePruningEnabled = true
+    PeerStatePruningEnabled = true
+    MaxStateTrieLevelInMemory = 38
+    MaxPeerTrieLevelInMemory = 39
 `
 	cfg := Config{}
 

--- a/dataRetriever/factory/storageRequestersContainer/args.go
+++ b/dataRetriever/factory/storageRequestersContainer/args.go
@@ -26,6 +26,5 @@ type FactoryArgs struct {
 	DataPacker               dataRetriever.DataPacker
 	ManualEpochStartNotifier dataRetriever.ManualEpochStartNotifier
 	ChanGracefullyClose      chan endProcess.ArgEndProcess
-	SnapshotsEnabled         bool
 	EnableEpochsHandler      common.EnableEpochsHandler
 }

--- a/dataRetriever/factory/storageRequestersContainer/metaRequestersContainerFactory.go
+++ b/dataRetriever/factory/storageRequestersContainer/metaRequestersContainerFactory.go
@@ -36,7 +36,7 @@ func NewMetaRequestersContainerFactory(
 		shardIDForTries:          args.ShardIDForTries,
 		chainID:                  args.ChainID,
 		workingDir:               args.WorkingDirectory,
-		snapshotsEnabled:         args.SnapshotsEnabled,
+		snapshotsEnabled:         args.GeneralConfig.StateTriesConfig.SnapshotsEnabled,
 		enableEpochsHandler:      args.EnableEpochsHandler,
 	}
 

--- a/dataRetriever/factory/storageRequestersContainer/metaRequestersContainerFactory_test.go
+++ b/dataRetriever/factory/storageRequestersContainer/metaRequestersContainerFactory_test.go
@@ -224,7 +224,6 @@ func getArgumentsMeta() storagerequesterscontainer.FactoryArgs {
 		DataPacker:               &mock.DataPackerStub{},
 		ManualEpochStartNotifier: &mock.ManualEpochStartNotifierStub{},
 		ChanGracefullyClose:      make(chan endProcess.ArgEndProcess),
-		SnapshotsEnabled:         true,
 		EnableEpochsHandler:      &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
 	}
 }

--- a/dataRetriever/factory/storageRequestersContainer/shardRequestersContainerFactory.go
+++ b/dataRetriever/factory/storageRequestersContainer/shardRequestersContainerFactory.go
@@ -36,7 +36,7 @@ func NewShardRequestersContainerFactory(
 		shardIDForTries:          args.ShardIDForTries,
 		chainID:                  args.ChainID,
 		workingDir:               args.WorkingDirectory,
-		snapshotsEnabled:         args.SnapshotsEnabled,
+		snapshotsEnabled:         args.GeneralConfig.StateTriesConfig.SnapshotsEnabled,
 		enableEpochsHandler:      args.EnableEpochsHandler,
 	}
 

--- a/dataRetriever/factory/storageRequestersContainer/shardRequestersContainerFactory_test.go
+++ b/dataRetriever/factory/storageRequestersContainer/shardRequestersContainerFactory_test.go
@@ -209,7 +209,6 @@ func getArgumentsShard() storagerequesterscontainer.FactoryArgs {
 		DataPacker:               &mock.DataPackerStub{},
 		ManualEpochStartNotifier: &mock.ManualEpochStartNotifierStub{},
 		ChanGracefullyClose:      make(chan endProcess.ArgEndProcess),
-		SnapshotsEnabled:         true,
 		EnableEpochsHandler:      &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
 	}
 }

--- a/epochStart/bootstrap/fromLocalStorage.go
+++ b/epochStart/bootstrap/fromLocalStorage.go
@@ -111,7 +111,6 @@ func (e *epochStartBootstrap) prepareEpochFromStorage() (Parameters, error) {
 	e.closeTrieComponents()
 	e.storageService = disabled.NewChainStorer()
 	triesContainer, trieStorageManagers, err := factory.CreateTriesComponentsForShardId(
-		e.flagsConfig.SnapshotsEnabled,
 		e.generalConfig,
 		e.coreComponentsHolder,
 		e.storageService,

--- a/epochStart/bootstrap/metaStorageHandler.go
+++ b/epochStart/bootstrap/metaStorageHandler.go
@@ -37,7 +37,6 @@ func NewMetaStorageHandler(
 	uint64Converter typeConverters.Uint64ByteSliceConverter,
 	nodeTypeProvider NodeTypeProviderHandler,
 	nodeProcessingMode common.NodeProcessingMode,
-	snapshotsEnabled bool,
 	managedPeersHolder common.ManagedPeersHolder,
 ) (*metaStorageHandler, error) {
 	epochStartNotifier := &disabled.EpochStartNotifier{}
@@ -53,7 +52,6 @@ func NewMetaStorageHandler(
 			StorageType:                   factory.BootstrapStorageService,
 			CreateTrieEpochRootHashStorer: false,
 			NodeProcessingMode:            nodeProcessingMode,
-			SnapshotsEnabled:              snapshotsEnabled,
 			RepopulateTokensSupplies:      false, // tokens supplies cannot be repopulated at this time
 			ManagedPeersHolder:            managedPeersHolder,
 		},

--- a/epochStart/bootstrap/metaStorageHandler_test.go
+++ b/epochStart/bootstrap/metaStorageHandler_test.go
@@ -46,7 +46,6 @@ func TestNewMetaStorageHandler_InvalidConfigErr(t *testing.T) {
 		uit64Cvt,
 		nodeTypeProvider,
 		common.Normal,
-		false,
 		managedPeersHolder,
 	)
 	assert.True(t, check.IfNil(mtStrHandler))
@@ -78,7 +77,6 @@ func TestNewMetaStorageHandler_CreateForMetaErr(t *testing.T) {
 		uit64Cvt,
 		nodeTypeProvider,
 		common.Normal,
-		false,
 		managedPeersHolder,
 	)
 	assert.False(t, check.IfNil(mtStrHandler))
@@ -111,7 +109,6 @@ func TestMetaStorageHandler_saveLastHeader(t *testing.T) {
 		uit64Cvt,
 		nodeTypeProvider,
 		common.Normal,
-		false,
 		managedPeersHolder,
 	)
 
@@ -153,7 +150,6 @@ func TestMetaStorageHandler_saveLastCrossNotarizedHeaders(t *testing.T) {
 		uit64Cvt,
 		nodeTypeProvider,
 		common.Normal,
-		false,
 		managedPeersHolder,
 	)
 
@@ -201,7 +197,6 @@ func TestMetaStorageHandler_saveTriggerRegistry(t *testing.T) {
 		uit64Cvt,
 		nodeTypeProvider,
 		common.Normal,
-		false,
 		managedPeersHolder,
 	)
 
@@ -240,7 +235,6 @@ func TestMetaStorageHandler_saveDataToStorage(t *testing.T) {
 		uit64Cvt,
 		nodeTypeProvider,
 		common.Normal,
-		false,
 		managedPeersHolder,
 	)
 
@@ -296,7 +290,6 @@ func testMetaWithMissingStorer(missingUnit dataRetriever.UnitType, atCallNumber 
 			uit64Cvt,
 			nodeTypeProvider,
 			common.Normal,
-			false,
 			managedPeersHolder,
 		)
 		counter := 0

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -486,7 +486,6 @@ func (e *epochStartBootstrap) prepareComponentsToSyncFromNetwork() error {
 	e.closeTrieComponents()
 	e.storageService = disabled.NewChainStorer()
 	triesContainer, trieStorageManagers, err := factory.CreateTriesComponentsForShardId(
-		e.flagsConfig.SnapshotsEnabled,
 		e.generalConfig,
 		e.coreComponentsHolder,
 		e.storageService,
@@ -767,7 +766,6 @@ func (e *epochStartBootstrap) requestAndProcessForMeta(peerMiniBlocks []*block.M
 		e.coreComponentsHolder.Uint64ByteSliceConverter(),
 		e.coreComponentsHolder.NodeTypeProvider(),
 		e.nodeProcessingMode,
-		e.flagsConfig.SnapshotsEnabled,
 		e.cryptoComponentsHolder.ManagedPeersHolder(),
 	)
 	if err != nil {
@@ -778,7 +776,6 @@ func (e *epochStartBootstrap) requestAndProcessForMeta(peerMiniBlocks []*block.M
 
 	e.closeTrieComponents()
 	triesContainer, trieStorageManagers, err := factory.CreateTriesComponentsForShardId(
-		e.flagsConfig.SnapshotsEnabled,
 		e.generalConfig,
 		e.coreComponentsHolder,
 		storageHandlerComponent.storageService,
@@ -937,7 +934,6 @@ func (e *epochStartBootstrap) requestAndProcessForShard(peerMiniBlocks []*block.
 		e.coreComponentsHolder.Uint64ByteSliceConverter(),
 		e.coreComponentsHolder.NodeTypeProvider(),
 		e.nodeProcessingMode,
-		e.flagsConfig.SnapshotsEnabled,
 		e.cryptoComponentsHolder.ManagedPeersHolder(),
 	)
 	if err != nil {
@@ -948,7 +944,6 @@ func (e *epochStartBootstrap) requestAndProcessForShard(peerMiniBlocks []*block.
 
 	e.closeTrieComponents()
 	triesContainer, trieStorageManagers, err := factory.CreateTriesComponentsForShardId(
-		e.flagsConfig.SnapshotsEnabled,
 		e.generalConfig,
 		e.coreComponentsHolder,
 		storageHandlerComponent.storageService,
@@ -1122,7 +1117,6 @@ func (e *epochStartBootstrap) createStorageService(
 			StorageType:                   storageFactory.BootstrapStorageService,
 			CreateTrieEpochRootHashStorer: createTrieEpochRootHashStorer,
 			NodeProcessingMode:            e.nodeProcessingMode,
-			SnapshotsEnabled:              e.flagsConfig.SnapshotsEnabled,
 			RepopulateTokensSupplies:      e.flagsConfig.RepopulateTokensSupplies,
 			ManagedPeersHolder:            e.cryptoComponentsHolder.ManagedPeersHolder(),
 		})

--- a/epochStart/bootstrap/process_test.go
+++ b/epochStart/bootstrap/process_test.go
@@ -1005,7 +1005,6 @@ func TestSyncValidatorAccountsState_NilRequestHandlerErr(t *testing.T) {
 		},
 	}
 	triesContainer, trieStorageManagers, err := factory.CreateTriesComponentsForShardId(
-		false,
 		args.GeneralConfig,
 		coreComp,
 		disabled.NewChainStorer(),
@@ -1025,7 +1024,6 @@ func TestCreateTriesForNewShardID(t *testing.T) {
 	args.GeneralConfig = testscommon.GetGeneralConfig()
 
 	triesContainer, trieStorageManagers, err := factory.CreateTriesComponentsForShardId(
-		false,
 		args.GeneralConfig,
 		coreComp,
 		disabled.NewChainStorer(),
@@ -1052,7 +1050,6 @@ func TestSyncUserAccountsState(t *testing.T) {
 	}
 
 	triesContainer, trieStorageManagers, err := factory.CreateTriesComponentsForShardId(
-		false,
 		args.GeneralConfig,
 		coreComp,
 		disabled.NewChainStorer(),

--- a/epochStart/bootstrap/shardStorageHandler.go
+++ b/epochStart/bootstrap/shardStorageHandler.go
@@ -41,7 +41,6 @@ func NewShardStorageHandler(
 	uint64Converter typeConverters.Uint64ByteSliceConverter,
 	nodeTypeProvider core.NodeTypeProviderHandler,
 	nodeProcessingMode common.NodeProcessingMode,
-	snapshotsEnabled bool,
 	managedPeersHolder common.ManagedPeersHolder,
 ) (*shardStorageHandler, error) {
 	epochStartNotifier := &disabled.EpochStartNotifier{}
@@ -57,7 +56,6 @@ func NewShardStorageHandler(
 			StorageType:                   factory.BootstrapStorageService,
 			CreateTrieEpochRootHashStorer: false,
 			NodeProcessingMode:            nodeProcessingMode,
-			SnapshotsEnabled:              snapshotsEnabled,
 			RepopulateTokensSupplies:      false, // tokens supplies cannot be repopulated at this time
 			ManagedPeersHolder:            managedPeersHolder,
 		},

--- a/epochStart/bootstrap/shardStorageHandler_test.go
+++ b/epochStart/bootstrap/shardStorageHandler_test.go
@@ -52,7 +52,6 @@ func TestNewShardStorageHandler_ShouldWork(t *testing.T) {
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 
@@ -77,7 +76,6 @@ func TestShardStorageHandler_SaveDataToStorageShardDataNotFound(t *testing.T) {
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 
@@ -108,7 +106,6 @@ func TestShardStorageHandler_SaveDataToStorageMissingHeader(t *testing.T) {
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 
@@ -162,7 +159,6 @@ func testShardWithMissingStorer(missingUnit dataRetriever.UnitType, atCallNumber
 			args.uint64Converter,
 			args.nodeTypeProvider,
 			args.nodeProcessingMode,
-			false,
 			args.managedPeersHolder,
 		)
 		shardStorage.storageService = &storageStubs.ChainStorerStub{
@@ -217,7 +213,6 @@ func TestShardStorageHandler_SaveDataToStorage(t *testing.T) {
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 
@@ -329,7 +324,6 @@ func TestShardStorageHandler_getCrossProcessedMiniBlockHeadersDestMe(t *testing.
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	shardHeader := &block.Header{
@@ -362,7 +356,6 @@ func TestShardStorageHandler_getProcessedAndPendingMiniBlocksWithScheduledErrorG
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	meta := &block.MetaBlock{
@@ -393,7 +386,6 @@ func TestShardStorageHandler_getProcessedAndPendingMiniBlocksWithScheduledNoSche
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	scenario := createPendingAndProcessedMiniBlocksScenario()
@@ -421,7 +413,6 @@ func TestShardStorageHandler_getProcessedAndPendingMiniBlocksWithScheduledWrongH
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	scenario := createPendingAndProcessedMiniBlocksScenario()
@@ -456,7 +447,6 @@ func TestShardStorageHandler_getProcessedAndPendingMiniBlocksWithScheduled(t *te
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	scenario := createPendingAndProcessedMiniBlocksScenario()
@@ -637,7 +627,6 @@ func TestShardStorageHandler_getProcessedAndPendingMiniBlocksErrorGettingEpochSt
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	meta := &block.MetaBlock{
@@ -673,7 +662,6 @@ func TestShardStorageHandler_getProcessedAndPendingMiniBlocksMissingHeader(t *te
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	meta := &block.MetaBlock{
@@ -712,7 +700,6 @@ func TestShardStorageHandler_getProcessedAndPendingMiniBlocksWrongHeader(t *test
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	lastFinishedHeaders := createDefaultEpochStartShardData([]byte(lastFinishedMetaBlockHash), []byte("headerHash"))
@@ -756,7 +743,6 @@ func TestShardStorageHandler_getProcessedAndPendingMiniBlocksNilMetaBlock(t *tes
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	lastFinishedHeaders := createDefaultEpochStartShardData([]byte(lastFinishedMetaBlockHash), []byte("headerHash"))
@@ -802,7 +788,6 @@ func TestShardStorageHandler_getProcessedAndPendingMiniBlocksNoProcessedNoPendin
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	lastFinishedHeaders := createDefaultEpochStartShardData([]byte(lastFinishedMetaBlockHash), []byte("headerHash"))
@@ -844,7 +829,6 @@ func TestShardStorageHandler_getProcessedAndPendingMiniBlocksWithProcessedAndPen
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	scenario := createPendingAndProcessedMiniBlocksScenario()
@@ -875,7 +859,6 @@ func TestShardStorageHandler_saveLastCrossNotarizedHeadersWithoutScheduledGetSha
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 
@@ -909,7 +892,6 @@ func TestShardStorageHandler_saveLastCrossNotarizedHeadersWithoutScheduledMissin
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	shard0HeaderHash := "shard0 header hash"
@@ -951,7 +933,6 @@ func TestShardStorageHandler_saveLastCrossNotarizedHeadersWithoutScheduledWrongT
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	shard0HeaderHash := "shard0 header hash"
@@ -1000,7 +981,6 @@ func TestShardStorageHandler_saveLastCrossNotarizedHeadersWithoutScheduledErrorW
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	shard0HeaderHash := "shard0 header hash"
@@ -1044,7 +1024,6 @@ func TestShardStorageHandler_saveLastCrossNotarizedHeadersWithoutScheduled(t *te
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	shard0HeaderHash := "shard0 header hash"
@@ -1093,7 +1072,6 @@ func TestShardStorageHandler_saveLastCrossNotarizedHeadersWithScheduledErrorUpda
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	shard0HeaderHash := "shard0 header hash"
@@ -1136,7 +1114,6 @@ func TestShardStorageHandler_saveLastCrossNotarizedHeadersWithScheduled(t *testi
 		args.uint64Converter,
 		args.nodeTypeProvider,
 		args.nodeProcessingMode,
-		false,
 		args.managedPeersHolder,
 	)
 	shard0HeaderHash := "shard0 header hash"

--- a/epochStart/bootstrap/storageProcess.go
+++ b/epochStart/bootstrap/storageProcess.go
@@ -149,7 +149,6 @@ func (sesb *storageEpochStartBootstrap) prepareComponentsToSync() error {
 	sesb.closeTrieComponents()
 	sesb.storageService = disabled.NewChainStorer()
 	triesContainer, trieStorageManagers, err := factory.CreateTriesComponentsForShardId(
-		sesb.flagsConfig.SnapshotsEnabled,
 		sesb.generalConfig,
 		sesb.coreComponentsHolder,
 		sesb.storageService,
@@ -252,7 +251,6 @@ func (sesb *storageEpochStartBootstrap) createStorageRequesters() error {
 		DataPacker:               dataPacker,
 		ManualEpochStartNotifier: mesn,
 		ChanGracefullyClose:      sesb.chanGracefullyClose,
-		SnapshotsEnabled:         sesb.flagsConfig.SnapshotsEnabled,
 		EnableEpochsHandler:      sesb.coreComponentsHolder.EnableEpochsHandler(),
 	}
 

--- a/factory/data/dataComponents.go
+++ b/factory/data/dataComponents.go
@@ -171,7 +171,6 @@ func (dcf *dataComponentsFactory) createDataStoreFromConfig() (dataRetriever.Sto
 			StorageType:                   storageFactory.ProcessStorageService,
 			CreateTrieEpochRootHashStorer: dcf.createTrieEpochRootHashStorer,
 			NodeProcessingMode:            dcf.nodeProcessingMode,
-			SnapshotsEnabled:              dcf.flagsConfig.SnapshotsEnabled,
 			RepopulateTokensSupplies:      dcf.flagsConfig.RepopulateTokensSupplies,
 			ManagedPeersHolder:            dcf.crypto.ManagedPeersHolder(),
 		})

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -1488,7 +1488,6 @@ func (pcf *processComponentsFactory) newStorageRequesters() (dataRetriever.Reque
 			StorageType:                   storageFactory.ProcessStorageService,
 			CreateTrieEpochRootHashStorer: false,
 			NodeProcessingMode:            common.GetNodeProcessingMode(&pcf.importDBConfig),
-			SnapshotsEnabled:              pcf.flagsConfig.SnapshotsEnabled,
 			RepopulateTokensSupplies:      pcf.flagsConfig.RepopulateTokensSupplies,
 			ManagedPeersHolder:            pcf.crypto.ManagedPeersHolder(),
 		},
@@ -1543,7 +1542,6 @@ func (pcf *processComponentsFactory) createStorageRequestersForMeta(
 		DataPacker:               dataPacker,
 		ManualEpochStartNotifier: manualEpochStartNotifier,
 		ChanGracefullyClose:      pcf.coreData.ChanStopNodeProcess(),
-		SnapshotsEnabled:         pcf.flagsConfig.SnapshotsEnabled,
 		EnableEpochsHandler:      pcf.coreData.EnableEpochsHandler(),
 	}
 
@@ -1573,7 +1571,6 @@ func (pcf *processComponentsFactory) createStorageRequestersForShard(
 		DataPacker:               dataPacker,
 		ManualEpochStartNotifier: manualEpochStartNotifier,
 		ChanGracefullyClose:      pcf.coreData.ChanStopNodeProcess(),
-		SnapshotsEnabled:         pcf.flagsConfig.SnapshotsEnabled,
 		EnableEpochsHandler:      pcf.coreData.EnableEpochsHandler(),
 	}
 

--- a/factory/state/stateComponents.go
+++ b/factory/state/stateComponents.go
@@ -28,7 +28,6 @@ type StateComponentsFactoryArgs struct {
 	StorageService           dataRetriever.StorageService
 	ProcessingMode           common.NodeProcessingMode
 	ShouldSerializeSnapshots bool
-	SnapshotsEnabled         bool
 	ChainHandler             chainData.ChainHandler
 }
 
@@ -39,7 +38,6 @@ type stateComponentsFactory struct {
 	storageService           dataRetriever.StorageService
 	processingMode           common.NodeProcessingMode
 	shouldSerializeSnapshots bool
-	snapshotsEnabled         bool
 	chainHandler             chainData.ChainHandler
 }
 
@@ -74,14 +72,12 @@ func NewStateComponentsFactory(args StateComponentsFactoryArgs) (*stateComponent
 		processingMode:           args.ProcessingMode,
 		shouldSerializeSnapshots: args.ShouldSerializeSnapshots,
 		chainHandler:             args.ChainHandler,
-		snapshotsEnabled:         args.SnapshotsEnabled,
 	}, nil
 }
 
 // Create creates the state components
 func (scf *stateComponentsFactory) Create() (*stateComponents, error) {
 	triesContainer, trieStorageManagers, err := trieFactory.CreateTriesComponentsForShardId(
-		scf.snapshotsEnabled,
 		scf.config,
 		scf.core,
 		scf.storageService,

--- a/integrationTests/multiShard/endOfEpoch/startInEpoch/startInEpoch_test.go
+++ b/integrationTests/multiShard/endOfEpoch/startInEpoch/startInEpoch_test.go
@@ -288,7 +288,6 @@ func testNodeStartsInEpoch(t *testing.T, shardID uint32, expectedHighestRound ui
 			StorageType:                   factory.ProcessStorageService,
 			CreateTrieEpochRootHashStorer: false,
 			NodeProcessingMode:            common.Normal,
-			SnapshotsEnabled:              false,
 			ManagedPeersHolder:            &testscommon.ManagedPeersHolderStub{},
 		},
 	)

--- a/integrationTests/realcomponents/processorRunner.go
+++ b/integrationTests/realcomponents/processorRunner.go
@@ -233,9 +233,7 @@ func (pr *ProcessorRunner) createDataComponents(tb testing.TB) {
 		CurrentEpoch:                  0,
 		CreateTrieEpochRootHashStorer: false,
 		NodeProcessingMode:            common.Normal,
-		FlagsConfigs: config.ContextFlagsConfig{
-			SnapshotsEnabled: false,
-		},
+		FlagsConfigs:                  config.ContextFlagsConfig{},
 	}
 
 	dataFactory, err := factoryData.NewDataComponentsFactory(argsData)
@@ -260,7 +258,6 @@ func (pr *ProcessorRunner) createStateComponents(tb testing.TB) {
 		StorageService:           pr.DataComponents.StorageService(),
 		ProcessingMode:           common.Normal,
 		ShouldSerializeSnapshots: false,
-		SnapshotsEnabled:         false,
 		ChainHandler:             pr.DataComponents.Blockchain(),
 	}
 
@@ -410,9 +407,8 @@ func (pr *ProcessorRunner) createProcessComponents(tb testing.TB) {
 		PrefConfigs:    *pr.Config.PreferencesConfig,
 		ImportDBConfig: *pr.Config.ImportDbConfig,
 		FlagsConfig: config.ContextFlagsConfig{
-			Version:          "test",
-			WorkingDir:       pr.Config.FlagsConfig.WorkingDir,
-			SnapshotsEnabled: false,
+			Version:    "test",
+			WorkingDir: pr.Config.FlagsConfig.WorkingDir,
 		},
 		AccountsParser:         accountsParser,
 		SmartContractParser:    smartContractParser,

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -1321,7 +1321,6 @@ func (nr *nodeRunner) CreateManagedStateComponents(
 		StorageService:           dataComponents.StorageService(),
 		ProcessingMode:           common.GetNodeProcessingMode(nr.configs.ImportDbConfig),
 		ShouldSerializeSnapshots: nr.configs.FlagsConfig.SerializeSnapshots,
-		SnapshotsEnabled:         nr.configs.FlagsConfig.SnapshotsEnabled,
 		ChainHandler:             dataComponents.Blockchain(),
 	}
 

--- a/storage/factory/storageServiceFactory.go
+++ b/storage/factory/storageServiceFactory.go
@@ -68,7 +68,6 @@ type StorageServiceFactoryArgs struct {
 	CurrentEpoch                  uint32
 	CreateTrieEpochRootHashStorer bool
 	NodeProcessingMode            common.NodeProcessingMode
-	SnapshotsEnabled              bool
 	RepopulateTokensSupplies      bool
 }
 
@@ -103,7 +102,7 @@ func NewStorageServiceFactory(args StorageServiceFactoryArgs) (*StorageServiceFa
 		oldDataCleanerProvider:        oldDataCleanProvider,
 		storageType:                   args.StorageType,
 		nodeProcessingMode:            args.NodeProcessingMode,
-		snapshotsEnabled:              args.SnapshotsEnabled,
+		snapshotsEnabled:              args.Config.StateTriesConfig.SnapshotsEnabled,
 		repopulateTokensSupplies:      args.RepopulateTokensSupplies,
 	}, nil
 }

--- a/trie/factory/trieCreator.go
+++ b/trie/factory/trieCreator.go
@@ -16,14 +16,14 @@ import (
 
 // TrieCreateArgs holds arguments for calling the Create method on the TrieFactory
 type TrieCreateArgs struct {
-	MainStorer         storage.Storer
-	CheckpointsStorer  storage.Storer
-	PruningEnabled     bool
-	CheckpointsEnabled bool
-	SnapshotsEnabled   bool
-	MaxTrieLevelInMem  uint
-	IdleProvider       trie.IdleNodeProvider
-	Identifier         string
+	MainStorer          storage.Storer
+	CheckpointsStorer   storage.Storer
+	PruningEnabled      bool
+	CheckpointsEnabled  bool
+	SnapshotsEnabled    bool
+	MaxTrieLevelInMem   uint
+	IdleProvider        trie.IdleNodeProvider
+	Identifier          string
 	EnableEpochsHandler common.EnableEpochsHandler
 }
 
@@ -109,7 +109,6 @@ func (tc *trieCreator) IsInterfaceNil() bool {
 
 // CreateTriesComponentsForShardId creates the user and peer tries and trieStorageManagers
 func CreateTriesComponentsForShardId(
-	snapshotsEnabled bool,
 	generalConfig config.Config,
 	coreComponentsHolder coreComponentsHandler,
 	storageService dataRetriever.StorageService,
@@ -136,14 +135,14 @@ func CreateTriesComponentsForShardId(
 	}
 
 	args := TrieCreateArgs{
-		MainStorer:         mainStorer,
-		CheckpointsStorer:  checkpointsStorer,
-		PruningEnabled:     generalConfig.StateTriesConfig.AccountsStatePruningEnabled,
-		CheckpointsEnabled: generalConfig.StateTriesConfig.CheckpointsEnabled,
-		MaxTrieLevelInMem:  generalConfig.StateTriesConfig.MaxStateTrieLevelInMemory,
-		SnapshotsEnabled:   snapshotsEnabled,
-		IdleProvider:       coreComponentsHolder.ProcessStatusHandler(),
-		Identifier:         dataRetriever.UserAccountsUnit.String(),
+		MainStorer:          mainStorer,
+		CheckpointsStorer:   checkpointsStorer,
+		PruningEnabled:      generalConfig.StateTriesConfig.AccountsStatePruningEnabled,
+		CheckpointsEnabled:  generalConfig.StateTriesConfig.CheckpointsEnabled,
+		MaxTrieLevelInMem:   generalConfig.StateTriesConfig.MaxStateTrieLevelInMemory,
+		SnapshotsEnabled:    generalConfig.StateTriesConfig.SnapshotsEnabled,
+		IdleProvider:        coreComponentsHolder.ProcessStatusHandler(),
+		Identifier:          dataRetriever.UserAccountsUnit.String(),
 		EnableEpochsHandler: coreComponentsHolder.EnableEpochsHandler(),
 	}
 	userStorageManager, userAccountTrie, err := trFactory.Create(args)
@@ -168,14 +167,14 @@ func CreateTriesComponentsForShardId(
 	}
 
 	args = TrieCreateArgs{
-		MainStorer:         mainStorer,
-		CheckpointsStorer:  checkpointsStorer,
-		PruningEnabled:     generalConfig.StateTriesConfig.PeerStatePruningEnabled,
-		CheckpointsEnabled: generalConfig.StateTriesConfig.CheckpointsEnabled,
-		MaxTrieLevelInMem:  generalConfig.StateTriesConfig.MaxPeerTrieLevelInMemory,
-		SnapshotsEnabled:   snapshotsEnabled,
-		IdleProvider:       coreComponentsHolder.ProcessStatusHandler(),
-		Identifier:         dataRetriever.PeerAccountsUnit.String(),
+		MainStorer:          mainStorer,
+		CheckpointsStorer:   checkpointsStorer,
+		PruningEnabled:      generalConfig.StateTriesConfig.PeerStatePruningEnabled,
+		CheckpointsEnabled:  generalConfig.StateTriesConfig.CheckpointsEnabled,
+		MaxTrieLevelInMem:   generalConfig.StateTriesConfig.MaxPeerTrieLevelInMemory,
+		SnapshotsEnabled:    generalConfig.StateTriesConfig.SnapshotsEnabled,
+		IdleProvider:        coreComponentsHolder.ProcessStatusHandler(),
+		Identifier:          dataRetriever.PeerAccountsUnit.String(),
 		EnableEpochsHandler: coreComponentsHolder.EnableEpochsHandler(),
 	}
 	peerStorageManager, peerAccountsTrie, err := trFactory.Create(args)

--- a/trie/factory/trieCreator_test.go
+++ b/trie/factory/trieCreator_test.go
@@ -32,14 +32,14 @@ func getArgs() factory.TrieFactoryArgs {
 
 func getCreateArgs() factory.TrieCreateArgs {
 	return factory.TrieCreateArgs{
-		MainStorer:         testscommon.CreateMemUnit(),
-		CheckpointsStorer:  testscommon.CreateMemUnit(),
-		PruningEnabled:     false,
-		CheckpointsEnabled: false,
-		SnapshotsEnabled:   true,
-		MaxTrieLevelInMem:  5,
-		IdleProvider:       &testscommon.ProcessStatusHandlerStub{},
-		Identifier:         dataRetriever.UserAccountsUnit.String(),
+		MainStorer:          testscommon.CreateMemUnit(),
+		CheckpointsStorer:   testscommon.CreateMemUnit(),
+		PruningEnabled:      false,
+		CheckpointsEnabled:  false,
+		SnapshotsEnabled:    true,
+		MaxTrieLevelInMem:   5,
+		IdleProvider:        &testscommon.ProcessStatusHandlerStub{},
+		Identifier:          dataRetriever.UserAccountsUnit.String(),
 		EnableEpochsHandler: &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
 	}
 }
@@ -194,7 +194,6 @@ func TestTrieCreator_CreateTriesComponentsForShardId(t *testing.T) {
 		t.Parallel()
 
 		holder, storageManager, err := factory.CreateTriesComponentsForShardId(
-			false,
 			testscommon.GetGeneralConfig(),
 			&mock.CoreComponentsStub{
 				InternalMarshalizerField:     &marshallerMock.MarshalizerMock{},
@@ -220,7 +219,6 @@ func testWithMissingStorer(missingUnit dataRetriever.UnitType) func(t *testing.T
 		t.Parallel()
 
 		holder, storageManager, err := factory.CreateTriesComponentsForShardId(
-			false,
 			testscommon.GetGeneralConfig(),
 			&mock.CoreComponentsStub{
 				InternalMarshalizerField:     &marshallerMock.MarshalizerMock{},


### PR DESCRIPTION
## Reasoning behind the pull request
- rc/v1.6.0 can not start a snapshot-less node by providing the config through config.toml
  
## Proposed changes
- put back snapshot-less config in config.toml

## Testing procedure
- standard system test in which we start a snapshot-less node using the following possibilities:
1. start the node with the flag `--snapshots-enabled=false`
2. start the node using the flag `--operation-mode snapshotless-observer`
3. start the node by altering the config.toml (either directly or using the override configs in prefs.toml) for `SnapshotsEnabled = false`

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
