### PR TITLE
Sovereign cross notarizer

### DIFF
--- a/process/block/baseCrossNotarizer.go
+++ b/process/block/baseCrossNotarizer.go
@@ -1,0 +1,32 @@
+package block
+
+import (
+	"github.com/multiversx/mx-chain-go/process"
+	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
+)
+
+type baseBlockNotarizer struct {
+	blockTracker process.BlockTracker
+}
+
+func (bbn *baseBlockNotarizer) getLastCrossNotarizedHeadersForShard(shardID uint32) *bootstrapStorage.BootstrapHeaderInfo {
+	lastCrossNotarizedHeader, lastCrossNotarizedHeaderHash, err := bbn.blockTracker.GetLastCrossNotarizedHeader(shardID)
+	if err != nil {
+		log.Warn("getLastCrossNotarizedHeadersForShard",
+			"shard", shardID,
+			"error", err.Error())
+		return nil
+	}
+
+	if lastCrossNotarizedHeader.GetNonce() == 0 {
+		return nil
+	}
+
+	headerInfo := &bootstrapStorage.BootstrapHeaderInfo{
+		ShardId: lastCrossNotarizedHeader.GetShardID(),
+		Nonce:   lastCrossNotarizedHeader.GetNonce(),
+		Hash:    lastCrossNotarizedHeaderHash,
+	}
+
+	return headerInfo
+}

--- a/process/block/interface.go
+++ b/process/block/interface.go
@@ -3,6 +3,7 @@ package block
 import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
 )
 
 type blockProcessor interface {
@@ -32,4 +33,8 @@ type validatorStatsRootHashGetter interface {
 
 type extendedShardHeaderHashesGetter interface {
 	GetExtendedShardHeaderHashes() [][]byte
+}
+
+type crossNotarizer interface {
+	getLastCrossNotarizedHeaders() []bootstrapStorage.BootstrapHeaderInfo
 }

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -90,6 +90,12 @@ func NewMetaProcessor(arguments ArgMetaProcessor) (*metaProcessor, error) {
 	}
 
 	genesisHdr := arguments.DataComponents.Blockchain().GetGenesisHeader()
+	notarizer := &multiShardCrossNotarizer{
+		shardCoordinator: arguments.BootstrapComponents.ShardCoordinator(),
+		baseBlockNotarizer: &baseBlockNotarizer{
+			blockTracker: arguments.BlockTracker,
+		},
+	}
 	base := &baseProcessor{
 		accountsDB:                    arguments.AccountsDB,
 		blockSizeThrottler:            arguments.BlockSizeThrottler,
@@ -136,6 +142,7 @@ func NewMetaProcessor(arguments ArgMetaProcessor) (*metaProcessor, error) {
 		processStatusHandler:          arguments.CoreComponents.ProcessStatusHandler(),
 		blockProcessingCutoffHandler:  arguments.BlockProcessingCutoffHandler,
 		managedPeersHolder:            arguments.ManagedPeersHolder,
+		crossNotarizer:                notarizer,
 	}
 
 	mp := metaProcessor{

--- a/process/block/multiShardCrossNotarizer.go
+++ b/process/block/multiShardCrossNotarizer.go
@@ -1,0 +1,34 @@
+package block
+
+import (
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
+	"github.com/multiversx/mx-chain-go/sharding"
+)
+
+type multiShardCrossNotarizer struct {
+	*baseBlockNotarizer
+	shardCoordinator sharding.Coordinator
+}
+
+func (mcn *multiShardCrossNotarizer) getLastCrossNotarizedHeaders() []bootstrapStorage.BootstrapHeaderInfo {
+	lastCrossNotarizedHeaders := make([]bootstrapStorage.BootstrapHeaderInfo, 0, mcn.shardCoordinator.NumberOfShards()+1)
+
+	for shardID := uint32(0); shardID < mcn.shardCoordinator.NumberOfShards(); shardID++ {
+		bootstrapHeaderInfo := mcn.getLastCrossNotarizedHeadersForShard(shardID)
+		if bootstrapHeaderInfo != nil {
+			lastCrossNotarizedHeaders = append(lastCrossNotarizedHeaders, *bootstrapHeaderInfo)
+		}
+	}
+
+	bootstrapHeaderInfo := mcn.getLastCrossNotarizedHeadersForShard(core.MetachainShardId)
+	if bootstrapHeaderInfo != nil {
+		lastCrossNotarizedHeaders = append(lastCrossNotarizedHeaders, *bootstrapHeaderInfo)
+	}
+
+	if len(lastCrossNotarizedHeaders) == 0 {
+		return nil
+	}
+
+	return trimSliceBootstrapHeaderInfo(lastCrossNotarizedHeaders)
+}

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -74,6 +74,12 @@ func NewShardProcessor(arguments ArgShardProcessor) (*shardProcessor, error) {
 		return nil, err
 	}
 
+	notarizer := &multiShardCrossNotarizer{
+		shardCoordinator: arguments.BootstrapComponents.ShardCoordinator(),
+		baseBlockNotarizer: &baseBlockNotarizer{
+			blockTracker: arguments.BlockTracker,
+		},
+	}
 	base := &baseProcessor{
 		accountsDB:                    arguments.AccountsDB,
 		blockSizeThrottler:            arguments.BlockSizeThrottler,
@@ -120,6 +126,7 @@ func NewShardProcessor(arguments ArgShardProcessor) (*shardProcessor, error) {
 		processStatusHandler:          arguments.CoreComponents.ProcessStatusHandler(),
 		blockProcessingCutoffHandler:  arguments.BlockProcessingCutoffHandler,
 		managedPeersHolder:            arguments.ManagedPeersHolder,
+		crossNotarizer:                notarizer,
 	}
 
 	sp := shardProcessor{

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -80,6 +80,11 @@ func NewSovereignChainBlockProcessor(
 	scbp.requestMissingHeadersFunc = scbp.requestMissingHeaders
 	scbp.cleanupPoolsForCrossShardFunc = scbp.cleanupPoolsForCrossShard
 	scbp.cleanupBlockTrackerPoolsForShardFunc = scbp.cleanupBlockTrackerPoolsForShard
+	scbp.crossNotarizer = &sovereignShardCrossNotarizer{
+		baseBlockNotarizer: &baseBlockNotarizer{
+			blockTracker: scbp.blockTracker,
+		},
+	}
 
 	return scbp, nil
 }

--- a/process/block/sovereignCrossNotarizer.go
+++ b/process/block/sovereignCrossNotarizer.go
@@ -1,0 +1,21 @@
+package block
+
+import (
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
+)
+
+type sovereignShardCrossNotarizer struct {
+	*baseBlockNotarizer
+}
+
+func (scn *sovereignShardCrossNotarizer) getLastCrossNotarizedHeaders() []bootstrapStorage.BootstrapHeaderInfo {
+	bootstrapHeaderInfo := scn.getLastCrossNotarizedHeadersForShard(core.SovereignChainShardId)
+	if bootstrapHeaderInfo == nil {
+		return nil
+	}
+
+	lastCrossNotarizedHeaders := make([]bootstrapStorage.BootstrapHeaderInfo, 0, 1)
+	lastCrossNotarizedHeaders = append(lastCrossNotarizedHeaders, *bootstrapHeaderInfo)
+	return trimSliceBootstrapHeaderInfo(lastCrossNotarizedHeaders)
+}

--- a/process/block/sovereignCrossNotarizer_test.go
+++ b/process/block/sovereignCrossNotarizer_test.go
@@ -1,0 +1,42 @@
+package block
+
+import (
+	"testing"
+
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-go/factory/mock"
+	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSovereignShardCrossNotarizer_getLastCrossNotarizedHeaders(t *testing.T) {
+	hash := []byte("hash")
+	header := &block.SovereignChainHeader{
+		Header: &block.Header{
+			ShardID: core.SovereignChainShardId,
+			Nonce:   4,
+		},
+	}
+	sovereignNotarzier := &sovereignShardCrossNotarizer{
+		&baseBlockNotarizer{
+			blockTracker: &mock.BlockTrackerStub{
+				GetLastCrossNotarizedHeaderCalled: func(shardID uint32) (data.HeaderHandler, []byte, error) {
+					require.Equal(t, core.SovereignChainShardId, shardID)
+					return header, hash, nil
+				},
+			},
+		},
+	}
+
+	headers := sovereignNotarzier.getLastCrossNotarizedHeaders()
+	expectedHeaders := []bootstrapStorage.BootstrapHeaderInfo{
+		{
+			ShardId: header.GetShardID(),
+			Nonce:   header.GetNonce(),
+			Hash:    hash,
+		},
+	}
+	require.Equal(t, expectedHeaders, headers)
+}


### PR DESCRIPTION
## Reasoning behind the pull request
- There was some meta notarization on sovereign chain that introduced warnings at each block
  
## Proposed changes
- Extracted `getLastCrossNotarizedHeaders` func from `baseProcessor.go`, which was notarizing all shards+meta.
- Created a small base component (`baseBlockNotarizer`) used for  `getLastCrossNotarizedHeadersForShard`
- Created two small components that inherit `baseBlockNotarizer`: `multiShardCrossNotarizer` for regular chain + `sovereignShardCrossNotarizer` for sovereign chain

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
