### PR TITLE
Enable sharded storage for user accounts and peer accounts

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -324,6 +324,8 @@
         BatchDelaySeconds = 2
         MaxBatchSize = 45000
         MaxOpenFiles = 10
+        ShardIDProviderType = "BinarySplit"
+        NumShards = 4
 
 [PeerAccountsTrieStorage]
     [PeerAccountsTrieStorage.Cache]
@@ -337,6 +339,8 @@
         BatchDelaySeconds = 2
         MaxBatchSize = 1000
         MaxOpenFiles = 10
+        ShardIDProviderType = "BinarySplit"
+        NumShards = 4
 
 [AccountsTrieCheckpointsStorage]
     [AccountsTrieCheckpointsStorage.Cache]


### PR DESCRIPTION
## Reasoning behind the pull request
- Enabled sharded storage feature on UserAccounts and PeerAccounts storers
  
## Proposed changes
- Set `ShardIDProviderType` and `NumShards` in config

## Testing procedure
- Standard testing procedure

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
