### PR TITLE
State changes collector

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -684,6 +684,7 @@
     PeerStatePruningEnabled = true
     MaxStateTrieLevelInMemory = 5
     MaxPeerTrieLevelInMemory = 5
+    CollectStateChangesEnabled = false
 
 [BlockSizeThrottleConfig]
     MinSizeInBytes = 104857 # 104857 is 10% from 1MB

--- a/config/config.go
+++ b/config/config.go
@@ -297,6 +297,7 @@ type StateTriesConfig struct {
 	SnapshotsEnabled            bool
 	AccountsStatePruningEnabled bool
 	PeerStatePruningEnabled     bool
+	CollectStateChangesEnabled  bool
 	MaxStateTrieLevelInMemory   uint
 	MaxPeerTrieLevelInMemory    uint
 }

--- a/epochStart/bootstrap/disabled/disabledAccountsAdapter.go
+++ b/epochStart/bootstrap/disabled/disabledAccountsAdapter.go
@@ -137,6 +137,11 @@ func (a *accountsAdapter) GetStackDebugFirstEntry() []byte {
 	return nil
 }
 
+// GetStateChangesForTheLatestTransaction -
+func (a *accountsAdapter) GetStateChangesForTheLatestTransaction() ([]state.StateChangeDTO, error) {
+	return nil, nil
+}
+
 // Close -
 func (a *accountsAdapter) Close() error {
 	return nil

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -903,6 +903,7 @@ func createAccountsDB(
 		ProcessStatusHandler:  &testscommon.ProcessStatusHandlerStub{},
 		AppStatusHandler:      &statusHandlerMock.AppStatusHandlerStub{},
 		AddressConverter:      &testscommon.PubkeyConverterMock{},
+		StateChangesCollector: state.NewStateChangesCollector(),
 	}
 	adb, _ := state.NewAccountsDB(args)
 	return adb

--- a/factory/api/apiResolverFactory.go
+++ b/factory/api/apiResolverFactory.go
@@ -37,6 +37,7 @@ import (
 	"github.com/multiversx/mx-chain-go/sharding"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/state/blockInfoProviders"
+	stateDisabled "github.com/multiversx/mx-chain-go/state/disabled"
 	factoryState "github.com/multiversx/mx-chain-go/state/factory"
 	"github.com/multiversx/mx-chain-go/state/storagePruningManager"
 	"github.com/multiversx/mx-chain-go/state/storagePruningManager/evictionWaitingList"
@@ -607,6 +608,7 @@ func createNewAccountsAdapterApi(args *scQueryElementArgs, chainHandler data.Cha
 		ProcessStatusHandler:  args.coreComponents.ProcessStatusHandler(),
 		AppStatusHandler:      args.statusCoreComponents.AppStatusHandler(),
 		AddressConverter:      args.coreComponents.AddressPubKeyConverter(),
+		StateChangesCollector: stateDisabled.NewDisabledStateChangesCollector(),
 	}
 
 	provider, err := blockInfoProviders.NewCurrentBlockInfo(chainHandler)

--- a/factory/processing/blockProcessorCreator_test.go
+++ b/factory/processing/blockProcessorCreator_test.go
@@ -208,6 +208,7 @@ func createAccountAdapter(
 		ProcessStatusHandler:  &testscommon.ProcessStatusHandlerStub{},
 		AppStatusHandler:      &statusHandler.AppStatusHandlerStub{},
 		AddressConverter:      &testscommon.PubkeyConverterMock{},
+		StateChangesCollector: state.NewStateChangesCollector(),
 	}
 	adb, err := state.NewAccountsDB(args)
 	if err != nil {

--- a/factory/state/stateComponents.go
+++ b/factory/state/stateComponents.go
@@ -11,6 +11,7 @@ import (
 	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/factory"
 	"github.com/multiversx/mx-chain-go/state"
+	"github.com/multiversx/mx-chain-go/state/disabled"
 	factoryState "github.com/multiversx/mx-chain-go/state/factory"
 	"github.com/multiversx/mx-chain-go/state/storagePruningManager"
 	"github.com/multiversx/mx-chain-go/state/storagePruningManager/evictionWaitingList"
@@ -135,6 +136,7 @@ func (scf *stateComponentsFactory) createAccountsAdapters(triesContainer common.
 		ProcessStatusHandler:     scf.core.ProcessStatusHandler(),
 		AppStatusHandler:         scf.statusCore.AppStatusHandler(),
 		AddressConverter:         scf.core.AddressPubKeyConverter(),
+		StateChangesCollector:    state.NewStateChangesCollector(),
 	}
 	accountsAdapter, err := state.NewAccountsDB(argsProcessingAccountsDB)
 	if err != nil {
@@ -151,6 +153,7 @@ func (scf *stateComponentsFactory) createAccountsAdapters(triesContainer common.
 		ProcessStatusHandler:  scf.core.ProcessStatusHandler(),
 		AppStatusHandler:      scf.statusCore.AppStatusHandler(),
 		AddressConverter:      scf.core.AddressPubKeyConverter(),
+		StateChangesCollector: disabled.NewDisabledStateChangesCollector(),
 	}
 
 	accountsAdapterApiOnFinal, err := factoryState.CreateAccountsAdapterAPIOnFinal(argsAPIAccountsDB, scf.chainHandler)
@@ -201,6 +204,7 @@ func (scf *stateComponentsFactory) createPeerAdapter(triesContainer common.Tries
 		ProcessStatusHandler:     scf.core.ProcessStatusHandler(),
 		AppStatusHandler:         scf.statusCore.AppStatusHandler(),
 		AddressConverter:         scf.core.AddressPubKeyConverter(),
+		StateChangesCollector:    state.NewStateChangesCollector(),
 	}
 	peerAdapter, err := state.NewPeerAccountsDB(argsProcessingPeerAccountsDB)
 	if err != nil {

--- a/factory/state/stateComponents.go
+++ b/factory/state/stateComponents.go
@@ -125,6 +125,11 @@ func (scf *stateComponentsFactory) createAccountsAdapters(triesContainer common.
 		return nil, nil, nil, err
 	}
 
+	stateChangesCollector := disabled.NewDisabledStateChangesCollector()
+	if scf.config.StateTriesConfig.CollectStateChangesEnabled {
+		stateChangesCollector = state.NewStateChangesCollector()
+	}
+
 	argsProcessingAccountsDB := state.ArgsAccountsDB{
 		Trie:                     merkleTrie,
 		Hasher:                   scf.core.Hasher(),
@@ -136,7 +141,7 @@ func (scf *stateComponentsFactory) createAccountsAdapters(triesContainer common.
 		ProcessStatusHandler:     scf.core.ProcessStatusHandler(),
 		AppStatusHandler:         scf.statusCore.AppStatusHandler(),
 		AddressConverter:         scf.core.AddressPubKeyConverter(),
-		StateChangesCollector:    state.NewStateChangesCollector(),
+		StateChangesCollector:    stateChangesCollector,
 	}
 	accountsAdapter, err := state.NewAccountsDB(argsProcessingAccountsDB)
 	if err != nil {
@@ -193,6 +198,11 @@ func (scf *stateComponentsFactory) createPeerAdapter(triesContainer common.Tries
 		return nil, err
 	}
 
+	stateChangesCollector := disabled.NewDisabledStateChangesCollector()
+	if scf.config.StateTriesConfig.CollectStateChangesEnabled {
+		stateChangesCollector = state.NewStateChangesCollector()
+	}
+
 	argsProcessingPeerAccountsDB := state.ArgsAccountsDB{
 		Trie:                     merkleTrie,
 		Hasher:                   scf.core.Hasher(),
@@ -204,7 +214,7 @@ func (scf *stateComponentsFactory) createPeerAdapter(triesContainer common.Tries
 		ProcessStatusHandler:     scf.core.ProcessStatusHandler(),
 		AppStatusHandler:         scf.statusCore.AppStatusHandler(),
 		AddressConverter:         scf.core.AddressPubKeyConverter(),
-		StateChangesCollector:    state.NewStateChangesCollector(),
+		StateChangesCollector:    stateChangesCollector,
 	}
 	peerAdapter, err := state.NewPeerAccountsDB(argsProcessingPeerAccountsDB)
 	if err != nil {

--- a/genesis/mock/userAccountMock.go
+++ b/genesis/mock/userAccountMock.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/state"
 )
 
 // ErrNegativeValue -
@@ -147,8 +148,8 @@ func (uam *UserAccountMock) GetUserName() []byte {
 }
 
 // SaveDirtyData -
-func (uam *UserAccountMock) SaveDirtyData(_ common.Trie) ([]core.TrieData, error) {
-	return nil, nil
+func (uam *UserAccountMock) SaveDirtyData(_ common.Trie) ([]state.DataTrieChange, []core.TrieData, error) {
+	return nil, nil, nil
 }
 
 // IsGuarded -

--- a/genesis/process/memoryComponents.go
+++ b/genesis/process/memoryComponents.go
@@ -36,6 +36,7 @@ func createAccountAdapter(
 		ProcessStatusHandler:  commonDisabled.NewProcessStatusHandler(),
 		AppStatusHandler:      commonDisabled.NewAppStatusHandler(),
 		AddressConverter:      addressConverter,
+		StateChangesCollector: state.NewStateChangesCollector(),
 	}
 
 	adb, err := state.NewAccountsDB(args)

--- a/integrationTests/state/stateTrie/stateTrie_test.go
+++ b/integrationTests/state/stateTrie/stateTrie_test.go
@@ -1066,6 +1066,7 @@ func createAccounts(
 		ProcessStatusHandler:  &testscommon.ProcessStatusHandlerStub{},
 		AppStatusHandler:      &statusHandler.AppStatusHandlerStub{},
 		AddressConverter:      &testscommon.PubkeyConverterMock{},
+		StateChangesCollector: state.NewStateChangesCollector(),
 	}
 	adb, _ := state.NewAccountsDB(argsAccountsDB)
 
@@ -2530,6 +2531,7 @@ func createAccountsDBTestSetup() *state.AccountsDB {
 		ProcessStatusHandler:  &testscommon.ProcessStatusHandlerStub{},
 		AppStatusHandler:      &statusHandler.AppStatusHandlerStub{},
 		AddressConverter:      &testscommon.PubkeyConverterMock{},
+		StateChangesCollector: state.NewStateChangesCollector(),
 	}
 	adb, _ := state.NewAccountsDB(argsAccountsDB)
 

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -473,6 +473,7 @@ func CreateAccountsDBWithEnableEpochsHandler(
 		ProcessStatusHandler:  &testscommon.ProcessStatusHandlerStub{},
 		AppStatusHandler:      &statusHandler.AppStatusHandlerStub{},
 		AddressConverter:      &testscommon.PubkeyConverterMock{},
+		StateChangesCollector: state.NewStateChangesCollector(),
 	}
 	adb, _ := state.NewAccountsDB(args)
 

--- a/process/transaction/metaProcess.go
+++ b/process/transaction/metaProcess.go
@@ -132,6 +132,14 @@ func (txProc *metaTxProcessor) ProcessTransaction(tx *transaction.Transaction) (
 
 	txType, _ := txProc.txTypeHandler.ComputeTransactionType(tx)
 
+	defer func() {
+		// TODO collect state changes from each transactions here
+		_, err = txProc.accounts.GetStateChangesForTheLatestTransaction()
+		if err != nil {
+			log.Error("GetStateChangesForTheLatestTransaction error", "err", err.Error())
+		}
+	}()
+
 	switch txType {
 	case process.SCDeployment:
 		return txProc.processSCDeployment(tx, tx.SndAddr)

--- a/process/transaction/shardProcess.go
+++ b/process/transaction/shardProcess.go
@@ -211,6 +211,14 @@ func (txProc *txProcessor) ProcessTransaction(tx *transaction.Transaction) (vmco
 		return vmcommon.UserError, err
 	}
 
+	defer func() {
+		// TODO collect state changes from each transactions here
+		_, err = txProc.accounts.GetStateChangesForTheLatestTransaction()
+		if err != nil {
+			log.Error("GetStateChangesForTheLatestTransaction error", "err", err.Error())
+		}
+	}()
+
 	switch txType {
 	case process.MoveBalance:
 		err = txProc.processMoveBalance(tx, acntSnd, acntDst, dstShardTxType, nil, false)

--- a/process/transactionEvaluator/simulationAccountsDB.go
+++ b/process/transactionEvaluator/simulationAccountsDB.go
@@ -176,6 +176,11 @@ func (r *simulationAccountsDB) GetStackDebugFirstEntry() []byte {
 	return nil
 }
 
+// GetStateChangesForTheLatestTransaction -
+func (r *simulationAccountsDB) GetStateChangesForTheLatestTransaction() ([]state.StateChangeDTO, error) {
+	return r.originalAccounts.GetStateChangesForTheLatestTransaction()
+}
+
 // Close will handle the closing of the underlying components
 func (r *simulationAccountsDB) Close() error {
 	return nil

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -881,6 +881,12 @@ func (adb *AccountsDB) commit() ([]byte, error) {
 	log.Trace("accountsDB.Commit started")
 	adb.entries = make([]JournalEntry, 0)
 
+	stateChanges := adb.stateChangesCollector.GetStateChanges()
+	if len(stateChanges) != 0 {
+		log.Warn("state changes collector is not empty", "state changes", stateChanges)
+		adb.stateChangesCollector.Reset()
+	}
+
 	oldHashes := make(common.ModifiedHashes)
 	newHashes := make(common.ModifiedHashes)
 	// Step 1. commit all data tries
@@ -1267,6 +1273,7 @@ func collectStats(
 	log.Debug(strings.Join(trieStats.ToString(), " "))
 }
 
+// GetStateChangesForTheLatestTransaction will return the state changes since the last call of this method
 func (adb *AccountsDB) GetStateChangesForTheLatestTransaction() ([]StateChangeDTO, error) {
 	stateChanges := adb.stateChangesCollector.GetStateChanges()
 	adb.stateChangesCollector.Reset()

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -110,6 +110,7 @@ type ArgsAccountsDB struct {
 	ProcessStatusHandler     common.ProcessStatusHandler
 	AppStatusHandler         core.AppStatusHandler
 	AddressConverter         core.PubkeyConverter
+	StateChangesCollector    StateChangesCollector
 }
 
 // NewAccountsDB creates a new account manager
@@ -163,7 +164,7 @@ func createAccountsDb(args ArgsAccountsDB, snapshotManager SnapshotsManager) *Ac
 		},
 		addressConverter:      args.AddressConverter,
 		snapshotsManger:       snapshotManager,
-		stateChangesCollector: NewStateChangesCollector(),
+		stateChangesCollector: args.StateChangesCollector,
 	}
 }
 
@@ -185,6 +186,9 @@ func checkArgsAccountsDB(args ArgsAccountsDB) error {
 	}
 	if check.IfNil(args.AddressConverter) {
 		return ErrNilAddressConverter
+	}
+	if check.IfNil(args.StateChangesCollector) {
+		return ErrNilStateChangesCollector
 	}
 
 	return nil

--- a/state/accountsDBApi.go
+++ b/state/accountsDBApi.go
@@ -221,6 +221,11 @@ func (accountsDB *accountsDBApi) GetStackDebugFirstEntry() []byte {
 	return accountsDB.innerAccountsAdapter.GetStackDebugFirstEntry()
 }
 
+// GetStateChangesForTheLatestTransaction will call the inner accountsAdapter method
+func (accountsDB *accountsDBApi) GetStateChangesForTheLatestTransaction() ([]StateChangeDTO, error) {
+	return accountsDB.innerAccountsAdapter.GetStateChangesForTheLatestTransaction()
+}
+
 // Close will handle the closing of the underlying components
 func (accountsDB *accountsDBApi) Close() error {
 	return accountsDB.innerAccountsAdapter.Close()

--- a/state/accountsDBApiWithHistory.go
+++ b/state/accountsDBApiWithHistory.go
@@ -144,6 +144,11 @@ func (accountsDB *accountsDBApiWithHistory) GetStackDebugFirstEntry() []byte {
 	return nil
 }
 
+// GetStateChangesForTheLatestTransaction returns nil
+func (accountsDB *accountsDBApiWithHistory) GetStateChangesForTheLatestTransaction() ([]StateChangeDTO, error) {
+	return nil, nil
+}
+
 // Close will handle the closing of the underlying components
 func (accountsDB *accountsDBApiWithHistory) Close() error {
 	return accountsDB.innerAccountsAdapter.Close()

--- a/state/accountsDB_test.go
+++ b/state/accountsDB_test.go
@@ -342,14 +342,16 @@ func TestAccountsDB_SaveAccountSavesCodeAndDataTrieForUserAccount(t *testing.T) 
 	})
 
 	dtt := &trieMock.DataTrieTrackerStub{
-		SaveDirtyDataCalled: func(_ common.Trie) ([]core.TrieData, error) {
-			return []core.TrieData{
+		SaveDirtyDataCalled: func(_ common.Trie) ([]state.DataTrieChange, []core.TrieData, error) {
+			var stateChanges []state.DataTrieChange
+			oldVal := []core.TrieData{
 				{
 					Key:     []byte("key"),
 					Value:   []byte("value"),
 					Version: 0,
 				},
-			}, nil
+			}
+			return stateChanges, oldVal, nil
 		},
 		DataTrieCalled: func() common.Trie {
 			return trieStub

--- a/state/accountsDB_test.go
+++ b/state/accountsDB_test.go
@@ -68,6 +68,7 @@ func createMockAccountsDBArgs() state.ArgsAccountsDB {
 		ProcessStatusHandler:  &testscommon.ProcessStatusHandlerStub{},
 		AppStatusHandler:      &statusHandler.AppStatusHandlerStub{},
 		AddressConverter:      &testscommon.PubkeyConverterMock{},
+		StateChangesCollector: state.NewStateChangesCollector(),
 	}
 }
 
@@ -155,6 +156,7 @@ func getDefaultStateComponents(
 		ProcessStatusHandler:  &testscommon.ProcessStatusHandlerStub{},
 		AppStatusHandler:      &statusHandler.AppStatusHandlerStub{},
 		AddressConverter:      &testscommon.PubkeyConverterMock{},
+		StateChangesCollector: state.NewStateChangesCollector(),
 	}
 	adb, _ := state.NewAccountsDB(argsAccountsDB)
 

--- a/state/disabled/disabledStateChangesCollector.go
+++ b/state/disabled/disabledStateChangesCollector.go
@@ -1,0 +1,34 @@
+package disabled
+
+import (
+	"github.com/multiversx/mx-chain-go/state"
+)
+
+// DisabledStateChangesCollector is a state changes collector that does nothing
+type DisabledStateChangesCollector struct {
+}
+
+// NewDisabledStateChangesCollector creates a new DisabledStateChangesCollector
+func NewDisabledStateChangesCollector() *DisabledStateChangesCollector {
+	return &DisabledStateChangesCollector{}
+}
+
+// AddStateChange does nothing
+func (d *DisabledStateChangesCollector) AddStateChange(_ state.StateChangeDTO) {
+
+}
+
+// GetStateChanges returns an empty slice
+func (d *DisabledStateChangesCollector) GetStateChanges() []state.StateChangeDTO {
+	return []state.StateChangeDTO{}
+}
+
+// Reset does nothing
+func (d *DisabledStateChangesCollector) Reset() {
+
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (d *DisabledStateChangesCollector) IsInterfaceNil() bool {
+	return d == nil
+}

--- a/state/disabled/disabledStateChangesCollector.go
+++ b/state/disabled/disabledStateChangesCollector.go
@@ -9,7 +9,7 @@ type DisabledStateChangesCollector struct {
 }
 
 // NewDisabledStateChangesCollector creates a new DisabledStateChangesCollector
-func NewDisabledStateChangesCollector() *DisabledStateChangesCollector {
+func NewDisabledStateChangesCollector() state.StateChangesCollector {
 	return &DisabledStateChangesCollector{}
 }
 

--- a/state/errors.go
+++ b/state/errors.go
@@ -144,3 +144,6 @@ var ErrNilStateMetrics = errors.New("nil sstate metrics")
 
 // ErrNilChannelsProvider signals that a nil channels provider has been given
 var ErrNilChannelsProvider = errors.New("nil channels provider")
+
+// ErrNilStateChangesCollector signals that a nil state changes collector has been given
+var ErrNilStateChangesCollector = errors.New("nil state changes collector")

--- a/state/factory/accountsAdapterAPICreator_test.go
+++ b/state/factory/accountsAdapterAPICreator_test.go
@@ -31,6 +31,7 @@ func createMockAccountsArgs() state.ArgsAccountsDB {
 		ProcessStatusHandler:  &testscommon.ProcessStatusHandlerStub{},
 		AppStatusHandler:      &statusHandler.AppStatusHandlerStub{},
 		AddressConverter:      &testscommon.PubkeyConverterMock{},
+		StateChangesCollector: state.NewStateChangesCollector(),
 	}
 }
 

--- a/state/interface.go
+++ b/state/interface.go
@@ -120,7 +120,7 @@ type baseAccountHandler interface {
 	GetRootHash() []byte
 	SetDataTrie(trie common.Trie)
 	DataTrie() common.DataTrieHandler
-	SaveDirtyData(trie common.Trie) ([]core.TrieData, error)
+	SaveDirtyData(trie common.Trie) ([]DataTrieChange, []core.TrieData, error)
 	IsInterfaceNil() bool
 }
 
@@ -183,7 +183,8 @@ type DataTrie interface {
 }
 
 // PeerAccountHandler models a peer state account, which can journalize a normal account's data
-//  with some extra features like signing statistics or rating information
+//
+//	with some extra features like signing statistics or rating information
 type PeerAccountHandler interface {
 	SetBLSPublicKey([]byte) error
 	GetRewardAddress() []byte
@@ -255,7 +256,7 @@ type DataTrieTracker interface {
 	SaveKeyValue(key []byte, value []byte) error
 	SetDataTrie(tr common.Trie)
 	DataTrie() common.DataTrieHandler
-	SaveDirtyData(common.Trie) ([]core.TrieData, error)
+	SaveDirtyData(common.Trie) ([]DataTrieChange, []core.TrieData, error)
 	MigrateDataTrieLeaves(args vmcommon.ArgsMigrateDataTrieLeaves) error
 	IsInterfaceNil() bool
 }
@@ -264,4 +265,11 @@ type DataTrieTracker interface {
 type SignRate interface {
 	GetNumSuccess() uint32
 	GetNumFailure() uint32
+}
+
+type StateChangesCollector interface {
+	AddStateChange(stateChange StateChangeDTO)
+	GetStateChanges() []StateChangeDTO
+	Reset()
+	IsInterfaceNil() bool
 }

--- a/state/interface.go
+++ b/state/interface.go
@@ -50,6 +50,7 @@ type AccountsAdapter interface {
 	GetStackDebugFirstEntry() []byte
 	SetSyncer(syncer AccountsDBSyncer) error
 	StartSnapshotIfNeeded() error
+	GetStateChangesForTheLatestTransaction() ([]StateChangeDTO, error)
 	Close() error
 	IsInterfaceNil() bool
 }

--- a/state/journalEntries.go
+++ b/state/journalEntries.go
@@ -66,7 +66,7 @@ func (jea *journalEntryCode) revertOldCodeEntry() error {
 		return nil
 	}
 
-	err := saveCodeEntry(jea.oldCodeHash, jea.oldCodeEntry, jea.trie, jea.marshalizer)
+	_, err := saveCodeEntry(jea.oldCodeHash, jea.oldCodeEntry, jea.trie, jea.marshalizer)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func (jea *journalEntryCode) revertNewCodeEntry() error {
 	}
 
 	newCodeEntry.NumReferences--
-	err = saveCodeEntry(jea.newCodeHash, newCodeEntry, jea.trie, jea.marshalizer)
+	_, err = saveCodeEntry(jea.newCodeHash, newCodeEntry, jea.trie, jea.marshalizer)
 	if err != nil {
 		return err
 	}

--- a/state/stateChangesCollector.go
+++ b/state/stateChangesCollector.go
@@ -1,0 +1,38 @@
+package state
+
+type StateChangeDTO struct {
+	MainTrieKey     []byte
+	MainTrieVal     []byte
+	DataTrieChanges []DataTrieChange
+}
+
+type DataTrieChange struct {
+	Key []byte
+	Val []byte
+}
+
+type stateChangesCollector struct {
+	stateChanges []StateChangeDTO
+}
+
+func NewStateChangesCollector() *stateChangesCollector {
+	return &stateChangesCollector{
+		stateChanges: []StateChangeDTO{},
+	}
+}
+
+func (scc *stateChangesCollector) AddStateChange(stateChange StateChangeDTO) {
+	scc.stateChanges = append(scc.stateChanges, stateChange)
+}
+
+func (scc *stateChangesCollector) GetStateChanges() []StateChangeDTO {
+	return scc.stateChanges
+}
+
+func (scc *stateChangesCollector) Reset() {
+	scc.stateChanges = []StateChangeDTO{}
+}
+
+func (scc *stateChangesCollector) IsInterfaceNil() bool {
+	return scc == nil
+}

--- a/state/stateChangesCollector.go
+++ b/state/stateChangesCollector.go
@@ -1,11 +1,13 @@
 package state
 
+// StateChangeDTO is used to collect state changes
 type StateChangeDTO struct {
 	MainTrieKey     []byte
 	MainTrieVal     []byte
 	DataTrieChanges []DataTrieChange
 }
 
+// DataTrieChange represents a change in the data trie
 type DataTrieChange struct {
 	Key []byte
 	Val []byte
@@ -15,24 +17,29 @@ type stateChangesCollector struct {
 	stateChanges []StateChangeDTO
 }
 
+// NewStateChangesCollector creates a new StateChangesCollector
 func NewStateChangesCollector() *stateChangesCollector {
 	return &stateChangesCollector{
 		stateChanges: []StateChangeDTO{},
 	}
 }
 
+// AddStateChange adds a new state change to the collector
 func (scc *stateChangesCollector) AddStateChange(stateChange StateChangeDTO) {
 	scc.stateChanges = append(scc.stateChanges, stateChange)
 }
 
+// GetStateChanges returns the accumulated state changes
 func (scc *stateChangesCollector) GetStateChanges() []StateChangeDTO {
 	return scc.stateChanges
 }
 
+// Reset resets the state changes collector
 func (scc *stateChangesCollector) Reset() {
 	scc.stateChanges = []StateChangeDTO{}
 }
 
+// IsInterfaceNil returns true if there is no value under the interface
 func (scc *stateChangesCollector) IsInterfaceNil() bool {
 	return scc == nil
 }

--- a/state/stateChangesCollector_test.go
+++ b/state/stateChangesCollector_test.go
@@ -1,0 +1,68 @@
+package state
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStateChangesCollector(t *testing.T) {
+	t.Parallel()
+
+	stateChangesCollector := NewStateChangesCollector()
+	require.False(t, stateChangesCollector.IsInterfaceNil())
+}
+
+func TestStateChangesCollector_AddStateChange(t *testing.T) {
+	t.Parallel()
+
+	scc := NewStateChangesCollector()
+	assert.Equal(t, 0, len(scc.stateChanges))
+
+	numStateChanges := 10
+	for i := 0; i < numStateChanges; i++ {
+		scc.AddStateChange(StateChangeDTO{})
+	}
+	assert.Equal(t, numStateChanges, len(scc.stateChanges))
+}
+
+func TestStateChangesCollector_GetStateChanges(t *testing.T) {
+	t.Parallel()
+
+	scc := NewStateChangesCollector()
+	assert.Equal(t, 0, len(scc.stateChanges))
+
+	numStateChanges := 10
+	for i := 0; i < numStateChanges; i++ {
+		scc.AddStateChange(StateChangeDTO{
+			MainTrieKey: []byte(strconv.Itoa(i)),
+		})
+	}
+	assert.Equal(t, numStateChanges, len(scc.stateChanges))
+
+	stateChanges := scc.GetStateChanges()
+	assert.Equal(t, numStateChanges, len(stateChanges))
+	for i := 0; i < numStateChanges; i++ {
+		assert.Equal(t, []byte(strconv.Itoa(i)), stateChanges[i].MainTrieKey)
+	}
+}
+
+func TestStateChangesCollector_Reset(t *testing.T) {
+	t.Parallel()
+
+	scc := NewStateChangesCollector()
+	assert.Equal(t, 0, len(scc.stateChanges))
+
+	numStateChanges := 10
+	for i := 0; i < numStateChanges; i++ {
+		scc.AddStateChange(StateChangeDTO{})
+	}
+	assert.Equal(t, numStateChanges, len(scc.stateChanges))
+	stateChanges := scc.GetStateChanges()
+
+	scc.Reset()
+	assert.Equal(t, 0, len(scc.stateChanges))
+	assert.Equal(t, numStateChanges, len(stateChanges))
+}

--- a/state/storagePruningManager/storagePruningManager_test.go
+++ b/state/storagePruningManager/storagePruningManager_test.go
@@ -54,6 +54,7 @@ func getDefaultTrieAndAccountsDbAndStoragePruningManager() (common.Trie, *state.
 		ProcessStatusHandler:  &testscommon.ProcessStatusHandlerStub{},
 		AppStatusHandler:      &statusHandler.AppStatusHandlerStub{},
 		AddressConverter:      &testscommon.PubkeyConverterMock{},
+		StateChangesCollector: state.NewStateChangesCollector(),
 	}
 	adb, _ := state.NewAccountsDB(argsAccountsDB)
 

--- a/state/trackableDataTrie/export_test.go
+++ b/state/trackableDataTrie/export_test.go
@@ -21,3 +21,9 @@ func (tdt *trackableDataTrie) DirtyData() map[string]DirtyData {
 
 	return dd
 }
+
+// GetValueForVersion -
+func (tdt *trackableDataTrie) GetValueForVersion(key []byte, val []byte, version core.TrieNodeVersion) []byte {
+	valWithMetadata, _ := tdt.getValueForVersion(key, val, version)
+	return valWithMetadata
+}

--- a/state/trackableDataTrie/trackableDataTrie.go
+++ b/state/trackableDataTrie/trackableDataTrie.go
@@ -234,7 +234,7 @@ func (tdt *trackableDataTrie) SaveDirtyData(mainTrie common.Trie) ([]state.DataT
 
 func (tdt *trackableDataTrie) updateTrie(dtr state.DataTrie) ([]state.DataTrieChange, []core.TrieData, error) {
 	oldValues := make([]core.TrieData, len(tdt.dirtyData))
-	stateChanges := make([]state.DataTrieChange, len(tdt.dirtyData))
+	newData := make([]state.DataTrieChange, len(tdt.dirtyData))
 	deletedKeys := make([]state.DataTrieChange, 0)
 
 	index := 0
@@ -270,11 +270,11 @@ func (tdt *trackableDataTrie) updateTrie(dtr state.DataTrie) ([]state.DataTrieCh
 			continue
 		}
 
-		if dataEntry.index > len(stateChanges)-1 {
+		if dataEntry.index > len(newData)-1 {
 			return nil, nil, fmt.Errorf("index out of range")
 		}
 
-		stateChanges[dataEntry.index] = state.DataTrieChange{
+		newData[dataEntry.index] = state.DataTrieChange{
 			Key: dataTrieKey,
 			Val: dataTrieVal,
 		}
@@ -282,12 +282,13 @@ func (tdt *trackableDataTrie) updateTrie(dtr state.DataTrie) ([]state.DataTrieCh
 
 	tdt.dirtyData = make(map[string]dirtyData)
 
-	for i := range stateChanges {
-		if len(stateChanges[i].Key) != 0 {
+	stateChanges := make([]state.DataTrieChange, 0)
+	for i := range newData {
+		if len(newData[i].Key) == 0 {
 			continue
 		}
 
-		stateChanges = append(stateChanges[:i], stateChanges[i+1:]...)
+		stateChanges = append(stateChanges, newData[i])
 	}
 
 	sort.Slice(deletedKeys, func(i, j int) bool {

--- a/state/trackableDataTrie/trackableDataTrie.go
+++ b/state/trackableDataTrie/trackableDataTrie.go
@@ -1,7 +1,9 @@
 package trackableDataTrie
 
 import (
+	"bytes"
 	"fmt"
+	"sort"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
@@ -19,6 +21,7 @@ import (
 var log = logger.GetOrCreate("state/trackableDataTrie")
 
 type dirtyData struct {
+	index      int
 	value      []byte
 	newVersion core.TrieNodeVersion
 }
@@ -97,6 +100,7 @@ func (tdt *trackableDataTrie) SaveKeyValue(key []byte, value []byte) error {
 	}
 
 	dataEntry := dirtyData{
+		index:      tdt.getIndexForKey(key),
 		value:      value,
 		newVersion: core.GetVersionForNewData(tdt.enableEpochsHandler),
 	}
@@ -126,20 +130,30 @@ func (tdt *trackableDataTrie) MigrateDataTrieLeaves(args vmcommon.ArgsMigrateDat
 
 	dataToBeMigrated := args.TrieMigrator.GetLeavesToBeMigrated()
 	for _, leafData := range dataToBeMigrated {
-		dataEntry := dirtyData{
-			value:      leafData.Value,
-			newVersion: args.NewVersion,
-		}
-
 		originalKey, err := tdt.getOriginalKeyFromTrieData(leafData)
 		if err != nil {
 			return err
+		}
+
+		dataEntry := dirtyData{
+			index:      tdt.getIndexForKey(originalKey),
+			value:      leafData.Value,
+			newVersion: args.NewVersion,
 		}
 
 		tdt.dirtyData[string(originalKey)] = dataEntry
 	}
 
 	return nil
+}
+
+func (tdt *trackableDataTrie) getIndexForKey(key []byte) int {
+	existingVal, ok := tdt.dirtyData[string(key)]
+	if ok {
+		return existingVal.index
+	}
+
+	return len(tdt.dirtyData)
 }
 
 func (tdt *trackableDataTrie) getOriginalKeyFromTrieData(trieData core.TrieData) ([]byte, error) {
@@ -196,15 +210,15 @@ func (tdt *trackableDataTrie) DataTrie() common.DataTrieHandler {
 }
 
 // SaveDirtyData saved the dirty data to the trie
-func (tdt *trackableDataTrie) SaveDirtyData(mainTrie common.Trie) ([]core.TrieData, error) {
+func (tdt *trackableDataTrie) SaveDirtyData(mainTrie common.Trie) ([]state.DataTrieChange, []core.TrieData, error) {
 	if len(tdt.dirtyData) == 0 {
-		return make([]core.TrieData, 0), nil
+		return make([]state.DataTrieChange, 0), make([]core.TrieData, 0), nil
 	}
 
 	if check.IfNil(tdt.tr) {
 		newDataTrie, err := mainTrie.Recreate(make([]byte, 0))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		tdt.tr = newDataTrie
@@ -212,39 +226,76 @@ func (tdt *trackableDataTrie) SaveDirtyData(mainTrie common.Trie) ([]core.TrieDa
 
 	dtr, ok := tdt.tr.(state.DataTrie)
 	if !ok {
-		return nil, fmt.Errorf("invalid trie, type is %T", tdt.tr)
+		return nil, nil, fmt.Errorf("invalid trie, type is %T", tdt.tr)
 	}
 
 	return tdt.updateTrie(dtr)
 }
 
-func (tdt *trackableDataTrie) updateTrie(dtr state.DataTrie) ([]core.TrieData, error) {
+func (tdt *trackableDataTrie) updateTrie(dtr state.DataTrie) ([]state.DataTrieChange, []core.TrieData, error) {
 	oldValues := make([]core.TrieData, len(tdt.dirtyData))
+	stateChanges := make([]state.DataTrieChange, len(tdt.dirtyData))
+	deletedKeys := make([]state.DataTrieChange, 0)
 
 	index := 0
 	for key, dataEntry := range tdt.dirtyData {
 		oldVal, _, err := tdt.retrieveValueFromTrie([]byte(key))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		oldValues[index] = oldVal
 
-		err = tdt.deleteOldEntryIfMigrated([]byte(key), dataEntry, oldVal)
+		wasDeleted, err := tdt.deleteOldEntryIfMigrated([]byte(key), dataEntry, oldVal)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
-		err = tdt.modifyTrie([]byte(key), dataEntry, oldVal, dtr)
+		if wasDeleted {
+			deletedKeys = append(deletedKeys,
+				state.DataTrieChange{
+					Key: []byte(key),
+					Val: nil,
+				},
+			)
+		}
+
+		dataTrieKey, dataTrieVal, err := tdt.modifyTrie([]byte(key), dataEntry, oldVal, dtr)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		index++
+
+		if len(dataTrieKey) == 0 {
+			continue
+		}
+
+		if dataEntry.index > len(stateChanges)-1 {
+			return nil, nil, fmt.Errorf("index out of range")
+		}
+
+		stateChanges[dataEntry.index] = state.DataTrieChange{
+			Key: dataTrieKey,
+			Val: dataTrieVal,
+		}
 	}
 
 	tdt.dirtyData = make(map[string]dirtyData)
 
-	return oldValues, nil
+	for i := range stateChanges {
+		if len(stateChanges[i].Key) != 0 {
+			continue
+		}
+
+		stateChanges = append(stateChanges[:i], stateChanges[i+1:]...)
+	}
+
+	sort.Slice(deletedKeys, func(i, j int) bool {
+		return bytes.Compare(deletedKeys[i].Key, deletedKeys[j].Key) < 0
+	})
+	stateChanges = append(stateChanges, deletedKeys...)
+
+	return stateChanges, oldValues, nil
 }
 
 func (tdt *trackableDataTrie) retrieveValueFromTrie(key []byte) (core.TrieData, uint32, error) {
@@ -320,48 +371,60 @@ func (tdt *trackableDataTrie) getValueNotSpecifiedVersion(key []byte, val []byte
 	return trimmedValue, nil
 }
 
-func (tdt *trackableDataTrie) deleteOldEntryIfMigrated(key []byte, newData dirtyData, oldEntry core.TrieData) error {
+func (tdt *trackableDataTrie) deleteOldEntryIfMigrated(key []byte, newData dirtyData, oldEntry core.TrieData) (bool, error) {
 	if !tdt.enableEpochsHandler.IsAutoBalanceDataTriesEnabled() {
-		return nil
+		return false, nil
 	}
 
 	isMigration := oldEntry.Version == core.NotSpecified && newData.newVersion == core.AutoBalanceEnabled
 	if isMigration && len(newData.value) != 0 {
-		return tdt.tr.Delete(key)
+		return true, tdt.tr.Delete(key)
 	}
 
-	return nil
+	return false, nil
 }
 
-func (tdt *trackableDataTrie) modifyTrie(key []byte, dataEntry dirtyData, oldVal core.TrieData, dtr state.DataTrie) error {
-	if len(dataEntry.value) == 0 {
-		return tdt.deleteFromTrie(oldVal, key, dtr)
-	}
-
+func (tdt *trackableDataTrie) modifyTrie(key []byte, dataEntry dirtyData, oldVal core.TrieData, dtr state.DataTrie) ([]byte, []byte, error) {
 	version := dataEntry.newVersion
 	newKey := tdt.getKeyForVersion(key, version)
-	value, err := tdt.getValueForVersion(key, dataEntry.value, version)
-	if err != nil {
-		return err
+
+	if len(dataEntry.value) == 0 {
+		deletedKey, err := tdt.deleteFromTrie(oldVal, key, dtr)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return deletedKey, nil, nil
 	}
 
-	return dtr.UpdateWithVersion(newKey, value, version)
+	value, err := tdt.getValueForVersion(key, dataEntry.value, version)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = dtr.UpdateWithVersion(newKey, value, version)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return newKey, value, nil
 }
 
-func (tdt *trackableDataTrie) deleteFromTrie(oldVal core.TrieData, key []byte, dtr state.DataTrie) error {
+func (tdt *trackableDataTrie) deleteFromTrie(oldVal core.TrieData, key []byte, dtr state.DataTrie) ([]byte, error) {
 	if len(oldVal.Value) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	if oldVal.Version == core.AutoBalanceEnabled {
-		return dtr.Delete(tdt.hasher.Compute(string(key)))
+		keyForTrie := tdt.hasher.Compute(string(key))
+		return keyForTrie, dtr.Delete(keyForTrie)
 	}
 
 	if oldVal.Version == core.NotSpecified {
-		return dtr.Delete(key)
+		return key, dtr.Delete(key)
 	}
 
-	return nil
+	return nil, nil
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/state/trackableDataTrie/trackableDataTrie_test.go
+++ b/state/trackableDataTrie/trackableDataTrie_test.go
@@ -379,21 +379,19 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		t.Parallel()
 
 		identifier := []byte("identifier")
-		expectedKey := []byte("key")
-		expectedVal := []byte("value")
-		value := append(expectedVal, expectedKey...)
-		value = append(value, identifier...)
 		hasher := &hashingMocks.HasherMock{}
 		marshaller := &marshallerMock.MarshalizerMock{}
 		deleteCalled := false
 		updateCalled := false
-
-		trieVal := &dataTrieValue.TrieLeafData{
-			Value:   expectedVal,
-			Key:     expectedKey,
-			Address: identifier,
+		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsAutoBalanceDataTriesEnabledField: true,
 		}
-		serializedTrieVal, _ := marshaller.Marshal(trieVal)
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
+
+		expectedKey := []byte("key")
+		expectedVal := []byte("value")
+		value := tdt.GetValueForVersion(expectedKey, expectedVal, core.NotSpecified)
+		serializedTrieVal := tdt.GetValueForVersion(expectedKey, expectedVal, core.AutoBalanceEnabled)
 
 		trie := &trieMock.TrieStub{
 			GetCalled: func(key []byte) ([]byte, uint32, error) {
@@ -414,11 +412,6 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 				return nil
 			},
 		}
-
-		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
-			IsAutoBalanceDataTriesEnabledField: true,
-		}
-		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
 		tdt.SetDataTrie(trie)
 
 		_ = tdt.SaveKeyValue(expectedKey, expectedVal)
@@ -440,13 +433,17 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		t.Parallel()
 
 		identifier := []byte("identifier")
-		expectedKey := []byte("key")
-		val := []byte("value")
-		expectedVal := append(val, expectedKey...)
-		expectedVal = append(expectedVal, identifier...)
 		hasher := &hashingMocks.HasherMock{}
 		marshaller := &marshallerMock.MarshalizerMock{}
 		updateCalled := false
+		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsAutoBalanceDataTriesEnabledField: false,
+		}
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
+
+		expectedKey := []byte("key")
+		val := []byte("value")
+		expectedVal := tdt.GetValueForVersion(expectedKey, val, core.NotSpecified)
 
 		trie := &trieMock.TrieStub{
 			GetCalled: func(key []byte) ([]byte, uint32, error) {
@@ -466,11 +463,6 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 				return nil
 			},
 		}
-
-		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
-			IsAutoBalanceDataTriesEnabledField: false,
-		}
-		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
 		tdt.SetDataTrie(trie)
 
 		_ = tdt.SaveKeyValue(expectedKey, val)
@@ -489,26 +481,19 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		t.Parallel()
 
 		identifier := []byte("identifier")
-		expectedKey := []byte("key")
-		newVal := []byte("value")
-		oldVal := []byte("old val")
 		hasher := &hashingMocks.HasherMock{}
 		marshaller := &marshallerMock.MarshalizerMock{}
 		updateCalled := false
-
-		oldTrieVal := &dataTrieValue.TrieLeafData{
-			Value:   oldVal,
-			Key:     expectedKey,
-			Address: identifier,
+		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsAutoBalanceDataTriesEnabledField: true,
 		}
-		serializedOldTrieVal, _ := marshaller.Marshal(oldTrieVal)
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
 
-		newTrieVal := &dataTrieValue.TrieLeafData{
-			Value:   newVal,
-			Key:     expectedKey,
-			Address: identifier,
-		}
-		serializedNewTrieVal, _ := marshaller.Marshal(newTrieVal)
+		expectedKey := []byte("key")
+		newVal := []byte("value")
+		oldVal := []byte("old val")
+		serializedOldTrieVal := tdt.GetValueForVersion(expectedKey, oldVal, core.AutoBalanceEnabled)
+		serializedNewTrieVal := tdt.GetValueForVersion(expectedKey, newVal, core.AutoBalanceEnabled)
 
 		trie := &trieMock.TrieStub{
 			GetCalled: func(key []byte) ([]byte, uint32, error) {
@@ -528,11 +513,6 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 				return nil
 			},
 		}
-
-		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
-			IsAutoBalanceDataTriesEnabledField: true,
-		}
-		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
 		tdt.SetDataTrie(trie)
 
 		_ = tdt.SaveKeyValue(expectedKey, newVal)
@@ -551,18 +531,17 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		t.Parallel()
 
 		identifier := []byte("identifier")
-		expectedKey := []byte("key")
-		newVal := []byte("value")
 		hasher := &hashingMocks.HasherMock{}
 		marshaller := &marshallerMock.MarshalizerMock{}
 		updateCalled := false
-
-		newTrieVal := &dataTrieValue.TrieLeafData{
-			Value:   newVal,
-			Key:     expectedKey,
-			Address: identifier,
+		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsAutoBalanceDataTriesEnabledField: true,
 		}
-		serializedNewTrieVal, _ := marshaller.Marshal(newTrieVal)
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
+
+		expectedKey := []byte("key")
+		newVal := []byte("value")
+		serializedNewTrieVal := tdt.GetValueForVersion(expectedKey, newVal, core.AutoBalanceEnabled)
 
 		trie := &trieMock.TrieStub{
 			GetCalled: func(key []byte) ([]byte, uint32, error) {
@@ -579,11 +558,6 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 				return nil
 			},
 		}
-
-		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
-			IsAutoBalanceDataTriesEnabledField: true,
-		}
-		tdt, _ := trackableDataTrie.NewTrackableDataTrie(identifier, hasher, marshaller, enableEpochsHandler)
 		tdt.SetDataTrie(trie)
 
 		_ = tdt.SaveKeyValue(expectedKey, newVal)
@@ -755,13 +729,22 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		t.Parallel()
 
 		identifier := []byte("identifier")
-		expectedKey := []byte("key")
-		newVal := []byte("value")
-		valueWithMetadata := append(newVal, expectedKey...)
-		valueWithMetadata = append(valueWithMetadata, identifier...)
 		hasher := &hashingMocks.HasherMock{}
 		marshaller := &marshallerMock.MarshalizerMock{}
 		updateCalled := false
+		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsAutoBalanceDataTriesEnabledField: false,
+		}
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(
+			identifier,
+			hasher,
+			marshaller,
+			enableEpochsHandler,
+		)
+
+		expectedKey := []byte("key")
+		newVal := []byte("value")
+		valueWithMetadata := tdt.GetValueForVersion(expectedKey, newVal, core.NotSpecified)
 
 		trie := &trieMock.TrieStub{
 			GetCalled: func(key []byte) ([]byte, uint32, error) {
@@ -778,16 +761,6 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 				return nil
 			},
 		}
-
-		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
-			IsAutoBalanceDataTriesEnabledField: false,
-		}
-		tdt, _ := trackableDataTrie.NewTrackableDataTrie(
-			identifier,
-			hasher,
-			marshaller,
-			enableEpochsHandler,
-		)
 		tdt.SetDataTrie(trie)
 
 		_ = tdt.SaveKeyValue(expectedKey, newVal)
@@ -800,6 +773,78 @@ func TestTrackableDataTrie_SaveDirtyData(t *testing.T) {
 		assert.Equal(t, 1, len(stateChanges))
 		assert.Equal(t, expectedKey, stateChanges[0].Key)
 		assert.Equal(t, valueWithMetadata, stateChanges[0].Val)
+	})
+
+	t.Run("state changes are ordered deterministically", func(t *testing.T) {
+		t.Parallel()
+
+		identifier := []byte("identifier")
+		hasher := &hashingMocks.HasherMock{}
+		marshaller := &marshallerMock.MarshalizerMock{}
+		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsAutoBalanceDataTriesEnabledField: true,
+		}
+		tdt, _ := trackableDataTrie.NewTrackableDataTrie(
+			identifier,
+			hasher,
+			marshaller,
+			enableEpochsHandler,
+		)
+
+		key1 := "key1"
+		key2 := "key2"
+		key3 := "key3"
+		key4 := "key4"
+
+		trie := &trieMock.TrieStub{
+			GetCalled: func(key []byte) ([]byte, uint32, error) {
+				if bytes.Equal(key, []byte(key1)) {
+					return tdt.GetValueForVersion([]byte(key1), []byte("value1"), core.NotSpecified), 0, nil
+				}
+				if bytes.Equal(key, []byte(key2)) {
+					return tdt.GetValueForVersion([]byte(key2), []byte("value2"), core.NotSpecified), 0, nil
+				}
+				if bytes.Equal(key, hasher.Compute(key3)) {
+					return tdt.GetValueForVersion([]byte(key3), []byte("value3"), core.AutoBalanceEnabled), 0, nil
+				}
+				if bytes.Equal(key, hasher.Compute(key4)) {
+					return tdt.GetValueForVersion([]byte(key4), []byte("value4"), core.AutoBalanceEnabled), 0, nil
+				}
+
+				return nil, 0, nil
+			},
+			UpdateWithVersionCalled: func(_, _ []byte, _ core.TrieNodeVersion) error {
+				return nil
+			},
+			DeleteCalled: func(_ []byte) error {
+				return nil
+			},
+		}
+		tdt.SetDataTrie(trie)
+
+		_ = tdt.SaveKeyValue([]byte(key1), []byte("value"))
+		_ = tdt.SaveKeyValue([]byte(key2), []byte("value"))
+		_ = tdt.SaveKeyValue([]byte(key3), []byte("value"))
+		_ = tdt.SaveKeyValue([]byte(key4), nil)
+		_ = tdt.SaveKeyValue([]byte("non existent key"), nil)
+
+		stateChanges, oldVals, err := tdt.SaveDirtyData(trie)
+		assert.Nil(t, err)
+		assert.Equal(t, 5, len(oldVals))
+		assert.Equal(t, 6, len(stateChanges))
+
+		assert.Equal(t, hasher.Compute(key1), stateChanges[0].Key)
+		assert.Equal(t, tdt.GetValueForVersion([]byte(key1), []byte("value"), core.AutoBalanceEnabled), stateChanges[0].Val)
+		assert.Equal(t, hasher.Compute(key2), stateChanges[1].Key)
+		assert.Equal(t, tdt.GetValueForVersion([]byte(key2), []byte("value"), core.AutoBalanceEnabled), stateChanges[1].Val)
+		assert.Equal(t, hasher.Compute(key3), stateChanges[2].Key)
+		assert.Equal(t, tdt.GetValueForVersion([]byte(key3), []byte("value"), core.AutoBalanceEnabled), stateChanges[2].Val)
+		assert.Equal(t, hasher.Compute(key4), stateChanges[3].Key)
+		assert.Equal(t, []byte(nil), stateChanges[3].Val)
+		assert.Equal(t, []byte(key1), stateChanges[4].Key)
+		assert.Equal(t, []byte(nil), stateChanges[4].Val)
+		assert.Equal(t, []byte(key2), stateChanges[5].Key)
+		assert.Equal(t, []byte(nil), stateChanges[5].Val)
 	})
 }
 

--- a/testscommon/integrationtests/factory.go
+++ b/testscommon/integrationtests/factory.go
@@ -119,6 +119,7 @@ func CreateAccountsDB(db storage.Storer, enableEpochs common.EnableEpochsHandler
 		ProcessStatusHandler:  &testscommon.ProcessStatusHandlerStub{},
 		AppStatusHandler:      &statusHandler.AppStatusHandlerStub{},
 		AddressConverter:      &testscommon.PubkeyConverterMock{},
+		StateChangesCollector: state.NewStateChangesCollector(),
 	}
 	adb, _ := state.NewAccountsDB(argsAccountsDB)
 

--- a/testscommon/state/accountWrapperMock.go
+++ b/testscommon/state/accountWrapperMock.go
@@ -196,7 +196,7 @@ func (awm *AccountWrapMock) DataTrie() common.DataTrieHandler {
 }
 
 // SaveDirtyData -
-func (awm *AccountWrapMock) SaveDirtyData(trie common.Trie) ([]core.TrieData, error) {
+func (awm *AccountWrapMock) SaveDirtyData(trie common.Trie) ([]state.DataTrieChange, []core.TrieData, error) {
 	return awm.trackableDataTrie.SaveDirtyData(trie)
 }
 
@@ -205,7 +205,7 @@ func (awm *AccountWrapMock) SetDataTrie(trie common.Trie) {
 	awm.trackableDataTrie.SetDataTrie(trie)
 }
 
-//IncreaseNonce adds the given value to the current nonce
+// IncreaseNonce adds the given value to the current nonce
 func (awm *AccountWrapMock) IncreaseNonce(val uint64) {
 	awm.nonce = awm.nonce + val
 }

--- a/testscommon/state/accountsAdapterStub.go
+++ b/testscommon/state/accountsAdapterStub.go
@@ -13,33 +13,34 @@ var errNotImplemented = errors.New("not implemented")
 
 // AccountsStub -
 type AccountsStub struct {
-	GetExistingAccountCalled      func(addressContainer []byte) (vmcommon.AccountHandler, error)
-	GetAccountFromBytesCalled     func(address []byte, accountBytes []byte) (vmcommon.AccountHandler, error)
-	LoadAccountCalled             func(container []byte) (vmcommon.AccountHandler, error)
-	SaveAccountCalled             func(account vmcommon.AccountHandler) error
-	RemoveAccountCalled           func(addressContainer []byte) error
-	CommitCalled                  func() ([]byte, error)
-	CommitInEpochCalled           func(uint32, uint32) ([]byte, error)
-	JournalLenCalled              func() int
-	RevertToSnapshotCalled        func(snapshot int) error
-	RootHashCalled                func() ([]byte, error)
-	RecreateTrieCalled            func(rootHash []byte) error
-	RecreateTrieFromEpochCalled   func(options common.RootHashHolder) error
-	PruneTrieCalled               func(rootHash []byte, identifier state.TriePruningIdentifier, handler state.PruningHandler)
-	CancelPruneCalled             func(rootHash []byte, identifier state.TriePruningIdentifier)
-	SnapshotStateCalled           func(rootHash []byte, epoch uint32)
-	SetStateCheckpointCalled      func(rootHash []byte)
-	IsPruningEnabledCalled        func() bool
-	GetAllLeavesCalled            func(leavesChannels *common.TrieIteratorChannels, ctx context.Context, rootHash []byte, trieLeafParser common.TrieLeafParser) error
-	RecreateAllTriesCalled        func(rootHash []byte) (map[string]common.Trie, error)
-	GetCodeCalled                 func([]byte) []byte
-	GetTrieCalled                 func([]byte) (common.Trie, error)
-	GetStackDebugFirstEntryCalled func() []byte
-	GetAccountWithBlockInfoCalled func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error)
-	GetCodeWithBlockInfoCalled    func(codeHash []byte, options common.RootHashHolder) ([]byte, common.BlockInfo, error)
-	CloseCalled                   func() error
-	SetSyncerCalled               func(syncer state.AccountsDBSyncer) error
-	StartSnapshotIfNeededCalled   func() error
+	GetExistingAccountCalled                     func(addressContainer []byte) (vmcommon.AccountHandler, error)
+	GetAccountFromBytesCalled                    func(address []byte, accountBytes []byte) (vmcommon.AccountHandler, error)
+	LoadAccountCalled                            func(container []byte) (vmcommon.AccountHandler, error)
+	SaveAccountCalled                            func(account vmcommon.AccountHandler) error
+	RemoveAccountCalled                          func(addressContainer []byte) error
+	CommitCalled                                 func() ([]byte, error)
+	CommitInEpochCalled                          func(uint32, uint32) ([]byte, error)
+	JournalLenCalled                             func() int
+	RevertToSnapshotCalled                       func(snapshot int) error
+	RootHashCalled                               func() ([]byte, error)
+	RecreateTrieCalled                           func(rootHash []byte) error
+	RecreateTrieFromEpochCalled                  func(options common.RootHashHolder) error
+	PruneTrieCalled                              func(rootHash []byte, identifier state.TriePruningIdentifier, handler state.PruningHandler)
+	CancelPruneCalled                            func(rootHash []byte, identifier state.TriePruningIdentifier)
+	SnapshotStateCalled                          func(rootHash []byte, epoch uint32)
+	SetStateCheckpointCalled                     func(rootHash []byte)
+	IsPruningEnabledCalled                       func() bool
+	GetAllLeavesCalled                           func(leavesChannels *common.TrieIteratorChannels, ctx context.Context, rootHash []byte, trieLeafParser common.TrieLeafParser) error
+	RecreateAllTriesCalled                       func(rootHash []byte) (map[string]common.Trie, error)
+	GetCodeCalled                                func([]byte) []byte
+	GetTrieCalled                                func([]byte) (common.Trie, error)
+	GetStackDebugFirstEntryCalled                func() []byte
+	GetAccountWithBlockInfoCalled                func(address []byte, options common.RootHashHolder) (vmcommon.AccountHandler, common.BlockInfo, error)
+	GetCodeWithBlockInfoCalled                   func(codeHash []byte, options common.RootHashHolder) ([]byte, common.BlockInfo, error)
+	CloseCalled                                  func() error
+	SetSyncerCalled                              func(syncer state.AccountsDBSyncer) error
+	StartSnapshotIfNeededCalled                  func() error
+	GetStateChangesForTheLatestTransactionCalled func() ([]state.StateChangeDTO, error)
 }
 
 // CleanCache -
@@ -263,6 +264,15 @@ func (as *AccountsStub) GetCodeWithBlockInfo(codeHash []byte, options common.Roo
 	}
 
 	return nil, nil, nil
+}
+
+// GetStateChangesForTheLatestTransaction -
+func (as *AccountsStub) GetStateChangesForTheLatestTransaction() ([]state.StateChangeDTO, error) {
+	if as.GetStateChangesForTheLatestTransactionCalled != nil {
+		return as.GetStateChangesForTheLatestTransactionCalled()
+	}
+
+	return nil, nil
 }
 
 // Close -

--- a/testscommon/state/userAccountStub.go
+++ b/testscommon/state/userAccountStub.go
@@ -185,8 +185,8 @@ func (u *UserAccountStub) IsGuarded() bool {
 }
 
 // SaveDirtyData -
-func (u *UserAccountStub) SaveDirtyData(_ common.Trie) ([]core.TrieData, error) {
-	return nil, nil
+func (u *UserAccountStub) SaveDirtyData(_ common.Trie) ([]state.DataTrieChange, []core.TrieData, error) {
+	return nil, nil, nil
 }
 
 // IsInterfaceNil -

--- a/testscommon/trie/dataTrieTrackerStub.go
+++ b/testscommon/trie/dataTrieTrackerStub.go
@@ -4,6 +4,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/state"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
@@ -15,7 +16,7 @@ type DataTrieTrackerStub struct {
 	SaveKeyValueCalled          func(key []byte, value []byte) error
 	SetDataTrieCalled           func(tr common.Trie)
 	DataTrieCalled              func() common.Trie
-	SaveDirtyDataCalled         func(trie common.Trie) ([]core.TrieData, error)
+	SaveDirtyDataCalled         func(trie common.Trie) ([]state.DataTrieChange, []core.TrieData, error)
 	SaveTrieDataCalled          func(trieData core.TrieData) error
 	MigrateDataTrieLeavesCalled func(args vmcommon.ArgsMigrateDataTrieLeaves) error
 }
@@ -61,12 +62,12 @@ func (dtts *DataTrieTrackerStub) DataTrie() common.DataTrieHandler {
 }
 
 // SaveDirtyData -
-func (dtts *DataTrieTrackerStub) SaveDirtyData(mainTrie common.Trie) ([]core.TrieData, error) {
+func (dtts *DataTrieTrackerStub) SaveDirtyData(mainTrie common.Trie) ([]state.DataTrieChange, []core.TrieData, error) {
 	if dtts.SaveDirtyDataCalled != nil {
 		return dtts.SaveDirtyDataCalled(mainTrie)
 	}
 
-	return make([]core.TrieData, 0), nil
+	return make([]state.DataTrieChange, 0), make([]core.TrieData, 0), nil
 }
 
 // MigrateDataTrieLeaves -

--- a/update/genesis/import.go
+++ b/update/genesis/import.go
@@ -19,6 +19,7 @@ import (
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/state"
+	stateDisabled "github.com/multiversx/mx-chain-go/state/disabled"
 	"github.com/multiversx/mx-chain-go/state/factory"
 	"github.com/multiversx/mx-chain-go/state/storagePruningManager/disabled"
 	"github.com/multiversx/mx-chain-go/trie"
@@ -422,6 +423,7 @@ func (si *stateImport) getAccountsDB(accType Type, shardID uint32, accountFactor
 				ProcessStatusHandler:  commonDisabled.NewProcessStatusHandler(),
 				AppStatusHandler:      commonDisabled.NewAppStatusHandler(),
 				AddressConverter:      si.addressConverter,
+				StateChangesCollector: stateDisabled.NewDisabledStateChangesCollector(),
 			}
 			accountsDB, errCreate := state.NewAccountsDB(argsAccountDB)
 			if errCreate != nil {
@@ -447,6 +449,7 @@ func (si *stateImport) getAccountsDB(accType Type, shardID uint32, accountFactor
 		ProcessStatusHandler:  commonDisabled.NewProcessStatusHandler(),
 		AppStatusHandler:      commonDisabled.NewAppStatusHandler(),
 		AddressConverter:      si.addressConverter,
+		StateChangesCollector: stateDisabled.NewDisabledStateChangesCollector(),
 	}
 	accountsDB, err = state.NewAccountsDB(argsAccountDB)
 	si.accountDBsMap[shardID] = accountsDB


### PR DESCRIPTION
## Reasoning behind the pull request
- The lite clients will need the state changes delta for each transaction. Currently, the protocol does not collect the state changes triggered by each transaction.
  
## Proposed changes
- Collect state changes for each transaction. This can be disabled by changing the `CollectStateChangesEnabled` flag in config

## Testing procedure
- Normal testing procedure
- Create a separate trie which is modified only by appling the collected state changes. The real trie and the new trie should have the same rootHash after each block.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
