### PR TITLE
set max gas per query to 300s equivalent

### DIFF
--- a/process/smartContract/scQueryService.go
+++ b/process/smartContract/scQueryService.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"sync"
 
@@ -28,6 +27,9 @@ import (
 )
 
 var _ process.SCQueryService = (*SCQueryService)(nil)
+
+// MaxGasLimitPerQuery - each unit is the equivalent of 1 nanosecond processing time
+const MaxGasLimitPerQuery = 300_000_000_000
 
 // SCQueryService can execute Get functions over SC to fetch stored values
 type SCQueryService struct {
@@ -78,7 +80,7 @@ func NewSCQueryService(
 		return nil, err
 	}
 
-	gasForQuery := uint64(math.MaxUint64)
+	gasForQuery := uint64(MaxGasLimitPerQuery)
 	if args.MaxGasLimitPerQuery > 0 {
 		gasForQuery = args.MaxGasLimitPerQuery
 	}

--- a/process/smartContract/scQueryService_test.go
+++ b/process/smartContract/scQueryService_test.go
@@ -599,13 +599,13 @@ func TestExecuteQuery_ReturnsCorrectly(t *testing.T) {
 func TestExecuteQuery_GasProvidedShouldBeApplied(t *testing.T) {
 	t.Parallel()
 
-	t.Run("no gas defined, should use max uint64", func(t *testing.T) {
+	t.Run("no gas defined, should use max gas limit", func(t *testing.T) {
 		t.Parallel()
 
 		runSCWasCalled := false
 		mockVM := &mock.VMExecutionHandlerStub{
 			RunSmartContractCallCalled: func(input *vmcommon.ContractCallInput) (output *vmcommon.VMOutput, e error) {
-				require.Equal(t, uint64(math.MaxUint64), input.GasProvided)
+				require.Equal(t, uint64(MaxGasLimitPerQuery), input.GasProvided)
 				runSCWasCalled = true
 				return &vmcommon.VMOutput{}, nil
 			},
@@ -976,7 +976,7 @@ func TestSCQueryService_ComputeTxCostScCall(t *testing.T) {
 	}
 	argsNewSCQuery.EconomicsFee = &economicsmocks.EconomicsHandlerStub{
 		MaxGasLimitPerBlockCalled: func(_ uint32) uint64 {
-			return uint64(MaxGasLimitPerQuery)
+			return uint64(math.MaxUint64)
 		},
 	}
 	target, _ := NewSCQueryService(argsNewSCQuery)

--- a/process/smartContract/scQueryService_test.go
+++ b/process/smartContract/scQueryService_test.go
@@ -962,7 +962,7 @@ func TestSCQueryService_ComputeTxCostScCall(t *testing.T) {
 	mockVM := &mock.VMExecutionHandlerStub{
 		RunSmartContractCallCalled: func(input *vmcommon.ContractCallInput) (output *vmcommon.VMOutput, e error) {
 			return &vmcommon.VMOutput{
-				GasRemaining: uint64(math.MaxUint64) - consumedGas,
+				GasRemaining: uint64(MaxGasLimitPerQuery) - consumedGas,
 				ReturnCode:   vmcommon.Ok,
 			}, nil
 		},
@@ -976,7 +976,7 @@ func TestSCQueryService_ComputeTxCostScCall(t *testing.T) {
 	}
 	argsNewSCQuery.EconomicsFee = &economicsmocks.EconomicsHandlerStub{
 		MaxGasLimitPerBlockCalled: func(_ uint32) uint64 {
-			return uint64(math.MaxUint64)
+			return uint64(MaxGasLimitPerQuery)
 		},
 	}
 	target, _ := NewSCQueryService(argsNewSCQuery)


### PR DESCRIPTION
## Reasoning behind the pull request
when configuring maximum gas limit per query should set a reasonable value
  
## Proposed changes
add 300s worth of gas as maximum/default limit, when not explicitly set otherwise

## Testing procedure
Execute VM queries (for 0 limits on ShardMaxGasPerVmQuery and/or MetaMaxGasPerVmQuery) and check the reported used and remaining gas. Should add up to 300_000_000_000

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
