### PR TITLE
Linter fixes for rc/v1.6.0 - 2023.08.30

### DIFF
--- a/api/groups/networkGroup_test.go
+++ b/api/groups/networkGroup_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -96,8 +95,8 @@ func TestNetworkConfigMetrics_ShouldWork(t *testing.T) {
 
 	statusMetricsProvider := statusHandler.NewStatusMetrics()
 	key := common.MetricMinGasLimit
-	value := uint64(37)
-	statusMetricsProvider.SetUInt64Value(key, value)
+	val := uint64(37)
+	statusMetricsProvider.SetUInt64Value(key, val)
 
 	facade := mock.FacadeStub{}
 	facade.StatusMetricsHandler = func() external.StatusMetricsHandler {
@@ -113,17 +112,15 @@ func TestNetworkConfigMetrics_ShouldWork(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	respStr := string(respBytes)
 	assert.Equal(t, resp.Code, http.StatusOK)
 
-	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, fmt.Sprintf("%d", value))
+	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, fmt.Sprintf("%d", val))
 	assert.True(t, keyAndValueFoundInResponse)
 }
 
 func TestGetNetworkConfig_ShouldReturnErrorIfFacadeReturnsError(t *testing.T) {
-	expectedErr := errors.New("i am an error")
-
 	facade := mock.FacadeStub{
 		StatusMetricsHandler: func() external.StatusMetricsHandler {
 			return &testscommon.StatusMetricsStub{
@@ -152,8 +149,6 @@ func TestGetNetworkConfig_ShouldReturnErrorIfFacadeReturnsError(t *testing.T) {
 }
 
 func TestGetNetworkStatus_ShouldReturnErrorIfFacadeReturnsError(t *testing.T) {
-	expectedErr := errors.New("i am an error")
-
 	facade := mock.FacadeStub{
 		StatusMetricsHandler: func() external.StatusMetricsHandler {
 			return &testscommon.StatusMetricsStub{
@@ -186,8 +181,8 @@ func TestNetworkConfigMetrics_GasLimitGuardedTxShouldWork(t *testing.T) {
 
 	statusMetricsProvider := statusHandler.NewStatusMetrics()
 	key := common.MetricExtraGasLimitGuardedTx
-	value := uint64(37)
-	statusMetricsProvider.SetUInt64Value(key, value)
+	val := uint64(37)
+	statusMetricsProvider.SetUInt64Value(key, val)
 
 	facade := mock.FacadeStub{}
 	facade.StatusMetricsHandler = func() external.StatusMetricsHandler {
@@ -203,11 +198,11 @@ func TestNetworkConfigMetrics_GasLimitGuardedTxShouldWork(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	respStr := string(respBytes)
 	assert.Equal(t, resp.Code, http.StatusOK)
 
-	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, fmt.Sprintf("%d", value))
+	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, fmt.Sprintf("%d", val))
 	assert.True(t, keyAndValueFoundInResponse)
 }
 
@@ -216,8 +211,8 @@ func TestNetworkStatusMetrics_ShouldWork(t *testing.T) {
 
 	statusMetricsProvider := statusHandler.NewStatusMetrics()
 	key := common.MetricEpochNumber
-	value := uint64(37)
-	statusMetricsProvider.SetUInt64Value(key, value)
+	val := uint64(37)
+	statusMetricsProvider.SetUInt64Value(key, val)
 
 	facade := mock.FacadeStub{}
 	facade.StatusMetricsHandler = func() external.StatusMetricsHandler {
@@ -233,19 +228,19 @@ func TestNetworkStatusMetrics_ShouldWork(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	respStr := string(respBytes)
 	assert.Equal(t, resp.Code, http.StatusOK)
 
-	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, fmt.Sprintf("%d", value))
+	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, fmt.Sprintf("%d", val))
 	assert.True(t, keyAndValueFoundInResponse)
 }
 
 func TestEconomicsMetrics_ShouldWork(t *testing.T) {
 	statusMetricsProvider := statusHandler.NewStatusMetrics()
 	key := common.MetricTotalSupply
-	value := "12345"
-	statusMetricsProvider.SetStringValue(key, value)
+	val := "12345"
+	statusMetricsProvider.SetStringValue(key, val)
 
 	facade := mock.FacadeStub{
 		GetTotalStakedValueHandler: func() (*api.StakeValues, error) {
@@ -268,17 +263,15 @@ func TestEconomicsMetrics_ShouldWork(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	respStr := string(respBytes)
 	assert.Equal(t, resp.Code, http.StatusOK)
 
-	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, value)
+	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, val)
 	assert.True(t, keyAndValueFoundInResponse)
 }
 
 func TestGetEconomicValues_ShouldReturnErrorIfFacadeReturnsError(t *testing.T) {
-	expectedErr := errors.New("i am an error")
-
 	facade := mock.FacadeStub{
 		StatusMetricsHandler: func() external.StatusMetricsHandler {
 			return &testscommon.StatusMetricsStub{
@@ -312,8 +305,8 @@ func TestGetEconomicValues_ShouldReturnErrorIfFacadeReturnsError(t *testing.T) {
 func TestEconomicsMetrics_CannotGetStakeValues(t *testing.T) {
 	statusMetricsProvider := statusHandler.NewStatusMetrics()
 	key := common.MetricTotalSupply
-	value := "12345"
-	statusMetricsProvider.SetStringValue(key, value)
+	val := "12345"
+	statusMetricsProvider.SetStringValue(key, val)
 
 	localErr := fmt.Errorf("%s", "local error")
 	facade := mock.FacadeStub{
@@ -410,7 +403,7 @@ func TestDirectStakedInfo_ShouldWork(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	respStr := string(respBytes)
 	assert.Equal(t, resp.Code, http.StatusOK)
 
@@ -440,7 +433,7 @@ func TestDirectStakedInfo_CannotGetDirectStakedList(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	respStr := string(respBytes)
 
 	assert.Equal(t, resp.Code, http.StatusInternalServerError)
@@ -495,7 +488,7 @@ func TestDelegatedInfo_ShouldWork(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	respStr := string(respBytes)
 	assert.Equal(t, resp.Code, http.StatusOK)
 
@@ -534,7 +527,7 @@ func TestDelegatedInfo_CannotGetDelegatedList(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	respStr := string(respBytes)
 
 	assert.Equal(t, resp.Code, http.StatusInternalServerError)
@@ -542,8 +535,6 @@ func TestDelegatedInfo_CannotGetDelegatedList(t *testing.T) {
 }
 
 func TestGetEnableEpochs_ShouldReturnErrorIfFacadeReturnsError(t *testing.T) {
-	expectedErr := errors.New("i am an error")
-
 	facade := mock.FacadeStub{
 		StatusMetricsHandler: func() external.StatusMetricsHandler {
 			return &testscommon.StatusMetricsStub{
@@ -576,8 +567,8 @@ func TestGetEnableEpochs_ShouldWork(t *testing.T) {
 
 	statusMetrics := statusHandler.NewStatusMetrics()
 	key := common.MetricScDeployEnableEpoch
-	value := uint64(4)
-	statusMetrics.SetUInt64Value(key, value)
+	val := uint64(4)
+	statusMetrics.SetUInt64Value(key, val)
 
 	facade := mock.FacadeStub{}
 	facade.StatusMetricsHandler = func() external.StatusMetricsHandler {
@@ -593,18 +584,17 @@ func TestGetEnableEpochs_ShouldWork(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	respStr := string(respBytes)
 	assert.Equal(t, resp.Code, http.StatusOK)
 
-	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, strconv.FormatUint(value, 10))
+	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, strconv.FormatUint(val, 10))
 	assert.True(t, keyAndValueFoundInResponse)
 }
 
 func TestGetESDTTotalSupply_InternalError(t *testing.T) {
 	t.Parallel()
 
-	expectedErr := errors.New("expected error")
 	facade := mock.FacadeStub{
 		GetTokenSupplyCalled: func(token string) (*api.ESDTSupply, error) {
 			return nil, expectedErr
@@ -620,7 +610,7 @@ func TestGetESDTTotalSupply_InternalError(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	respStr := string(respBytes)
 	assert.Equal(t, resp.Code, http.StatusInternalServerError)
 
@@ -629,8 +619,6 @@ func TestGetESDTTotalSupply_InternalError(t *testing.T) {
 }
 
 func TestGetNetworkRatings_ShouldReturnErrorIfFacadeReturnsError(t *testing.T) {
-	expectedErr := errors.New("i am an error")
-
 	facade := mock.FacadeStub{
 		StatusMetricsHandler: func() external.StatusMetricsHandler {
 			return &testscommon.StatusMetricsStub{
@@ -716,7 +704,7 @@ func TestGetESDTTotalSupply(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, resp.Code, http.StatusOK)
 
 	respSupply := &supplyResponse{}
@@ -964,7 +952,6 @@ func TestNetworkGroup_UpdateFacade(t *testing.T) {
 		loadResponse(resp.Body, &response)
 		assert.Equal(t, builtInCost, response.Data.Configs.BuiltInCost)
 
-		expectedErr := errors.New("expected error")
 		newFacade := mock.FacadeStub{
 			GetGasConfigsCalled: func() (map[string]map[string]uint64, error) {
 				return nil, expectedErr

--- a/api/groups/nodeGroup_test.go
+++ b/api/groups/nodeGroup_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -162,8 +161,6 @@ func TestHeartbeatStatus(t *testing.T) {
 }
 
 func TestP2PMetrics_ShouldReturnErrorIfFacadeReturnsError(t *testing.T) {
-	expectedErr := errors.New("i am an error")
-
 	facade := mock.FacadeStub{
 		StatusMetricsHandler: func() external.StatusMetricsHandler {
 			return &testscommon.StatusMetricsStub{
@@ -192,8 +189,6 @@ func TestP2PMetrics_ShouldReturnErrorIfFacadeReturnsError(t *testing.T) {
 }
 
 func TestNodeStatus_ShouldReturnErrorIfFacadeReturnsError(t *testing.T) {
-	expectedErr := errors.New("i am an error")
-
 	facade := mock.FacadeStub{
 		StatusMetricsHandler: func() external.StatusMetricsHandler {
 			return &testscommon.StatusMetricsStub{
@@ -222,8 +217,6 @@ func TestNodeStatus_ShouldReturnErrorIfFacadeReturnsError(t *testing.T) {
 }
 
 func TestBootstrapStatus_ShouldReturnErrorIfFacadeReturnsError(t *testing.T) {
-	expectedErr := errors.New("i am an error")
-
 	facade := mock.FacadeStub{
 		StatusMetricsHandler: func() external.StatusMetricsHandler {
 			return &testscommon.StatusMetricsStub{
@@ -270,7 +263,7 @@ func TestBootstrapStatusMetrics_ShouldWork(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	respStr := string(respBytes)
 	assert.Equal(t, resp.Code, http.StatusOK)
 
@@ -320,8 +313,8 @@ func TestNodeGroup_GetConnectedPeersRatings(t *testing.T) {
 func TestStatusMetrics_ShouldDisplayNonP2pMetrics(t *testing.T) {
 	statusMetricsProvider := statusHandler.NewStatusMetrics()
 	key := "test-details-key"
-	value := "test-details-value"
-	statusMetricsProvider.SetStringValue(key, value)
+	val := "test-details-value"
+	statusMetricsProvider.SetStringValue(key, val)
 
 	p2pKey := "a_p2p_specific_key"
 	statusMetricsProvider.SetStringValue(p2pKey, "p2p value")
@@ -340,11 +333,11 @@ func TestStatusMetrics_ShouldDisplayNonP2pMetrics(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	respStr := string(respBytes)
 	assert.Equal(t, resp.Code, http.StatusOK)
 
-	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, value)
+	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, val)
 	assert.True(t, keyAndValueFoundInResponse)
 	assert.False(t, strings.Contains(respStr, p2pKey))
 }
@@ -352,8 +345,8 @@ func TestStatusMetrics_ShouldDisplayNonP2pMetrics(t *testing.T) {
 func TestP2PStatusMetrics_ShouldDisplayNonP2pMetrics(t *testing.T) {
 	statusMetricsProvider := statusHandler.NewStatusMetrics()
 	key := "test-details-key"
-	value := "test-details-value"
-	statusMetricsProvider.SetStringValue(key, value)
+	val := "test-details-value"
+	statusMetricsProvider.SetStringValue(key, val)
 
 	p2pKey := "a_p2p_specific_key"
 	p2pValue := "p2p value"
@@ -373,7 +366,7 @@ func TestP2PStatusMetrics_ShouldDisplayNonP2pMetrics(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	respStr := string(respBytes)
 	assert.Equal(t, resp.Code, http.StatusOK)
 
@@ -401,11 +394,11 @@ func TestQueryDebug_ShouldBindJSONErrorsShouldErr(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	queryResponse := &generalResponse{}
-	loadResponse(resp.Body, queryResponse)
+	queryResp := &generalResponse{}
+	loadResponse(resp.Body, queryResp)
 
 	assert.Equal(t, http.StatusBadRequest, resp.Code)
-	assert.Contains(t, queryResponse.Error, apiErrors.ErrValidation.Error())
+	assert.Contains(t, queryResp.Error, apiErrors.ErrValidation.Error())
 }
 
 func TestQueryDebug_GetQueryErrorsShouldErr(t *testing.T) {
@@ -429,11 +422,11 @@ func TestQueryDebug_GetQueryErrorsShouldErr(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	queryResponse := &generalResponse{}
-	loadResponse(resp.Body, queryResponse)
+	queryResp := &generalResponse{}
+	loadResponse(resp.Body, queryResp)
 
 	assert.Equal(t, http.StatusBadRequest, resp.Code)
-	assert.Contains(t, queryResponse.Error, expectedErr.Error())
+	assert.Contains(t, queryResp.Error, expectedErr.Error())
 }
 
 func TestQueryDebug_GetQueryShouldWork(t *testing.T) {
@@ -467,14 +460,14 @@ func TestQueryDebug_GetQueryShouldWork(t *testing.T) {
 	response := shared.GenericAPIResponse{}
 	loadResponse(resp.Body, &response)
 
-	queryResponse := queryResponse{}
+	queryResp := queryResponse{}
 	mapResponseData := response.Data.(map[string]interface{})
 	mapResponseDataBytes, _ := json.Marshal(mapResponseData)
-	_ = json.Unmarshal(mapResponseDataBytes, &queryResponse)
+	_ = json.Unmarshal(mapResponseDataBytes, &queryResp)
 
 	assert.Equal(t, http.StatusOK, resp.Code)
-	assert.Contains(t, queryResponse.Result, str1)
-	assert.Contains(t, queryResponse.Result, str2)
+	assert.Contains(t, queryResp.Result, str1)
+	assert.Contains(t, queryResp.Result, str2)
 }
 
 func TestPeerInfo_PeerInfoErrorsShouldErr(t *testing.T) {
@@ -628,8 +621,6 @@ func TestEpochStartData_ShouldWork(t *testing.T) {
 }
 
 func TestPrometheusMetrics_ShouldReturnErrorIfFacadeReturnsError(t *testing.T) {
-	expectedErr := errors.New("i am an error")
-
 	facade := mock.FacadeStub{
 		StatusMetricsHandler: func() external.StatusMetricsHandler {
 			return &testscommon.StatusMetricsStub{
@@ -660,8 +651,8 @@ func TestPrometheusMetrics_ShouldReturnErrorIfFacadeReturnsError(t *testing.T) {
 func TestPrometheusMetrics_ShouldWork(t *testing.T) {
 	statusMetricsProvider := statusHandler.NewStatusMetrics()
 	key := "test-key"
-	value := uint64(37)
-	statusMetricsProvider.SetUInt64Value(key, value)
+	val := uint64(37)
+	statusMetricsProvider.SetUInt64Value(key, val)
 
 	facade := mock.FacadeStub{}
 	facade.StatusMetricsHandler = func() external.StatusMetricsHandler {
@@ -677,11 +668,11 @@ func TestPrometheusMetrics_ShouldWork(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	respBytes, _ := ioutil.ReadAll(resp.Body)
+	respBytes, _ := io.ReadAll(resp.Body)
 	respStr := string(respBytes)
 	assert.Equal(t, resp.Code, http.StatusOK)
 
-	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, fmt.Sprintf("%d", value))
+	keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, fmt.Sprintf("%d", val))
 	assert.True(t, keyAndValueFoundInResponse)
 }
 
@@ -886,8 +877,8 @@ func TestNodeGroup_UpdateFacade(t *testing.T) {
 
 		statusMetricsProvider := statusHandler.NewStatusMetrics()
 		key := "test-key"
-		value := uint64(37)
-		statusMetricsProvider.SetUInt64Value(key, value)
+		val := uint64(37)
+		statusMetricsProvider.SetUInt64Value(key, val)
 
 		facade := mock.FacadeStub{}
 		facade.StatusMetricsHandler = func() external.StatusMetricsHandler {
@@ -903,10 +894,10 @@ func TestNodeGroup_UpdateFacade(t *testing.T) {
 		resp := httptest.NewRecorder()
 		ws.ServeHTTP(resp, req)
 
-		respBytes, _ := ioutil.ReadAll(resp.Body)
+		respBytes, _ := io.ReadAll(resp.Body)
 		respStr := string(respBytes)
 		assert.Equal(t, resp.Code, http.StatusOK)
-		keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, fmt.Sprintf("%d", value))
+		keyAndValueFoundInResponse := strings.Contains(respStr, key) && strings.Contains(respStr, fmt.Sprintf("%d", val))
 		assert.True(t, keyAndValueFoundInResponse)
 
 		newFacade := mock.FacadeStub{
@@ -944,7 +935,7 @@ func TestNodeGroup_IsInterfaceNil(t *testing.T) {
 }
 
 func loadResponseAsString(rsp io.Reader, response *statusResponse) {
-	buff, err := ioutil.ReadAll(rsp)
+	buff, err := io.ReadAll(rsp)
 	if err != nil {
 		logError(err)
 		return

--- a/api/middleware/responseLogger.go
+++ b/api/middleware/responseLogger.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -64,7 +64,7 @@ func (rlm *responseLoggerMiddleware) logRequestAndResponse(c *gin.Context, durat
 
 	if c.Request.Body != nil {
 		reqBody := c.Request.Body
-		reqBodyBytes, err := ioutil.ReadAll(reqBody)
+		reqBodyBytes, err := io.ReadAll(reqBody)
 		if err != nil {
 			log.Debug(err.Error())
 			return

--- a/cmd/assessment/main.go
+++ b/cmd/assessment/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/csv"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -142,5 +141,5 @@ func saveToFile(hi *hostParameters.HostInfo, results *benchmarks.TestResults, ou
 		return err
 	}
 
-	return ioutil.WriteFile(outputFileName, buff.Bytes(), core.FileModeReadWrite)
+	return os.WriteFile(outputFileName, buff.Bytes(), core.FileModeReadWrite)
 }

--- a/cmd/termui/provider/metricsProvider.go
+++ b/cmd/termui/provider/metricsProvider.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -88,7 +88,7 @@ func (smp *StatusMetricsProvider) loadMetricsFromApi(metricsPath string) (map[st
 		return nil, err
 	}
 
-	responseBytes, err := ioutil.ReadAll(resp.Body)
+	responseBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/common/statistics/osLevel/memStats.go
+++ b/common/statistics/osLevel/memStats.go
@@ -2,7 +2,7 @@ package osLevel
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -74,7 +74,7 @@ func (memStats *MemStats) String() string {
 
 // ReadCurrentMemStats will read the current mem stats at the OS level
 func ReadCurrentMemStats() (*MemStats, error) {
-	buff, err := ioutil.ReadFile(procFile)
+	buff, err := os.ReadFile(procFile)
 	if err != nil {
 		return nil, err
 	}

--- a/common/statistics/osLevel/memStats_test.go
+++ b/common/statistics/osLevel/memStats_test.go
@@ -1,5 +1,4 @@
 //go:build darwin || linux
-// +build darwin linux
 
 package osLevel
 

--- a/dataRetriever/factory/dataPoolFactory.go
+++ b/dataRetriever/factory/dataPoolFactory.go
@@ -2,7 +2,7 @@ package factory
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core"
@@ -187,7 +187,7 @@ func createTrieSyncDB(args ArgsDataPool) (storage.Persister, error) {
 	}
 
 	if mainConfig.TrieSyncStorage.DB.UseTmpAsFilePath {
-		filePath, errTempDir := ioutil.TempDir("", "trieSyncStorage")
+		filePath, errTempDir := os.MkdirTemp("", "trieSyncStorage")
 		if errTempDir != nil {
 			return nil, errTempDir
 		}

--- a/debug/process/stateExport_test.go
+++ b/debug/process/stateExport_test.go
@@ -3,8 +3,8 @@ package process
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/state"
@@ -63,14 +63,14 @@ func TestExportUserAccountState(t *testing.T) {
 	})
 	t.Run("test files are produced", func(t *testing.T) {
 		tempDir := t.TempDir()
-		contents, errReadDir := ioutil.ReadDir(tempDir)
+		contents, errReadDir := os.ReadDir(tempDir)
 		require.Nil(t, errReadDir)
 		assert.Zero(t, len(contents))
 
 		errExport := ExportUserAccountState(accounts, "", address, tempDir)
 		require.Nil(t, errExport)
 
-		contents, errReadDir = ioutil.ReadDir(tempDir)
+		contents, errReadDir = os.ReadDir(tempDir)
 		require.Nil(t, errReadDir)
 		assert.Equal(t, 2, len(contents))
 	})

--- a/genesis/process/genesisBlockCreator_test.go
+++ b/genesis/process/genesisBlockCreator_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO reinstate test after Wasm VM pointer fix
 

--- a/genesis/process/intermediate/baseDeploy.go
+++ b/genesis/process/intermediate/baseDeploy.go
@@ -3,8 +3,8 @@ package intermediate
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -104,7 +104,7 @@ func (dp *baseDeploy) deployForOneAddress(
 }
 
 func getSCCodeAsHex(filename string) (string, error) {
-	code, err := ioutil.ReadFile(filepath.Clean(filename))
+	code, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return "", err
 	}

--- a/integrationTests/multiShard/smartContract/polynetworkbridge/bridge_test.go
+++ b/integrationTests/multiShard/smartContract/polynetworkbridge/bridge_test.go
@@ -3,8 +3,8 @@ package polynetworkbridge
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/config"
@@ -80,7 +80,7 @@ func TestBridgeSetupAndBurn(t *testing.T) {
 		factory.WasmVirtualMachine,
 	)
 
-	scCode, err := ioutil.ReadFile(tokenManagerPath)
+	scCode, err := os.ReadFile(tokenManagerPath)
 	if err != nil {
 		panic(fmt.Sprintf("putDeploySCToDataPool(): %s", err))
 	}

--- a/integrationTests/multiShard/smartContract/scCallingSC_test.go
+++ b/integrationTests/multiShard/smartContract/scCallingSC_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -984,7 +984,7 @@ func putDeploySCToDataPool(
 	nodes []*integrationTests.TestProcessorNode,
 	gasLimit uint64,
 ) []byte {
-	scCode, err := ioutil.ReadFile(fileName)
+	scCode, err := os.ReadFile(fileName)
 	if err != nil {
 		panic(fmt.Sprintf("putDeploySCToDataPool(): %s", err))
 	}

--- a/integrationTests/multiShard/softfork/scDeploy_test.go
+++ b/integrationTests/multiShard/softfork/scDeploy_test.go
@@ -2,8 +2,8 @@ package softfork
 
 import (
 	"encoding/hex"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 
@@ -121,7 +121,7 @@ func TestScDeploy(t *testing.T) {
 }
 
 func deploySc(t *testing.T, nodes []*integrationTests.TestProcessorNode) []byte {
-	scCode, err := ioutil.ReadFile("./testdata/answer.wasm")
+	scCode, err := os.ReadFile("./testdata/answer.wasm")
 	require.Nil(t, err)
 
 	node := nodes[0]

--- a/integrationTests/multiShard/txScenarios/builtinFunctions_test.go
+++ b/integrationTests/multiShard/txScenarios/builtinFunctions_test.go
@@ -3,8 +3,8 @@ package txScenarios
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 
@@ -32,7 +32,7 @@ func TestTransaction_TransactionBuiltinFunctionsScenarios(t *testing.T) {
 	nonce++
 
 	scPath := "./../../vm/wasm/testdata/counter/counter_old.wasm"
-	scCode, err := ioutil.ReadFile(scPath)
+	scCode, err := os.ReadFile(scPath)
 
 	if err != nil {
 		panic(fmt.Sprintf("cannotReadContractCode: %s", err))

--- a/integrationTests/multiShard/txScenarios/scCalls_test.go
+++ b/integrationTests/multiShard/txScenarios/scCalls_test.go
@@ -2,7 +2,7 @@ package txScenarios
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -25,7 +25,7 @@ func TestTransaction_TransactionSCScenarios(t *testing.T) {
 	net.Increment()
 
 	scPath := "./../../vm/wasm/testdata/counter/counter_old.wasm"
-	scCode, err := ioutil.ReadFile(scPath)
+	scCode, err := os.ReadFile(scPath)
 
 	if err != nil {
 		panic(fmt.Sprintf("cannotReadContractCode: %s", err))

--- a/integrationTests/singleShard/block/executingMiniblocksSc/executingMiniblocksSc_test.go
+++ b/integrationTests/singleShard/block/executingMiniblocksSc/executingMiniblocksSc_test.go
@@ -3,8 +3,8 @@ package executingMiniblocksSc
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 
@@ -20,7 +20,7 @@ func TestShouldProcessMultipleERC20ContractsInSingleShard(t *testing.T) {
 		t.Skip("this is not a short test")
 	}
 
-	scCode, err := ioutil.ReadFile("../../../vm/wasm/testdata/erc20-c-03/wrc20_wasm.wasm")
+	scCode, err := os.ReadFile("../../../vm/wasm/testdata/erc20-c-03/wrc20_wasm.wasm")
 	assert.Nil(t, err)
 
 	maxShards := uint32(1)

--- a/integrationTests/testNetwork.go
+++ b/integrationTests/testNetwork.go
@@ -2,8 +2,8 @@ package integrationTests
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -153,14 +153,17 @@ func (net *TestNetwork) CreateWallets(count int) {
 	}
 }
 
+// SetWallet -
 func (net *TestNetwork) SetWallet(walletIndex int, wallet *TestWalletAccount) {
 	net.Wallets[walletIndex] = wallet
 }
 
+// CreateUninitializedWallets -
 func (net *TestNetwork) CreateUninitializedWallets(count int) {
 	net.Wallets = make([]*TestWalletAccount, count)
 }
 
+// CreateWalletOnShard -
 func (net *TestNetwork) CreateWalletOnShard(walletIndex int, shardID uint32) *TestWalletAccount {
 	node := net.firstNodeInShard(shardID)
 	net.Wallets[walletIndex] = CreateTestWalletAccount(node.ShardCoordinator, shardID)
@@ -226,7 +229,7 @@ func (net *TestNetwork) DeploySCWithInitArgs(
 	args ...[]byte,
 ) []byte {
 	scAddress := net.NewAddress(owner)
-	code, err := ioutil.ReadFile(filepath.Clean(fileName))
+	code, err := os.ReadFile(filepath.Clean(fileName))
 	require.Nil(net.T, err)
 
 	codeMetadata := &vmcommon.CodeMetadata{

--- a/integrationTests/vm/delegation/changeOwner_test.go
+++ b/integrationTests/vm/delegation/changeOwner_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package delegation
 

--- a/integrationTests/vm/delegation/delegationMulti_test.go
+++ b/integrationTests/vm/delegation/delegationMulti_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package delegation
 

--- a/integrationTests/vm/delegation/delegationScenarios_test.go
+++ b/integrationTests/vm/delegation/delegationScenarios_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package delegation
 

--- a/integrationTests/vm/delegation/delegation_test.go
+++ b/integrationTests/vm/delegation/delegation_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package delegation
 

--- a/integrationTests/vm/esdt/localFuncs/esdtLocalFunsSC_MockContracts_test.go
+++ b/integrationTests/vm/esdt/localFuncs/esdtLocalFunsSC_MockContracts_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package localFuncs
 

--- a/integrationTests/vm/esdt/localFuncs/esdtLocalFunsSC_test.go
+++ b/integrationTests/vm/esdt/localFuncs/esdtLocalFunsSC_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package localFuncs
 

--- a/integrationTests/vm/esdt/multisign/esdtMultisign_test.go
+++ b/integrationTests/vm/esdt/multisign/esdtMultisign_test.go
@@ -1,12 +1,11 @@
 //go:build !race
-// +build !race
 
 package multisign
 
 import (
 	"encoding/hex"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -157,7 +156,7 @@ func deployMultisig(t *testing.T, nodes []*integrationTests.TestProcessorNode, o
 		Readable:    true,
 	}
 
-	contractBytes, err := ioutil.ReadFile("../testdata/multisig-callback.wasm")
+	contractBytes, err := os.ReadFile("../testdata/multisig-callback.wasm")
 	require.Nil(t, err)
 	proposers := make([]string, 0, len(proposersIndexes)+1)
 	proposers = append(proposers, hex.EncodeToString(nodes[ownerIdx].OwnAccount.Address))

--- a/integrationTests/vm/esdt/nft/esdtNFT/esdtNft_test.go
+++ b/integrationTests/vm/esdt/nft/esdtNFT/esdtNft_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package esdtNFT
 

--- a/integrationTests/vm/esdt/nft/esdtNFTSCs/esdtNFTSCs_test.go
+++ b/integrationTests/vm/esdt/nft/esdtNFTSCs/esdtNFTSCs_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package esdtNFTSCs
 

--- a/integrationTests/vm/esdt/process/esdtProcess_test.go
+++ b/integrationTests/vm/esdt/process/esdtProcess_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package process
 

--- a/integrationTests/vm/esdt/roles/esdtRoles_test.go
+++ b/integrationTests/vm/esdt/roles/esdtRoles_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package roles
 

--- a/integrationTests/vm/txsFee/asyncCall_multi_test.go
+++ b/integrationTests/vm/txsFee/asyncCall_multi_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package txsFee
 
@@ -28,7 +27,6 @@ func TestAsyncCallLegacy(t *testing.T) {
 	require.Nil(t, err)
 	defer testContext.Close()
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(5000000)
 
 	senderAddr := []byte("12345678901234567890123456789011")
@@ -72,7 +70,6 @@ func TestAsyncCallMulti(t *testing.T) {
 	require.Nil(t, err)
 	defer testContext.Close()
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(5000000)
 
 	senderAddr := []byte("12345678901234567890123456789011")
@@ -120,7 +117,6 @@ func TestAsyncCallTransferAndExecute(t *testing.T) {
 	require.Nil(t, err)
 	defer testContext.Close()
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(5000000)
 
 	senderAddr := []byte("12345678901234567890123456789011")
@@ -178,7 +174,6 @@ func transferESDTAndExecute(t *testing.T, numberOfCallsFromParent int, numberOfB
 	require.Nil(t, err)
 	defer testContext.Close()
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(5000000)
 
 	senderAddr := []byte("12345678901234567890123456789011")
@@ -232,9 +227,9 @@ func transferESDTAndExecute(t *testing.T, numberOfCallsFromParent int, numberOfB
 			int64(numberOfCallsFromParent)*int64(numberOfBackTransfers)*esdtToTransferBackFromChild /* sent back via callback*/))
 
 	utils.CheckESDTNFTBalance(t, testContext, forwarderSCAddress, esdtToken, 0,
-		big.NewInt((esdtBalance.Int64() - /* initial */
-			int64(numberOfCallsFromParent)*esdtToTransferFromParent + /* sent via async */
-			int64(numberOfCallsFromParent)*int64(numberOfBackTransfers)*esdtToTransferBackFromChild /* received back via callback */)))
+		big.NewInt(esdtBalance.Int64()- /* initial */
+			int64(numberOfCallsFromParent)*esdtToTransferFromParent+ /* sent via async */
+			int64(numberOfCallsFromParent)*int64(numberOfBackTransfers)*esdtToTransferBackFromChild /* received back via callback */))
 
 	res := vm.GetIntValueFromSC(nil, testContext.Accounts, childSCAddress, "num_called_retrieve_funds_promises")
 	require.Equal(t, big.NewInt(int64(numberOfCallsFromParent)), res)
@@ -310,7 +305,6 @@ func TestAsyncCallMulti_CrossShard(t *testing.T) {
 	_, _ = vm.CreateAccount(testContextFirstContract.Accounts, firstContractOwner, 0, egldBalance)
 	_, _ = vm.CreateAccount(testContextSecondContract.Accounts, secondContractOwner, 0, egldBalance)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(5000000)
 	firstAccount, _ := testContextFirstContract.Accounts.LoadAccount(firstContractOwner)
 
@@ -397,7 +391,6 @@ func TestAsyncCallTransferAndExecute_CrossShard(t *testing.T) {
 	_, _ = vm.CreateAccount(childShard.Accounts, childOwner, 0, egldBalance)
 	_, _ = vm.CreateAccount(forwarderShard.Accounts, forwarderOwner, 0, egldBalance)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(5000000)
 	childOwnerAccount, _ := childShard.Accounts.LoadAccount(childOwner)
 
@@ -456,10 +449,10 @@ func TestAsyncCallTransferAndExecute_CrossShard(t *testing.T) {
 func TestAsyncCallTransferESDTAndExecute_CrossShard_Success(t *testing.T) {
 	numberOfCallsFromParent := 3
 	numberOfBackTransfers := 2
-	transferESDTAndExecute_CrossShard(t, numberOfCallsFromParent, numberOfBackTransfers)
+	transferESDTAndExecuteCrossShard(t, numberOfCallsFromParent, numberOfBackTransfers)
 }
 
-func transferESDTAndExecute_CrossShard(t *testing.T, numberOfCallsFromParent int, numberOfBackTransfers int) {
+func transferESDTAndExecuteCrossShard(t *testing.T, numberOfCallsFromParent int, numberOfBackTransfers int) {
 	vaultShard, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(0, config.EnableEpochs{
 		DynamicGasCostForDataTrieStorageLoadEnableEpoch: integrationTests.UnreachableEpoch,
 	})
@@ -491,7 +484,6 @@ func transferESDTAndExecute_CrossShard(t *testing.T, numberOfCallsFromParent int
 	_, _ = vm.CreateAccount(vaultShard.Accounts, vaultOwner, 0, egldBalance)
 	_, _ = vm.CreateAccount(forwarderShard.Accounts, forwarderOwner, 0, egldBalance)
 
-	gasPrice := uint64(10)
 	gasLimit := uint64(5000000)
 	vaultOwnerAccount, _ := vaultShard.Accounts.LoadAccount(vaultOwner)
 
@@ -567,9 +559,9 @@ func transferESDTAndExecute_CrossShard(t *testing.T, numberOfCallsFromParent int
 			int64(numberOfCallsFromParent)*int64(numberOfBackTransfers)*esdtToTransferBackFromChild /* sent back via callback*/))
 
 	utils.CheckESDTNFTBalance(t, forwarderShard, forwarderSCAddress, esdtToken, 0,
-		big.NewInt((esdtBalance.Int64() - /* initial */
-			int64(numberOfCallsFromParent)*esdtToTransferFromParent + /* sent via async */
-			int64(numberOfCallsFromParent)*int64(numberOfBackTransfers)*esdtToTransferBackFromChild /* received back via callback */)))
+		big.NewInt(esdtBalance.Int64()- /* initial */
+			int64(numberOfCallsFromParent)*esdtToTransferFromParent+ /* sent via async */
+			int64(numberOfCallsFromParent)*int64(numberOfBackTransfers)*esdtToTransferBackFromChild /* received back via callback */))
 
 	res := vm.GetIntValueFromSC(nil, vaultShard.Accounts, vaultSCAddress, "num_called_retrieve_funds_promises")
 	require.Equal(t, big.NewInt(int64(numberOfCallsFromParent)), res)

--- a/integrationTests/vm/txsFee/asyncCall_test.go
+++ b/integrationTests/vm/txsFee/asyncCall_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 
@@ -37,11 +36,11 @@ func TestAsyncCallShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	defer testContext.Close()
 
-	egldBalance := big.NewInt(100000000)
+	balance := big.NewInt(100000000)
 	senderAddr := []byte("12345678901234567890123456789011")
 	ownerAddr := []byte("12345678901234567890123456789010")
-	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, egldBalance)
-	_, _ = vm.CreateAccount(testContext.Accounts, senderAddr, 0, egldBalance)
+	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, balance)
+	_, _ = vm.CreateAccount(testContext.Accounts, senderAddr, 0, balance)
 
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(50000)
@@ -94,9 +93,9 @@ func TestMinterContractWithAsyncCalls(t *testing.T) {
 	require.Nil(t, err)
 	defer testContext.Close()
 
-	egldBalance := big.NewInt(1000000000000)
+	balance := big.NewInt(1000000000000)
 	ownerAddr := []byte("12345678901234567890123456789011")
-	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, egldBalance)
+	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, balance)
 
 	token := []byte("miiutoken")
 	roles := [][]byte{[]byte(core.ESDTRoleNFTCreate)}

--- a/integrationTests/vm/txsFee/asyncESDT_test.go
+++ b/integrationTests/vm/txsFee/asyncESDT_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 
@@ -32,16 +31,16 @@ func TestAsyncESDTCallShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	defer testContext.Close()
 
-	egldBalance := big.NewInt(100000000)
+	localEgldBalance := big.NewInt(100000000)
 	ownerAddr := []byte("12345678901234567890123456789010")
-	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, egldBalance)
+	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, localEgldBalance)
 
 	// create an address with ESDT token
 	sndAddr := []byte("12345678901234567890123456789012")
 
-	esdtBalance := big.NewInt(100000000)
+	localEsdtBalance := big.NewInt(100000000)
 	token := []byte("miiutoken")
-	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance)
+	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, localEgldBalance, token, 0, localEsdtBalance)
 
 	// deploy 2 contracts
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
@@ -84,16 +83,16 @@ func TestAsyncESDTCallSecondScRefusesPayment(t *testing.T) {
 	require.Nil(t, err)
 	defer testContext.Close()
 
-	egldBalance := big.NewInt(100000000)
+	localEgldBalance := big.NewInt(100000000)
 	ownerAddr := []byte("12345678901234567890123456789010")
-	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, egldBalance)
+	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, localEgldBalance)
 
 	// create an address with ESDT token
 	sndAddr := []byte("12345678901234567890123456789012")
 
-	esdtBalance := big.NewInt(100000000)
+	localEsdtBalance := big.NewInt(100000000)
 	token := []byte("miiutoken")
-	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance)
+	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, localEgldBalance, token, 0, localEsdtBalance)
 
 	// deploy 2 contracts
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
@@ -137,16 +136,16 @@ func TestAsyncESDTCallsOutOfGas(t *testing.T) {
 	require.Nil(t, err)
 	defer testContext.Close()
 
-	egldBalance := big.NewInt(100000000)
+	localEgldBalance := big.NewInt(100000000)
 	ownerAddr := []byte("12345678901234567890123456789010")
-	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, egldBalance)
+	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, localEgldBalance)
 
 	// create an address with ESDT token
 	sndAddr := []byte("12345678901234567890123456789012")
 
-	esdtBalance := big.NewInt(100000000)
+	localEsdtBalance := big.NewInt(100000000)
 	token := []byte("miiutoken")
-	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance)
+	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, localEgldBalance, token, 0, localEsdtBalance)
 
 	// deploy 2 contracts
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
@@ -486,20 +485,19 @@ func TestAsyncESDTCallForThirdContractShouldWork(t *testing.T) {
 	function1 := []byte("add_queued_call")
 	function2 := []byte("forward_queued_calls")
 
-	egldBalance := big.NewInt(100000000)
+	localEgldBalance := big.NewInt(100000000)
 	ownerAddr := []byte("owner-78901234567890123456789000")
-	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, egldBalance)
+	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, localEgldBalance)
 
 	// create an address with ESDT token
 	sndAddr := []byte("sender-8901234567890123456789000")
 
-	esdtBalance := big.NewInt(100000000)
+	localEsdtBalance := big.NewInt(100000000)
 	esdtTransferValue := big.NewInt(5000)
 	token := []byte("miiutoken")
-	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, egldBalance, token, 0, esdtBalance)
+	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, localEgldBalance, token, 0, localEsdtBalance)
 
 	// deploy contract
-	gasPrice := uint64(10)
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(50000)
 	scAddress := utils.DoDeploySecond(t, testContext, "./testdata/third/third.wasm", ownerAccount, gasPrice, deployGasLimit, nil, big.NewInt(0))
@@ -516,7 +514,7 @@ func TestAsyncESDTCallForThirdContractShouldWork(t *testing.T) {
 	require.Equal(t, vmcommon.UserError, retCode)
 	require.Nil(t, err)
 
-	utils.CheckESDTBalance(t, testContext, sndAddr, token, esdtBalance)
+	utils.CheckESDTBalance(t, testContext, sndAddr, token, localEsdtBalance)
 	utils.CheckESDTBalance(t, testContext, scAddress, token, big.NewInt(0))
 
 	// execute second call
@@ -530,7 +528,7 @@ func TestAsyncESDTCallForThirdContractShouldWork(t *testing.T) {
 	_, err = testContext.Accounts.Commit()
 	require.Nil(t, err)
 
-	utils.CheckESDTBalance(t, testContext, sndAddr, token, big.NewInt(0).Sub(esdtBalance, esdtTransferValue))
+	utils.CheckESDTBalance(t, testContext, sndAddr, token, big.NewInt(0).Sub(localEsdtBalance, esdtTransferValue))
 	utils.CheckESDTBalance(t, testContext, scAddress, token, esdtTransferValue)
 
 	// try to recreate the data trie

--- a/integrationTests/vm/txsFee/builtInFunctions_test.go
+++ b/integrationTests/vm/txsFee/builtInFunctions_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 
@@ -37,7 +36,6 @@ func TestBuildInFunctionChangeOwnerCallShouldWorkV1(t *testing.T) {
 	utils.CleanAccumulatedIntermediateTransactions(t, testContext)
 
 	newOwner := []byte("12345678901234567890123456789112")
-	gasPrice := uint64(10)
 	gasLimit := uint64(1000)
 
 	txData := []byte(core.BuiltInFunctionChangeOwnerAddress + "@" + hex.EncodeToString(newOwner))

--- a/integrationTests/vm/txsFee/dns_test.go
+++ b/integrationTests/vm/txsFee/dns_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 

--- a/integrationTests/vm/txsFee/dynamicGasCost_test.go
+++ b/integrationTests/vm/txsFee/dynamicGasCost_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 
@@ -34,8 +33,6 @@ func TestDynamicGasCostForDataTrieStorageLoad(t *testing.T) {
 	require.Nil(t, err)
 	defer testContext.Close()
 
-	gasPrice := uint64(10)
-
 	scAddress, _ := utils.DoDeployNoChecks(t, testContext, "../wasm/testdata/trieStoreAndLoad/storage.wasm")
 	acc := getAccount(t, testContext, scAddress)
 	require.Nil(t, acc.DataTrie())
@@ -47,8 +44,8 @@ func TestDynamicGasCostForDataTrieStorageLoad(t *testing.T) {
 
 	keys := insertInDataTrie(t, testContext, scAddress, 15)
 
-	dataTrie := getAccountDataTrie(t, testContext, scAddress)
-	trieKeysDepth := getTrieDepthForKeys(t, dataTrie, keys)
+	dataTrieInstance := getAccountDataTrie(t, testContext, scAddress)
+	trieKeysDepth := getTrieDepthForKeys(t, dataTrieInstance, keys)
 
 	apiCallsCost := 3
 	loadValCost := 32

--- a/integrationTests/vm/txsFee/guardAccount_test.go
+++ b/integrationTests/vm/txsFee/guardAccount_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 
@@ -7,8 +6,8 @@ package txsFee
 
 import (
 	"encoding/hex"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -115,7 +114,7 @@ func prepareTestContextForGuardedAccounts(tb testing.TB) *vm.VMTestContext {
 }
 
 func getLatestGasScheduleVersion(tb testing.TB, directoryToSearch string) string {
-	fileInfoSlice, err := ioutil.ReadDir(directoryToSearch)
+	fileInfoSlice, err := os.ReadDir(directoryToSearch)
 	require.Nil(tb, err)
 
 	gasSchedulePrefix := "gasScheduleV"

--- a/integrationTests/vm/txsFee/migrateDataTrie_test.go
+++ b/integrationTests/vm/txsFee/migrateDataTrie_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 

--- a/integrationTests/vm/txsFee/multiShard/asyncCall_test.go
+++ b/integrationTests/vm/txsFee/multiShard/asyncCall_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package multiShard
 

--- a/integrationTests/vm/txsFee/multiShard/asyncESDT_test.go
+++ b/integrationTests/vm/txsFee/multiShard/asyncESDT_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 

--- a/integrationTests/vm/txsFee/multiShard/relayedScDeploy_test.go
+++ b/integrationTests/vm/txsFee/multiShard/relayedScDeploy_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package multiShard
 

--- a/integrationTests/vm/txsFee/multiShard/relayedTxScCalls_test.go
+++ b/integrationTests/vm/txsFee/multiShard/relayedTxScCalls_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 

--- a/integrationTests/vm/txsFee/multiShard/scCallWithValueTransfer_test.go
+++ b/integrationTests/vm/txsFee/multiShard/scCallWithValueTransfer_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package multiShard
 

--- a/integrationTests/vm/txsFee/multiShard/scCalls_test.go
+++ b/integrationTests/vm/txsFee/multiShard/scCalls_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 

--- a/integrationTests/vm/txsFee/relayedAsyncCall_test.go
+++ b/integrationTests/vm/txsFee/relayedAsyncCall_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 
@@ -46,12 +45,12 @@ func testRelayedAsyncCallShouldWork(t *testing.T, enableEpochs config.EnableEpoc
 	testContext, err := vm.CreatePreparedTxProcessorWithVMs(enableEpochs)
 	require.Nil(t, err)
 
-	egldBalance := big.NewInt(100000000)
+	localEgldBalance := big.NewInt(100000000)
 	ownerAddr := []byte("12345678901234567890123456789010")
 	relayerAddr := []byte("12345678901234567890123456789017")
 
-	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, egldBalance)
-	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, egldBalance)
+	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, localEgldBalance)
+	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, localEgldBalance)
 
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
 	deployGasLimit := uint64(50000)

--- a/integrationTests/vm/txsFee/relayedAsyncESDT_test.go
+++ b/integrationTests/vm/txsFee/relayedAsyncESDT_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 
@@ -25,18 +24,18 @@ func TestRelayedAsyncESDTCallShouldWork(t *testing.T) {
 	require.Nil(t, err)
 	defer testContext.Close()
 
-	egldBalance := big.NewInt(100000000)
+	localEgldBalance := big.NewInt(100000000)
 	ownerAddr := []byte("12345678901234567890123456789010")
-	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, egldBalance)
+	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, localEgldBalance)
 
 	// create an address with ESDT token
 	relayerAddr := []byte("12345678901234567890123456789033")
 	sndAddr := []byte("12345678901234567890123456789012")
 
-	esdtBalance := big.NewInt(100000000)
+	localEsdtBalance := big.NewInt(100000000)
 	token := []byte("miiutoken")
-	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, big.NewInt(0), token, 0, esdtBalance)
-	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, egldBalance)
+	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, big.NewInt(0), token, 0, localEsdtBalance)
+	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, localEgldBalance)
 
 	// deploy 2 contracts
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
@@ -83,18 +82,18 @@ func TestRelayedAsyncESDTCall_InvalidCallFirstContract(t *testing.T) {
 	require.Nil(t, err)
 	defer testContext.Close()
 
-	egldBalance := big.NewInt(100000000)
+	localEgldBalance := big.NewInt(100000000)
 	ownerAddr := []byte("12345678901234567890123456789010")
-	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, egldBalance)
+	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, localEgldBalance)
 
 	// create an address with ESDT token
 	relayerAddr := []byte("12345678901234567890123456789033")
 	sndAddr := []byte("12345678901234567890123456789012")
 
-	esdtBalance := big.NewInt(100000000)
+	localEsdtBalance := big.NewInt(100000000)
 	token := []byte("miiutoken")
-	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, big.NewInt(0), token, 0, esdtBalance)
-	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, egldBalance)
+	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, big.NewInt(0), token, 0, localEsdtBalance)
+	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, localEgldBalance)
 
 	// deploy 2 contracts
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)
@@ -141,18 +140,18 @@ func TestRelayedAsyncESDTCall_InvalidOutOfGas(t *testing.T) {
 	require.Nil(t, err)
 	defer testContext.Close()
 
-	egldBalance := big.NewInt(100000000)
+	localEgldBalance := big.NewInt(100000000)
 	ownerAddr := []byte("12345678901234567890123456789010")
-	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, egldBalance)
+	_, _ = vm.CreateAccount(testContext.Accounts, ownerAddr, 0, localEgldBalance)
 
 	// create an address with ESDT token
 	relayerAddr := []byte("12345678901234567890123456789033")
 	sndAddr := []byte("12345678901234567890123456789012")
 
-	esdtBalance := big.NewInt(100000000)
+	localEsdtBalance := big.NewInt(100000000)
 	token := []byte("miiutoken")
-	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, big.NewInt(0), token, 0, esdtBalance)
-	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, egldBalance)
+	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, big.NewInt(0), token, 0, localEsdtBalance)
+	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, localEgldBalance)
 
 	// deploy 2 contracts
 	ownerAccount, _ := testContext.Accounts.LoadAccount(ownerAddr)

--- a/integrationTests/vm/txsFee/relayedBuiltInFunctions_test.go
+++ b/integrationTests/vm/txsFee/relayedBuiltInFunctions_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 
@@ -163,22 +162,19 @@ func TestRelayedBuildInFunctionChangeOwnerCallInsufficientGasLimitShouldConsumeG
 		testRelayedBuildInFunctionChangeOwnerCallInsufficientGasLimitShouldConsumeGas(t,
 			config.EnableEpochs{
 				RelayedNonceFixEnableEpoch: 1000,
-			},
-			2)
+			})
 	})
 	t.Run("nonce fix is enabled, should still increase the sender's nonce", func(t *testing.T) {
 		testRelayedBuildInFunctionChangeOwnerCallInsufficientGasLimitShouldConsumeGas(t,
 			config.EnableEpochs{
 				RelayedNonceFixEnableEpoch: 0,
-			},
-			2)
+			})
 	})
 }
 
 func testRelayedBuildInFunctionChangeOwnerCallInsufficientGasLimitShouldConsumeGas(
 	t *testing.T,
 	enableEpochs config.EnableEpochs,
-	expectedOwnerNonce uint64,
 ) {
 	testContext, err := vm.CreatePreparedTxProcessorWithVMs(enableEpochs)
 	require.Nil(t, err)

--- a/integrationTests/vm/txsFee/relayedDns_test.go
+++ b/integrationTests/vm/txsFee/relayedDns_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 

--- a/integrationTests/vm/txsFee/relayedESDT_test.go
+++ b/integrationTests/vm/txsFee/relayedESDT_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 
@@ -27,9 +26,9 @@ func TestRelayedESDTTransferShouldWork(t *testing.T) {
 	rcvAddr := []byte("12345678901234567890123456789022")
 
 	relayerBalance := big.NewInt(10000000)
-	esdtBalance := big.NewInt(100000000)
+	localEsdtBalance := big.NewInt(100000000)
 	token := []byte("miiutoken")
-	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, big.NewInt(0), token, 0, esdtBalance)
+	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, big.NewInt(0), token, 0, localEsdtBalance)
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, relayerBalance)
 
 	gasLimit := uint64(40)
@@ -72,9 +71,9 @@ func TestTestRelayedESTTransferNotEnoughESTValueShouldConsumeGas(t *testing.T) {
 	rcvAddr := []byte("12345678901234567890123456789022")
 
 	relayerBalance := big.NewInt(10000000)
-	esdtBalance := big.NewInt(100000000)
+	localEsdtBalance := big.NewInt(100000000)
 	token := []byte("miiutoken")
-	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, big.NewInt(0), token, 0, esdtBalance)
+	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, big.NewInt(0), token, 0, localEsdtBalance)
 	_, _ = vm.CreateAccount(testContext.Accounts, relayerAddr, 0, relayerBalance)
 
 	gasLimit := uint64(40)

--- a/integrationTests/vm/txsFee/relayedScCalls_test.go
+++ b/integrationTests/vm/txsFee/relayedScCalls_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 
@@ -266,7 +265,6 @@ func testRelayedDeployInvalidContractShouldIncrementNonceOnSender(
 	require.Nil(t, err)
 
 	relayerAddr := []byte("12345678901234567890123456789033")
-	gasPrice := uint64(10)
 	gasLimit := uint64(20)
 
 	_, _ = vm.CreateAccount(testContext.Accounts, senderAddr, 0, big.NewInt(0))

--- a/integrationTests/vm/txsFee/relayedScDeploy_test.go
+++ b/integrationTests/vm/txsFee/relayedScDeploy_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 

--- a/integrationTests/vm/txsFee/scCalls_test.go
+++ b/integrationTests/vm/txsFee/scCalls_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 
@@ -30,7 +29,7 @@ import (
 	logger "github.com/multiversx/mx-chain-logger-go"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	wasmConfig "github.com/multiversx/mx-chain-vm-go/config"
-	vmhost "github.com/multiversx/mx-chain-vm-go/vmhost"
+	"github.com/multiversx/mx-chain-vm-go/vmhost"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -326,9 +325,9 @@ func TestESDTScCallAndGasChangeShouldWork(t *testing.T) {
 	senderBalance = big.NewInt(10000000)
 	gasLimit = uint64(30000)
 
-	esdtBalance := big.NewInt(100000000)
+	localEsdtBalance := big.NewInt(100000000)
 	token := []byte("miiutoken")
-	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, senderBalance, token, 0, esdtBalance)
+	utils.CreateAccountWithESDTBalance(t, testContext.Accounts, sndAddr, senderBalance, token, 0, localEsdtBalance)
 
 	txData := txDataBuilder.NewBuilder()
 	valueToSendToSc := int64(1000)

--- a/integrationTests/vm/txsFee/scDeploy_test.go
+++ b/integrationTests/vm/txsFee/scDeploy_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 

--- a/integrationTests/vm/txsFee/utils/utils.go
+++ b/integrationTests/vm/txsFee/utils/utils.go
@@ -5,8 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -420,15 +420,15 @@ func GenerateUserNameForDNSContract(contractAddress []byte) []byte {
 // Before applying the data it does a cleanup on the old state
 // the data from the file must be in the following format:
 //
-//hex(key1),hex(value1)
-//hex(key2),hex(value2)
-//...
+// hex(key1),hex(value1)
+// hex(key2),hex(value2)
+// ...
 //
 // Example:
-//61750100,0000
-//61750101,0001
+// 61750100,0000
+// 61750101,0001
 func OverwriteAccountStorageWithHexFileContent(tb testing.TB, testContext *vm.VMTestContext, address []byte, pathToData string) {
-	allData, err := ioutil.ReadFile(filepath.Clean(pathToData))
+	allData, err := os.ReadFile(filepath.Clean(pathToData))
 	require.Nil(tb, err)
 
 	account, err := testContext.Accounts.GetExistingAccount(address)

--- a/integrationTests/vm/wasm/badcontracts/badcontracts_test.go
+++ b/integrationTests/vm/wasm/badcontracts/badcontracts_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package badcontracts
 

--- a/integrationTests/vm/wasm/delegation/delegationSimulation_test.go
+++ b/integrationTests/vm/wasm/delegation/delegationSimulation_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package delegation
 

--- a/integrationTests/vm/wasm/delegation/delegation_test.go
+++ b/integrationTests/vm/wasm/delegation/delegation_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package delegation
 

--- a/integrationTests/vm/wasm/delegation/testRunner.go
+++ b/integrationTests/vm/wasm/delegation/testRunner.go
@@ -4,8 +4,8 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"sync"
 	"time"
 
@@ -59,7 +59,7 @@ func RunDelegationStressTest(
 		return nil, err
 	}
 
-	tempDir, err := ioutil.TempDir("", "integrationTest")
+	tempDir, err := os.MkdirTemp("", "integrationTest")
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func deployDelegationSC(node *integrationTests.TestProcessorNode, delegationFile
 	blocksBeforeUnBond := 60
 	value := big.NewInt(10)
 
-	contractBytes, err := ioutil.ReadFile(delegationFilename)
+	contractBytes, err := os.ReadFile(delegationFilename)
 	if err != nil {
 		return err
 	}

--- a/integrationTests/vm/wasm/erc20/erc20_test.go
+++ b/integrationTests/vm/wasm/erc20/erc20_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package erc20
 

--- a/integrationTests/vm/wasm/upgrades/upgrades_test.go
+++ b/integrationTests/vm/wasm/upgrades/upgrades_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 

--- a/integrationTests/vm/wasm/utils.go
+++ b/integrationTests/vm/wasm/utils.go
@@ -5,9 +5,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/big"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -616,7 +616,7 @@ func (context *TestContext) UpgradeSC(wasmPath string, parametersString string) 
 
 // GetSCCode -
 func GetSCCode(fileName string) string {
-	code, err := ioutil.ReadFile(filepath.Clean(fileName))
+	code, err := os.ReadFile(filepath.Clean(fileName))
 	if err != nil {
 		panic("Could not get SC code.")
 	}

--- a/integrationTests/vm/wasm/wasmer/wasmer_test.go
+++ b/integrationTests/vm/wasm/wasmer/wasmer_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 

--- a/integrationTests/vm/wasm/wasmvm/executeViaBlockchainhook_test.go
+++ b/integrationTests/vm/wasm/wasmvm/executeViaBlockchainhook_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package wasmvm
 

--- a/integrationTests/vm/wasm/wasmvm/gasSchedule_test.go
+++ b/integrationTests/vm/wasm/wasmvm/gasSchedule_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 

--- a/integrationTests/vm/wasm/wasmvm/versionswitch/vm_test.go
+++ b/integrationTests/vm/wasm/wasmvm/versionswitch/vm_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 
@@ -12,7 +11,7 @@ import (
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
-	wasmvm "github.com/multiversx/mx-chain-go/integrationTests/vm/wasm/wasmvm"
+	"github.com/multiversx/mx-chain-go/integrationTests/vm/wasm/wasmvm"
 	"github.com/stretchr/testify/require"
 )
 

--- a/integrationTests/vm/wasm/wasmvm/versionswitch_revert/vm_test.go
+++ b/integrationTests/vm/wasm/wasmvm/versionswitch_revert/vm_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 
@@ -12,7 +11,7 @@ import (
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
-	wasmvm "github.com/multiversx/mx-chain-go/integrationTests/vm/wasm/wasmvm"
+	"github.com/multiversx/mx-chain-go/integrationTests/vm/wasm/wasmvm"
 	"github.com/stretchr/testify/require"
 )
 

--- a/integrationTests/vm/wasm/wasmvm/versionswitch_vmquery/vm_test.go
+++ b/integrationTests/vm/wasm/wasmvm/versionswitch_vmquery/vm_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 
@@ -12,7 +11,7 @@ import (
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
-	wasmvm "github.com/multiversx/mx-chain-go/integrationTests/vm/wasm/wasmvm"
+	"github.com/multiversx/mx-chain-go/integrationTests/vm/wasm/wasmvm"
 	"github.com/stretchr/testify/require"
 )
 

--- a/integrationTests/vm/wasm/wasmvm/wasmVM_test.go
+++ b/integrationTests/vm/wasm/wasmvm/wasmVM_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // TODO remove build condition above to allow -race -short, after Wasm VM fix
 

--- a/node/nodeMemoryConfig_test.go
+++ b/node/nodeMemoryConfig_test.go
@@ -1,7 +1,7 @@
 package node
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core"
@@ -13,7 +13,7 @@ import (
 func TestMemoryConfig(t *testing.T) {
 	nodeConfig := config.Config{}
 
-	tomlBytes, err := ioutil.ReadFile("../cmd/node/config/config.toml")
+	tomlBytes, err := os.ReadFile("../cmd/node/config/config.toml")
 	require.Nil(t, err)
 	err = toml.Unmarshal(tomlBytes, &nodeConfig)
 	require.Nil(t, err)

--- a/node/nodeRunner_test.go
+++ b/node/nodeRunner_test.go
@@ -1,10 +1,8 @@
 //go:build !race
-// +build !race
 
 package node
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"syscall"
@@ -96,17 +94,17 @@ func TestCopyDirectory(t *testing.T) {
 	//   +- dir2
 	//         +- file4
 
-	err := ioutil.WriteFile(path.Join(tempDir, file1Name), file1Contents, os.ModePerm)
+	err := os.WriteFile(path.Join(tempDir, file1Name), file1Contents, os.ModePerm)
 	require.Nil(t, err)
 	err = os.MkdirAll(path.Join(tempDir, "src", "dir1"), os.ModePerm)
 	require.Nil(t, err)
 	err = os.MkdirAll(path.Join(tempDir, "src", "dir2"), os.ModePerm)
 	require.Nil(t, err)
-	err = ioutil.WriteFile(path.Join(tempDir, "src", file2Name), file2Contents, os.ModePerm)
+	err = os.WriteFile(path.Join(tempDir, "src", file2Name), file2Contents, os.ModePerm)
 	require.Nil(t, err)
-	err = ioutil.WriteFile(path.Join(tempDir, "src", "dir1", file3Name), file3Contents, os.ModePerm)
+	err = os.WriteFile(path.Join(tempDir, "src", "dir1", file3Name), file3Contents, os.ModePerm)
 	require.Nil(t, err)
-	err = ioutil.WriteFile(path.Join(tempDir, "src", "dir2", file4Name), file4Contents, os.ModePerm)
+	err = os.WriteFile(path.Join(tempDir, "src", "dir2", file4Name), file4Contents, os.ModePerm)
 	require.Nil(t, err)
 
 	err = copyDirectory(path.Join(tempDir, "src"), path.Join(tempDir, "dst"))
@@ -114,19 +112,19 @@ func TestCopyDirectory(t *testing.T) {
 	copySingleFile(path.Join(tempDir, "dst"), path.Join(tempDir, file1Name))
 
 	// after copy, check that the files are the same
-	buff, err := ioutil.ReadFile(path.Join(tempDir, "dst", file1Name))
+	buff, err := os.ReadFile(path.Join(tempDir, "dst", file1Name))
 	require.Nil(t, err)
 	assert.Equal(t, file1Contents, buff)
 
-	buff, err = ioutil.ReadFile(path.Join(tempDir, "dst", file2Name))
+	buff, err = os.ReadFile(path.Join(tempDir, "dst", file2Name))
 	require.Nil(t, err)
 	assert.Equal(t, file2Contents, buff)
 
-	buff, err = ioutil.ReadFile(path.Join(tempDir, "dst", "dir1", file3Name))
+	buff, err = os.ReadFile(path.Join(tempDir, "dst", "dir1", file3Name))
 	require.Nil(t, err)
 	assert.Equal(t, file3Contents, buff)
 
-	buff, err = ioutil.ReadFile(path.Join(tempDir, "dst", "dir2", file4Name))
+	buff, err = os.ReadFile(path.Join(tempDir, "dst", "dir2", file4Name))
 	require.Nil(t, err)
 	assert.Equal(t, file4Contents, buff)
 }

--- a/outport/notifier/httpClientWrapper.go
+++ b/outport/notifier/httpClientWrapper.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -94,7 +94,7 @@ func (h *httpClientWrapper) Post(
 		}
 	}()
 
-	resBody, err := ioutil.ReadAll(resp.Body)
+	resBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/storage/factory/dbConfigHandler.go
+++ b/storage/factory/dbConfigHandler.go
@@ -1,7 +1,6 @@
 package factory
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -122,7 +121,7 @@ func checkIfDirExists(path string) (bool, error) {
 }
 
 func checkIfDirIsEmpty(path string) bool {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		log.Trace("getDBConfig: failed to check if dir is empty", "path", path, "error", err.Error())
 		return true

--- a/testscommon/dataRetriever/poolFactory.go
+++ b/testscommon/dataRetriever/poolFactory.go
@@ -2,7 +2,7 @@ package dataRetriever
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/multiversx/mx-chain-core-go/marshal"
@@ -87,7 +87,7 @@ func CreatePoolsHolder(numShards uint32, selfShard uint32) dataRetriever.PoolsHo
 	cacher, err := cache.NewCapacityLRU(10, 10000)
 	panicIfError("Create trieSync cacher", err)
 
-	tempDir, _ := ioutil.TempDir("", "integrationTests")
+	tempDir, _ := os.MkdirTemp("", "integrationTests")
 	cfg := storageunit.ArgDB{
 		Path:              tempDir,
 		DBType:            storageunit.LvlDBSerial,

--- a/testscommon/goroutines/counter_test.go
+++ b/testscommon/goroutines/counter_test.go
@@ -1,7 +1,7 @@
 package goroutines
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +12,7 @@ func TestGoRoutines_SnapshotAll(t *testing.T) {
 	t.Parallel()
 
 	handler := func() string {
-		buffFile1, err := ioutil.ReadFile("testdata/test1.data")
+		buffFile1, err := os.ReadFile("testdata/test1.data")
 		require.Nil(t, err)
 
 		return string(buffFile1)
@@ -35,7 +35,7 @@ func TestGoRoutines_SnapshotAllDifferentFiles(t *testing.T) {
 
 	filename := "testdata/test2.data"
 	handler := func() string {
-		buffFile, err := ioutil.ReadFile(filename)
+		buffFile, err := os.ReadFile(filename)
 		require.Nil(t, err)
 
 		return string(buffFile)
@@ -68,7 +68,7 @@ func TestGoRoutines_Reset(t *testing.T) {
 
 	filename := "testdata/test2.data"
 	handler := func() string {
-		buffFile, err := ioutil.ReadFile(filename)
+		buffFile, err := os.ReadFile(filename)
 		require.Nil(t, err)
 
 		return string(buffFile)

--- a/testscommon/goroutines/snapshot_test.go
+++ b/testscommon/goroutines/snapshot_test.go
@@ -1,7 +1,7 @@
 package goroutines
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +11,7 @@ import (
 func TestNewSnapshot(t *testing.T) {
 	t.Parallel()
 
-	buff, err := ioutil.ReadFile("testdata/test1.data")
+	buff, err := os.ReadFile("testdata/test1.data")
 	require.Nil(t, err)
 	s, err := newSnapshot(string(buff), AllPassFilter)
 	assert.Nil(t, err)
@@ -21,7 +21,7 @@ func TestNewSnapshot(t *testing.T) {
 func TestNewSnapshot_WithFilter(t *testing.T) {
 	t.Parallel()
 
-	buff, err := ioutil.ReadFile("testdata/test1.data")
+	buff, err := os.ReadFile("testdata/test1.data")
 	require.Nil(t, err)
 	s, err := newSnapshot(string(buff), TestsRelevantGoRoutines)
 	assert.Nil(t, err)
@@ -31,12 +31,12 @@ func TestNewSnapshot_WithFilter(t *testing.T) {
 func TestSnapshot_Diff(t *testing.T) {
 	t.Parallel()
 
-	buffFile2, err := ioutil.ReadFile("testdata/test2.data")
+	buffFile2, err := os.ReadFile("testdata/test2.data")
 	require.Nil(t, err)
 	snapshot2, err := newSnapshot(string(buffFile2), AllPassFilter)
 	require.Nil(t, err)
 
-	buffFile3, err := ioutil.ReadFile("testdata/test3.data")
+	buffFile3, err := os.ReadFile("testdata/test3.data")
 	require.Nil(t, err)
 	snapshot3, err := newSnapshot(string(buffFile3), AllPassFilter)
 	require.Nil(t, err)

--- a/testscommon/realConfigsHandling.go
+++ b/testscommon/realConfigsHandling.go
@@ -1,7 +1,7 @@
 package testscommon
 
 import (
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path"
 	"strings"
@@ -96,7 +96,7 @@ func CreateTestConfigs(tb testing.TB, originalConfigsPath string) *config.Config
 }
 
 func correctTestPathInGenesisSmartContracts(tb testing.TB, tempDir string, newGenesisSmartContractsFilename string) {
-	input, err := ioutil.ReadFile(newGenesisSmartContractsFilename)
+	input, err := os.ReadFile(newGenesisSmartContractsFilename)
 	require.Nil(tb, err)
 
 	lines := strings.Split(string(input), "\n")
@@ -106,6 +106,6 @@ func correctTestPathInGenesisSmartContracts(tb testing.TB, tempDir string, newGe
 		}
 	}
 	output := strings.Join(lines, "\n")
-	err = ioutil.WriteFile(newGenesisSmartContractsFilename, []byte(output), 0644)
+	err = os.WriteFile(newGenesisSmartContractsFilename, []byte(output), 0644)
 	require.Nil(tb, err)
 }

--- a/update/genesis/export.go
+++ b/update/genesis/export.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -492,7 +492,7 @@ func (se *stateExport) exportNodesSetupJson(validators map[uint32][]*state.Valid
 		return err
 	}
 
-	return ioutil.WriteFile(filepath.Join(se.exportFolder, common.NodesSetupJsonFileName), nodesSetupBytes, 0664)
+	return os.WriteFile(filepath.Join(se.exportFolder, common.NodesSetupJsonFileName), nodesSetupBytes, 0664)
 }
 
 // IsInterfaceNil returns true if underlying object is nil

--- a/update/genesis/export_test.go
+++ b/update/genesis/export_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -405,7 +404,7 @@ func TestStateExport_ExportNodesSetupJsonShouldExportKeysInAlphabeticalOrder(t *
 
 	var nodesSetup sharding.NodesSetup
 
-	nsBytes, err := ioutil.ReadFile(filepath.Join(testFolderName, common.NodesSetupJsonFileName))
+	nsBytes, err := os.ReadFile(filepath.Join(testFolderName, common.NodesSetupJsonFileName))
 	require.NoError(t, err)
 
 	err = json.Unmarshal(nsBytes, &nodesSetup)

--- a/update/trigger/importStartHandler.go
+++ b/update/trigger/importStartHandler.go
@@ -1,7 +1,6 @@
 package trigger
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,7 +48,7 @@ func (ish *importStartHandler) loadFileStatus() (string, bool) {
 		return "", false
 	}
 
-	contents, err := ioutil.ReadFile(ish.getFilename())
+	contents, err := os.ReadFile(ish.getFilename())
 	if err != nil {
 		log.Error("error reading must import file",
 			"file", ish.getFilename(),


### PR DESCRIPTION
## Reasoning behind the pull request
- linter issues
  
## Proposed changes
Implemented the following recommendations:
```
ioutil.ReadFile:  Deprecated: As of Go 1.16, this function simply calls os.ReadFile
ioutil.ReadAll:   Deprecated: As of Go 1.16, this function simply calls io.ReadAll
ioutil.TempDir:   Deprecated: As of Go 1.17, this function simply calls os.MkdirTemp
ioutil.WriteFile: Deprecated: As of Go 1.16, this function simply calls os.WriteFile
//+build comments can be removed
```

## Testing procedure
- standard system test, termui check to see the memory consumed by the process is not 0

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
