### PR TITLE
Verify + save received extended header

### DIFF
--- a/cmd/sovereignnode/incomingHeader/incomingHeaderProcessor.go
+++ b/cmd/sovereignnode/incomingHeader/incomingHeaderProcessor.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
@@ -82,6 +83,15 @@ func (ihp *incomingHeaderProcessor) AddHeader(headerHash []byte, header sovereig
 
 	ihp.scrProc.addSCRsToPool(incomingSCRs)
 	return nil
+}
+
+func (ihp *incomingHeaderProcessor) CreateExtendedHeader(header sovereign.IncomingHeaderHandler) (data.ShardHeaderExtendedHandler, error) {
+	incomingSCRs, err := ihp.scrProc.createIncomingSCRs(header.GetIncomingEventHandlers())
+	if err != nil {
+		return nil, err
+	}
+
+	return createExtendedHeader(header, incomingSCRs)
 }
 
 // IsInterfaceNil checks if the underlying pointer is nil

--- a/cmd/sovereignnode/incomingHeader/incomingHeaderProcessor.go
+++ b/cmd/sovereignnode/incomingHeader/incomingHeaderProcessor.go
@@ -85,6 +85,7 @@ func (ihp *incomingHeaderProcessor) AddHeader(headerHash []byte, header sovereig
 	return nil
 }
 
+// CreateExtendedHeader will create an extended shard header with incoming scrs and mbs from the events of the received header
 func (ihp *incomingHeaderProcessor) CreateExtendedHeader(header sovereign.IncomingHeaderHandler) (data.ShardHeaderExtendedHandler, error) {
 	incomingSCRs, err := ihp.scrProc.createIncomingSCRs(header.GetIncomingEventHandlers())
 	if err != nil {

--- a/cmd/sovereignnode/incomingHeader/incomingHeaderProcessor_test.go
+++ b/cmd/sovereignnode/incomingHeader/incomingHeaderProcessor_test.go
@@ -279,10 +279,12 @@ func TestIncomingHeaderHandler_AddHeader(t *testing.T) {
 		{
 			Identifier: []byte("deposit"),
 			Topics:     topic1,
+			Data:       big.NewInt(0).Bytes(),
 		},
 		{
 			Identifier: []byte("deposit"),
 			Topics:     topic2,
+			Data:       big.NewInt(1).Bytes(),
 		},
 	}
 
@@ -334,82 +336,4 @@ func TestIncomingHeaderHandler_AddHeader(t *testing.T) {
 	require.Nil(t, err)
 	require.True(t, wasAddedInHeaderPool)
 	require.True(t, wasAddedInTxPool)
-}
-
-func TestIncomingHeaderHandler_AddHeaderExpectNoncesIncremented(t *testing.T) {
-	t.Parallel()
-
-	args := createArgs()
-
-	addr1 := []byte("addr1")
-	addInTxPoolCt := uint64(0)
-	args.TxPool = &testscommon.ShardedDataStub{
-		AddDataCalled: func(key []byte, data interface{}, sizeInBytes int, cacheID string) {
-			expectedSCR := &smartContractResult.SmartContractResult{
-				Nonce:   addInTxPoolCt,
-				Value:   big.NewInt(0),
-				RcvAddr: addr1,
-				SndAddr: core.ESDTSCAddress,
-				Data:    []byte("MultiESDTNFTTransfer@01@746f6b656e31@@64"),
-			}
-
-			expectedScrHash, err := core.CalculateHash(args.Marshaller, args.Hasher, expectedSCR)
-			require.Nil(t, err)
-			require.Equal(t, expectedScrHash, key)
-
-			addInTxPoolCt++
-		},
-	}
-
-	errCt := uint64(4)
-	errUnmarshall := errors.New("error unmarshall")
-	args.Marshaller = &marshallerMock.MarshalizerStub{
-		MarshalCalled: func(obj interface{}) ([]byte, error) {
-			if addInTxPoolCt == errCt {
-				return nil, errUnmarshall
-			}
-
-			return json.Marshal(obj)
-		},
-	}
-
-	handler, _ := NewIncomingHeaderProcessor(args)
-	incomingHeader := &sovereign.IncomingHeader{
-		Header: &block.HeaderV2{
-			ScheduledRootHash: []byte("root hash"),
-		},
-		IncomingEvents: []*transaction.Event{
-			{
-				Identifier: []byte("deposit"),
-				Topics: [][]byte{
-					addr1,
-					[]byte("token1"),
-					big.NewInt(0).Bytes(),
-					big.NewInt(100).Bytes(),
-				},
-			},
-		},
-	}
-
-	i := uint64(0)
-	for ; i < 4; i++ {
-		err := handler.AddHeader([]byte(fmt.Sprintf("hash%d", i)), incomingHeader)
-		require.Nil(t, err)
-		require.Equal(t, i+1, addInTxPoolCt)
-	}
-	require.Equal(t, uint64(4), handler.scrProc.nonce)
-
-	err := handler.AddHeader([]byte(fmt.Sprintf("hash%d", i)), incomingHeader)
-	require.Equal(t, errUnmarshall, err)
-	require.Equal(t, i, addInTxPoolCt)
-	require.Equal(t, uint64(4), handler.scrProc.nonce)
-
-	errCt = 0
-	for ; i < 10; i++ {
-		err = handler.AddHeader([]byte(fmt.Sprintf("hash%d", i)), incomingHeader)
-		require.Nil(t, err)
-		require.Equal(t, i+1, addInTxPoolCt)
-	}
-
-	require.Equal(t, uint64(10), handler.scrProc.nonce)
 }

--- a/cmd/sovereignnode/incomingHeader/incomingSCRProcessor.go
+++ b/cmd/sovereignnode/incomingHeader/incomingSCRProcessor.go
@@ -27,7 +27,6 @@ type scrProcessor struct {
 	txPool     TransactionPool
 	marshaller marshal.Marshalizer
 	hasher     hashing.Hasher
-	nonce      uint64
 }
 
 func (sp *scrProcessor) createIncomingSCRs(events []data.EventHandler) ([]*scrInfo, error) {
@@ -45,9 +44,10 @@ func (sp *scrProcessor) createIncomingSCRs(events []data.EventHandler) ([]*scrIn
 				errInvalidNumTopicsIncomingEvent, idx, len(topics))
 		}
 
+		eventNonce := big.NewInt(0).SetBytes(event.GetData())
 		scr := &smartContractResult.SmartContractResult{
-			Nonce:          sp.nonce, // TODO:  Save this nonce in storage + load in from storage in MX-14320 task
-			OriginalTxHash: nil,      // TODO:  Implement this in MX-14321 task
+			Nonce:          eventNonce.Uint64(),
+			OriginalTxHash: nil, // TODO:  Implement this in MX-14321 task
 			RcvAddr:        topics[0],
 			SndAddr:        core.ESDTSCAddress,
 			Data:           createSCRData(topics),
@@ -59,8 +59,6 @@ func (sp *scrProcessor) createIncomingSCRs(events []data.EventHandler) ([]*scrIn
 			return nil, err
 		}
 
-		// TODO: Should we revert nonce incrementation if processing fails later in code?
-		sp.nonce++
 		scrs = append(scrs, &scrInfo{
 			scr:  scr,
 			hash: hash,

--- a/cmd/sovereignnode/systemTestDemo/mockNotifier/notifier.go
+++ b/cmd/sovereignnode/systemTestDemo/mockNotifier/notifier.go
@@ -173,6 +173,7 @@ func createLogs(subscribedAddr []byte, ct uint64) ([]*outport.LogData, error) {
 						Address:    subscribedAddr,
 						Identifier: []byte("deposit"),
 						Topics:     topics,
+						Data:       big.NewInt(int64(ct)).Bytes(),
 					},
 				},
 			},

--- a/dataRetriever/requestHandlers/sovereignRequestHandler.go
+++ b/dataRetriever/requestHandlers/sovereignRequestHandler.go
@@ -88,7 +88,7 @@ func (srrh *sovereignResolverRequestHandler) RequestExtendedShardHeader(hash []b
 		return
 	}
 
-	log.Debug("rsovereign: requesting extended shard header from network by hash",
+	log.Debug("sovereign: requesting extended shard header from network by hash",
 		"shard", srrh.shardID,
 		"hash", hash,
 	)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -650,5 +650,5 @@ var ErrNilShardResolversContainerFactory = errors.New("nil shard resolvers conta
 // ErrNilShardResolversContainerFactoryCreator signals that a nil shard resolvers container factory creator has been provided
 var ErrNilShardResolversContainerFactoryCreator = errors.New("nil shard resolvers container factory creator has been provided")
 
-// ErrInvalidReceivedSovereignProof signals that an invalid sovereign proof has been intercepted when requested
-var ErrInvalidReceivedSovereignProof = errors.New("invalid received sovereign proof")
+// ErrInvalidReceivedExtendedShardHeader signals that an invalid extended shard header has been intercepted when requested
+var ErrInvalidReceivedExtendedShardHeader = errors.New("invalid extended shard header has been intercepted")

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -649,3 +649,6 @@ var ErrNilShardResolversContainerFactory = errors.New("nil shard resolvers conta
 
 // ErrNilShardResolversContainerFactoryCreator signals that a nil shard resolvers container factory creator has been provided
 var ErrNilShardResolversContainerFactoryCreator = errors.New("nil shard resolvers container factory creator has been provided")
+
+// ErrInvalidReceivedSovereignProof signals that an invalid sovereign proof has been intercepted when requested
+var ErrInvalidReceivedSovereignProof = errors.New("invalid received sovereign proof")

--- a/process/factory/interceptorscontainer/sovereignShardInterceptorsContainerFactory.go
+++ b/process/factory/interceptorscontainer/sovereignShardInterceptorsContainerFactory.go
@@ -71,6 +71,7 @@ func (sicf *sovereignShardInterceptorsContainerFactory) generateSovereignHeaderI
 		Hasher:                   sicf.argInterceptorFactory.CoreComponents.Hasher(),
 		Marshaller:               sicf.argInterceptorFactory.CoreComponents.InternalMarshalizer(),
 		IncomingHeaderSubscriber: sicf.incomingHeaderSubscriber,
+		HeadersPool:              sicf.dataPool.Headers(),
 	}
 	hdrProcessor, err := processor.NewSovereignHdrInterceptorProcessor(argProcessor)
 	if err != nil {

--- a/process/interceptors/processor/sovereignHdrInterceptorProcessor.go
+++ b/process/interceptors/processor/sovereignHdrInterceptorProcessor.go
@@ -112,7 +112,7 @@ func (hip *sovereignHeaderInterceptorProcessor) validateReceivedHeader(
 	return nil
 }
 
-// Save will save the received data into headers pool
+// Save will save the received data into headers pool, if it doesn't exit already
 func (hip *sovereignHeaderInterceptorProcessor) Save(data process.InterceptedData, _ core.PeerID, _ string) error {
 	interceptedHdr, ok := data.(process.ExtendedHeaderValidatorHandler)
 	if !ok {

--- a/process/interceptors/processor/sovereignHdrInterceptorProcessor.go
+++ b/process/interceptors/processor/sovereignHdrInterceptorProcessor.go
@@ -103,7 +103,7 @@ func (hip *sovereignHeaderInterceptorProcessor) validateReceivedHeader(
 
 	if !bytes.Equal(computedHeaderHash, hash) {
 		return fmt.Errorf("%w, computed hash: %s, received hash: %s",
-			errors.ErrInvalidReceivedSovereignProof,
+			errors.ErrInvalidReceivedExtendedShardHeader,
 			hex.EncodeToString(computedHeaderHash),
 			hex.EncodeToString(hash),
 		)

--- a/process/interceptors/processor/sovereignHdrInterceptorProcessor.go
+++ b/process/interceptors/processor/sovereignHdrInterceptorProcessor.go
@@ -101,7 +101,7 @@ func (hip *sovereignHeaderInterceptorProcessor) validateReceivedHeader(
 		return err
 	}
 
-	if bytes.Compare(computedHeaderHash, hash) != 0 {
+	if !bytes.Equal(computedHeaderHash, hash) {
 		return fmt.Errorf("%w, computed hash: %s, received hash: %s",
 			errors.ErrInvalidReceivedSovereignProof,
 			hex.EncodeToString(computedHeaderHash),

--- a/process/interceptors/processor/sovereignHdrInterceptorProcessor.go
+++ b/process/interceptors/processor/sovereignHdrInterceptorProcessor.go
@@ -1,12 +1,15 @@
 package processor
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+	"github.com/multiversx/mx-chain-go/dataRetriever"
+	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/process"
 )
 
@@ -16,6 +19,7 @@ type ArgsSovereignHeaderInterceptorProcessor struct {
 	Hasher                   hashing.Hasher
 	Marshaller               marshal.Marshalizer
 	IncomingHeaderSubscriber process.IncomingHeaderSubscriber
+	HeadersPool              dataRetriever.HeadersPool
 }
 
 type sovereignHeaderInterceptorProcessor struct {
@@ -23,30 +27,49 @@ type sovereignHeaderInterceptorProcessor struct {
 	Hasher                   hashing.Hasher
 	Marshaller               marshal.Marshalizer
 	IncomingHeaderSubscriber process.IncomingHeaderSubscriber
+	headersPool              dataRetriever.HeadersPool
 }
 
 // NewSovereignHdrInterceptorProcessor creates a new sovereign extended header interceptor processor
-func NewSovereignHdrInterceptorProcessor(argument *ArgsSovereignHeaderInterceptorProcessor) (*sovereignHeaderInterceptorProcessor, error) {
-	if argument == nil {
+func NewSovereignHdrInterceptorProcessor(args *ArgsSovereignHeaderInterceptorProcessor) (*sovereignHeaderInterceptorProcessor, error) {
+	if args == nil {
 		return nil, process.ErrNilArgumentStruct
 	}
-	if check.IfNil(argument.BlockBlackList) {
+	if check.IfNil(args.BlockBlackList) {
 		return nil, process.ErrNilBlackListCacher
 	}
 
 	return &sovereignHeaderInterceptorProcessor{
-		blackList:                argument.BlockBlackList,
-		Hasher:                   argument.Hasher,
-		Marshaller:               argument.Marshaller,
-		IncomingHeaderSubscriber: argument.IncomingHeaderSubscriber,
+		blackList:                args.BlockBlackList,
+		Hasher:                   args.Hasher,
+		Marshaller:               args.Marshaller,
+		IncomingHeaderSubscriber: args.IncomingHeaderSubscriber,
+		headersPool:              args.HeadersPool,
 	}, nil
 }
 
 // Validate checks if the intercepted data can be processed
 func (hip *sovereignHeaderInterceptorProcessor) Validate(data process.InterceptedData, _ core.PeerID) error {
-	_, ok := data.(process.ExtendedHeaderValidatorHandler)
+	interceptedHdr, ok := data.(process.ExtendedHeaderValidatorHandler)
 	if !ok {
 		return fmt.Errorf("sovereignHeaderInterceptorProcessor.Validate error: %w", process.ErrWrongTypeAssertion)
+	}
+
+	hip.blackList.Sweep()
+	isBlackListed := hip.blackList.Has(string(interceptedHdr.Hash()))
+	if isBlackListed {
+		return process.ErrHeaderIsBlackListed
+	}
+
+	extendedHdr := interceptedHdr.GetExtendedHeader()
+	computedExtendedHeader, err := hip.IncomingHeaderSubscriber.CreateExtendedHeader(extendedHdr)
+	if err != nil {
+		return err
+	}
+
+	computedHeaderHash, err := core.CalculateHash(hip.Marshaller, hip.Hasher, computedExtendedHeader)
+	if bytes.Compare(computedHeaderHash, interceptedHdr.Hash()) != 0 {
+		return errors.ErrInvalidReceivedSovereignProof
 	}
 
 	return nil
@@ -54,12 +77,16 @@ func (hip *sovereignHeaderInterceptorProcessor) Validate(data process.Intercepte
 
 // Save will save the received data into headers pool
 func (hip *sovereignHeaderInterceptorProcessor) Save(data process.InterceptedData, _ core.PeerID, _ string) error {
-	_, ok := data.(process.ExtendedHeaderValidatorHandler)
+	interceptedHdr, ok := data.(process.ExtendedHeaderValidatorHandler)
 	if !ok {
 		return fmt.Errorf("sovereignHeaderInterceptorProcessor.Save error: %w", process.ErrWrongTypeAssertion)
 	}
 
-	return nil
+	if _, err := hip.headersPool.GetHeaderByHash(interceptedHdr.Hash()); err == nil {
+		return nil
+	}
+
+	return hip.IncomingHeaderSubscriber.AddHeader(interceptedHdr.Hash(), interceptedHdr.GetExtendedHeader())
 }
 
 // RegisterHandler does nothing

--- a/process/interceptors/processor/sovereignHdrInterceptorProcessor.go
+++ b/process/interceptors/processor/sovereignHdrInterceptorProcessor.go
@@ -112,7 +112,7 @@ func (hip *sovereignHeaderInterceptorProcessor) validateReceivedHeader(
 	return nil
 }
 
-// Save will save the received data into headers pool, if it doesn't exit already
+// Save will save the received data into headers pool, if it doesn't already exist
 func (hip *sovereignHeaderInterceptorProcessor) Save(data process.InterceptedData, _ core.PeerID, _ string) error {
 	interceptedHdr, ok := data.(process.ExtendedHeaderValidatorHandler)
 	if !ok {

--- a/process/interceptors/processor/sovereignHdrInterceptorProcessor.go
+++ b/process/interceptors/processor/sovereignHdrInterceptorProcessor.go
@@ -2,10 +2,12 @@ package processor
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
@@ -32,11 +34,9 @@ type sovereignHeaderInterceptorProcessor struct {
 
 // NewSovereignHdrInterceptorProcessor creates a new sovereign extended header interceptor processor
 func NewSovereignHdrInterceptorProcessor(args *ArgsSovereignHeaderInterceptorProcessor) (*sovereignHeaderInterceptorProcessor, error) {
-	if args == nil {
-		return nil, process.ErrNilArgumentStruct
-	}
-	if check.IfNil(args.BlockBlackList) {
-		return nil, process.ErrNilBlackListCacher
+	err := checkSovHdrProcArgs(args)
+	if err != nil {
+		return nil, err
 	}
 
 	return &sovereignHeaderInterceptorProcessor{
@@ -46,6 +46,29 @@ func NewSovereignHdrInterceptorProcessor(args *ArgsSovereignHeaderInterceptorPro
 		IncomingHeaderSubscriber: args.IncomingHeaderSubscriber,
 		headersPool:              args.HeadersPool,
 	}, nil
+}
+
+func checkSovHdrProcArgs(args *ArgsSovereignHeaderInterceptorProcessor) error {
+	if args == nil {
+		return process.ErrNilArgumentStruct
+	}
+	if check.IfNil(args.BlockBlackList) {
+		return process.ErrNilBlackListCacher
+	}
+	if check.IfNil(args.Hasher) {
+		return errors.ErrNilHasher
+	}
+	if check.IfNil(args.Marshaller) {
+		return errors.ErrNilMarshalizer
+	}
+	if check.IfNil(args.IncomingHeaderSubscriber) {
+		return errors.ErrNilIncomingHeaderSubscriber
+	}
+	if check.IfNil(args.HeadersPool) {
+		return process.ErrNilHeadersDataPool
+	}
+
+	return nil
 }
 
 // Validate checks if the intercepted data can be processed
@@ -61,15 +84,29 @@ func (hip *sovereignHeaderInterceptorProcessor) Validate(data process.Intercepte
 		return process.ErrHeaderIsBlackListed
 	}
 
-	extendedHdr := interceptedHdr.GetExtendedHeader()
+	return hip.validateReceivedHeader(interceptedHdr.GetExtendedHeader(), interceptedHdr.Hash())
+}
+
+func (hip *sovereignHeaderInterceptorProcessor) validateReceivedHeader(
+	extendedHdr data.ShardHeaderExtendedHandler,
+	hash []byte,
+) error {
 	computedExtendedHeader, err := hip.IncomingHeaderSubscriber.CreateExtendedHeader(extendedHdr)
 	if err != nil {
 		return err
 	}
 
 	computedHeaderHash, err := core.CalculateHash(hip.Marshaller, hip.Hasher, computedExtendedHeader)
-	if bytes.Compare(computedHeaderHash, interceptedHdr.Hash()) != 0 {
-		return errors.ErrInvalidReceivedSovereignProof
+	if err != nil {
+		return err
+	}
+
+	if bytes.Compare(computedHeaderHash, hash) != 0 {
+		return fmt.Errorf("%w, computed hash: %s, received hash: %s",
+			errors.ErrInvalidReceivedSovereignProof,
+			hex.EncodeToString(computedHeaderHash),
+			hex.EncodeToString(hash),
+		)
 	}
 
 	return nil
@@ -82,7 +119,11 @@ func (hip *sovereignHeaderInterceptorProcessor) Save(data process.InterceptedDat
 		return fmt.Errorf("sovereignHeaderInterceptorProcessor.Save error: %w", process.ErrWrongTypeAssertion)
 	}
 
-	if _, err := hip.headersPool.GetHeaderByHash(interceptedHdr.Hash()); err == nil {
+	// do not add header again + create scrs and mbs if already received
+	_, err := hip.headersPool.GetHeaderByHash(interceptedHdr.Hash())
+	if err == nil {
+		log.Debug("sovereignHeaderInterceptorProcessor.Save skipping already received extended header",
+			"hash", hex.EncodeToString(interceptedHdr.Hash()))
 		return nil
 	}
 

--- a/process/interceptors/processor/sovereignHdrInterceptorProcessor_test.go
+++ b/process/interceptors/processor/sovereignHdrInterceptorProcessor_test.go
@@ -1,0 +1,114 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/block"
+	sovereignData "github.com/multiversx/mx-chain-core-go/data/sovereign"
+	"github.com/multiversx/mx-chain-go/errors"
+	"github.com/multiversx/mx-chain-go/process"
+	"github.com/multiversx/mx-chain-go/process/mock"
+	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
+	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
+	"github.com/multiversx/mx-chain-go/testscommon/sovereign"
+	"github.com/stretchr/testify/require"
+)
+
+func createSovHdrProcArgs() *ArgsSovereignHeaderInterceptorProcessor {
+	return &ArgsSovereignHeaderInterceptorProcessor{
+		BlockBlackList:           &testscommon.TimeCacheStub{},
+		Hasher:                   &hashingMocks.HasherMock{},
+		Marshaller:               &marshallerMock.MarshalizerMock{},
+		IncomingHeaderSubscriber: &sovereign.IncomingHeaderSubscriberStub{},
+		HeadersPool:              &mock.HeadersCacherStub{},
+	}
+}
+
+func TestNewSovereignHdrInterceptorProcessor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should work", func(t *testing.T) {
+		args := createSovHdrProcArgs()
+		sovHdrProc, err := NewSovereignHdrInterceptorProcessor(args)
+		require.Nil(t, err)
+		require.False(t, sovHdrProc.IsInterfaceNil())
+	})
+	t.Run("nil args, should return error", func(t *testing.T) {
+		sovHdrProc, err := NewSovereignHdrInterceptorProcessor(nil)
+		require.Equal(t, process.ErrNilArgumentStruct, err)
+		require.Nil(t, sovHdrProc)
+	})
+	t.Run("nil black list cache, should return error", func(t *testing.T) {
+		args := createSovHdrProcArgs()
+		args.BlockBlackList = nil
+		sovHdrProc, err := NewSovereignHdrInterceptorProcessor(args)
+		require.Equal(t, process.ErrNilBlackListCacher, err)
+		require.Nil(t, sovHdrProc)
+	})
+	t.Run("nil hasher, should return error", func(t *testing.T) {
+		args := createSovHdrProcArgs()
+		args.Hasher = nil
+		sovHdrProc, err := NewSovereignHdrInterceptorProcessor(args)
+		require.Equal(t, errors.ErrNilHasher, err)
+		require.Nil(t, sovHdrProc)
+	})
+	t.Run("nil marshaller, should return error", func(t *testing.T) {
+		args := createSovHdrProcArgs()
+		args.Marshaller = nil
+		sovHdrProc, err := NewSovereignHdrInterceptorProcessor(args)
+		require.Equal(t, errors.ErrNilMarshalizer, err)
+		require.Nil(t, sovHdrProc)
+	})
+	t.Run("nil incoming header subscriber, should return error", func(t *testing.T) {
+		args := createSovHdrProcArgs()
+		args.IncomingHeaderSubscriber = nil
+		sovHdrProc, err := NewSovereignHdrInterceptorProcessor(args)
+		require.Equal(t, errors.ErrNilIncomingHeaderSubscriber, err)
+		require.Nil(t, sovHdrProc)
+	})
+	t.Run("nil headers pool, should return error", func(t *testing.T) {
+		args := createSovHdrProcArgs()
+		args.HeadersPool = nil
+		sovHdrProc, err := NewSovereignHdrInterceptorProcessor(args)
+		require.Equal(t, process.ErrNilHeadersDataPool, err)
+		require.Nil(t, sovHdrProc)
+	})
+}
+
+func TestSovereignHeaderInterceptorProcessor_Validate(t *testing.T) {
+	t.Parallel()
+
+	extendedHdrHash := []byte("hash")
+	wasHashComputed := false
+
+	args := createSovHdrProcArgs()
+	args.Hasher = &testscommon.HasherStub{
+		ComputeCalled: func(s string) []byte {
+			wasHashComputed = true
+			return extendedHdrHash
+		},
+	}
+
+	extendedHeader := &block.ShardHeaderExtended{}
+	interceptedHdr := &testscommon.SovereignInterceptedExtendedHeaderDataStub{
+		HashCalled: func() []byte {
+			return extendedHdrHash
+		},
+		GetExtendedHeaderCalled: func() data.ShardHeaderExtendedHandler {
+			return extendedHeader
+		},
+	}
+	args.IncomingHeaderSubscriber = &sovereign.IncomingHeaderSubscriberStub{
+		CreateExtendedHeaderCalled: func(header sovereignData.IncomingHeaderHandler) (data.ShardHeaderExtendedHandler, error) {
+			require.Equal(t, extendedHeader, header)
+			return extendedHeader, nil
+		},
+	}
+
+	sovHdrProc, _ := NewSovereignHdrInterceptorProcessor(args)
+	err := sovHdrProc.Validate(interceptedHdr, "")
+	require.Nil(t, err)
+	require.True(t, wasHashComputed)
+}

--- a/process/interceptors/processor/sovereignHdrInterceptorProcessor_test.go
+++ b/process/interceptors/processor/sovereignHdrInterceptorProcessor_test.go
@@ -219,7 +219,7 @@ func TestSovereignHeaderInterceptorProcessor_ValidateErrorCases(t *testing.T) {
 
 		sovHdrProc, _ := NewSovereignHdrInterceptorProcessor(args)
 		err := sovHdrProc.Validate(interceptedHdr, "")
-		require.ErrorIs(t, err, errors.ErrInvalidReceivedSovereignProof)
+		require.ErrorIs(t, err, errors.ErrInvalidReceivedExtendedShardHeader)
 		require.True(t, strings.Contains(err.Error(), fmt.Sprintf("computed hash: %s", hex.EncodeToString(extendedHdrHash))))
 		require.True(t, strings.Contains(err.Error(), fmt.Sprintf("received hash: %s", hex.EncodeToString(anotherHash))))
 	})

--- a/process/interface.go
+++ b/process/interface.go
@@ -1344,5 +1344,6 @@ type Debugger interface {
 // IncomingHeaderSubscriber defines a subscriber to incoming headers
 type IncomingHeaderSubscriber interface {
 	AddHeader(headerHash []byte, header sovereign.IncomingHeaderHandler) error
+	CreateExtendedHeader(header sovereign.IncomingHeaderHandler) (data.ShardHeaderExtendedHandler, error)
 	IsInterfaceNil() bool
 }

--- a/testscommon/sovereign/incomgHeaderSubscriberStub.go
+++ b/testscommon/sovereign/incomgHeaderSubscriberStub.go
@@ -1,9 +1,13 @@
 package sovereign
 
-import "github.com/multiversx/mx-chain-core-go/data/sovereign"
+import (
+	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/sovereign"
+)
 
 type IncomingHeaderSubscriberStub struct {
-	AddHeaderCalled func(headerHash []byte, header sovereign.IncomingHeaderHandler) error
+	AddHeaderCalled            func(headerHash []byte, header sovereign.IncomingHeaderHandler) error
+	CreateExtendedHeaderCalled func(header sovereign.IncomingHeaderHandler) (data.ShardHeaderExtendedHandler, error)
 }
 
 func (ihs *IncomingHeaderSubscriberStub) AddHeader(headerHash []byte, header sovereign.IncomingHeaderHandler) error {
@@ -12,6 +16,14 @@ func (ihs *IncomingHeaderSubscriberStub) AddHeader(headerHash []byte, header sov
 	}
 
 	return nil
+}
+
+func (ihs *IncomingHeaderSubscriberStub) CreateExtendedHeader(header sovereign.IncomingHeaderHandler) (data.ShardHeaderExtendedHandler, error) {
+	if ihs.CreateExtendedHeaderCalled != nil {
+		return ihs.CreateExtendedHeaderCalled(header)
+	}
+
+	return nil, nil
 }
 
 func (ihs *IncomingHeaderSubscriberStub) IsInterfaceNil() bool {

--- a/testscommon/sovereignInterceptedExtendedHeaderDataStub.go
+++ b/testscommon/sovereignInterceptedExtendedHeaderDataStub.go
@@ -2,12 +2,14 @@ package testscommon
 
 import "github.com/multiversx/mx-chain-core-go/data"
 
+// SovereignInterceptedExtendedHeaderDataStub -
 type SovereignInterceptedExtendedHeaderDataStub struct {
 	*InterceptedDataStub
 	HashCalled              func() []byte
 	GetExtendedHeaderCalled func() data.ShardHeaderExtendedHandler
 }
 
+// Hash -
 func (s *SovereignInterceptedExtendedHeaderDataStub) Hash() []byte {
 	if s.HashCalled != nil {
 		return s.HashCalled()
@@ -16,6 +18,7 @@ func (s *SovereignInterceptedExtendedHeaderDataStub) Hash() []byte {
 	return nil
 }
 
+// GetExtendedHeader -
 func (s *SovereignInterceptedExtendedHeaderDataStub) GetExtendedHeader() data.ShardHeaderExtendedHandler {
 	if s.GetExtendedHeaderCalled != nil {
 		return s.GetExtendedHeaderCalled()

--- a/testscommon/sovereignInterceptedExtendedHeaderDataStub.go
+++ b/testscommon/sovereignInterceptedExtendedHeaderDataStub.go
@@ -1,0 +1,25 @@
+package testscommon
+
+import "github.com/multiversx/mx-chain-core-go/data"
+
+type SovereignInterceptedExtendedHeaderDataStub struct {
+	*InterceptedDataStub
+	HashCalled              func() []byte
+	GetExtendedHeaderCalled func() data.ShardHeaderExtendedHandler
+}
+
+func (s *SovereignInterceptedExtendedHeaderDataStub) Hash() []byte {
+	if s.HashCalled != nil {
+		return s.HashCalled()
+	}
+
+	return nil
+}
+
+func (s *SovereignInterceptedExtendedHeaderDataStub) GetExtendedHeader() data.ShardHeaderExtendedHandler {
+	if s.GetExtendedHeaderCalled != nil {
+		return s.GetExtendedHeaderCalled()
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Reasoning behind the pull request
- Verify intercepted received extended header and save it
  
## Proposed changes
- In order to verify the received extended header, we use the incoming header processor. This will create incoming scrs + miniblocks from the received header + incoming events. If the hash of received data matches the computed one, then the proof is valid.
- Save will add incoming header once.

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
