### PR TITLE
Added p2p debugger setter

### DIFF
--- a/cmd/seednode/main.go
+++ b/cmd/seednode/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/multiversx/mx-chain-go/cmd/seednode/api"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/config"
+	p2pDebug "github.com/multiversx/mx-chain-go/debug/p2p"
 	"github.com/multiversx/mx-chain-go/epochStart/bootstrap/disabled"
 	"github.com/multiversx/mx-chain-go/facade"
 	cryptoFactory "github.com/multiversx/mx-chain-go/factory/crypto"
@@ -271,7 +272,17 @@ func createNode(
 		Logger:                logger.GetOrCreate("seed/p2p"),
 	}
 
-	return p2pFactory.NewNetworkMessenger(arg)
+	netMessenger, err := p2pFactory.NewNetworkMessenger(arg)
+	if err != nil {
+		return nil, err
+	}
+
+	err = netMessenger.SetDebugger(p2pDebug.NewP2PDebugger(netMessenger.ID()))
+	if err != nil {
+		return nil, err
+	}
+
+	return netMessenger, err
 }
 
 func displayMessengerInfo(messenger p2p.Messenger) {

--- a/common/constants.go
+++ b/common/constants.go
@@ -881,3 +881,6 @@ const MetricTrieSyncNumReceivedBytes = "erd_trie_sync_num_bytes_received"
 
 // MetricTrieSyncNumProcessedNodes is the metric that outputs the number of trie nodes processed for accounts during trie sync
 const MetricTrieSyncNumProcessedNodes = "erd_trie_sync_num_nodes_processed"
+
+// FullArchiveMetricSuffix is the suffix added to metrics specific for full archive network
+const FullArchiveMetricSuffix = "_full_archive"

--- a/common/converters.go
+++ b/common/converters.go
@@ -46,3 +46,8 @@ func AssignShardForPubKeyWhenNotSpecified(pubKey []byte, numShards uint32) uint3
 
 	return randomShardID
 }
+
+// SuffixedMetric appends the suffix to the provided metric and returns it
+func SuffixedMetric(metric string, suffix string) string {
+	return fmt.Sprintf("%s%s", metric, suffix)
+}

--- a/common/converters_test.go
+++ b/common/converters_test.go
@@ -362,3 +362,16 @@ func testProcessDestinationShardAsObserver(providedShard string, expectedShard u
 		require.Equal(t, expectedShard, shard)
 	}
 }
+
+func TestSuffixedMetric(t *testing.T) {
+	t.Parallel()
+
+	providedMetric := common.MetricP2PPeerInfo
+	providedSuffix := ""
+	expectedMetric := providedMetric
+	require.Equal(t, expectedMetric, common.SuffixedMetric(providedMetric, providedSuffix))
+
+	providedSuffix = common.FullArchiveMetricSuffix
+	expectedMetric = providedMetric + providedSuffix
+	require.Equal(t, expectedMetric, common.SuffixedMetric(providedMetric, providedSuffix))
+}

--- a/factory/network/networkComponents.go
+++ b/factory/network/networkComponents.go
@@ -11,6 +11,7 @@ import (
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/consensus"
+	p2pDebug "github.com/multiversx/mx-chain-go/debug/p2p"
 	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/factory"
 	"github.com/multiversx/mx-chain-go/factory/disabled"
@@ -257,6 +258,11 @@ func (ncf *networkComponentsFactory) createNetworkHolder(
 		Logger:                logger,
 	}
 	networkMessenger, err := p2pFactory.NewNetworkMessenger(argsMessenger)
+	if err != nil {
+		return networkComponentsHolder{}, err
+	}
+
+	err = networkMessenger.SetDebugger(p2pDebug.NewP2PDebugger(networkMessenger.ID()))
 	if err != nil {
 		return networkComponentsHolder{}, err
 	}

--- a/factory/status/export_test.go
+++ b/factory/status/export_test.go
@@ -16,16 +16,18 @@ func (pc *statusComponents) EpochStartEventHandler() epochStart.ActionHandler {
 func ComputeNumConnectedPeers(
 	appStatusHandler core.AppStatusHandler,
 	netMessenger p2p.Messenger,
+	suffix string,
 ) {
-	computeNumConnectedPeers(appStatusHandler, netMessenger)
+	computeNumConnectedPeers(appStatusHandler, netMessenger, suffix)
 }
 
 // ComputeConnectedPeers -
 func ComputeConnectedPeers(
 	appStatusHandler core.AppStatusHandler,
 	netMessenger p2p.Messenger,
+	suffix string,
 ) {
-	computeConnectedPeers(appStatusHandler, netMessenger)
+	computeConnectedPeers(appStatusHandler, netMessenger, suffix)
 }
 
 // MakeHostDriversArgs -

--- a/factory/status/statusComponentsHandler.go
+++ b/factory/status/statusComponentsHandler.go
@@ -225,13 +225,17 @@ func registerPollConnectedPeers(
 		if check.IfNil(networkComponents) {
 			return
 		}
-		netMessenger := networkComponents.NetworkMessenger()
-		if check.IfNil(netMessenger) {
+		mainNetMessenger := networkComponents.NetworkMessenger()
+		if check.IfNil(mainNetMessenger) {
 			return
 		}
+		computeMetricsForMessenger(appStatusHandler, mainNetMessenger, "")
 
-		computeNumConnectedPeers(appStatusHandler, netMessenger)
-		computeConnectedPeers(appStatusHandler, netMessenger)
+		fullArchiveNetMessenger := networkComponents.FullArchiveNetworkMessenger()
+		if check.IfNil(fullArchiveNetMessenger) {
+			return
+		}
+		computeMetricsForMessenger(appStatusHandler, fullArchiveNetMessenger, common.FullArchiveMetricSuffix)
 	}
 
 	err := appStatusPollingHandler.RegisterPollingFunc(p2pMetricsHandlerFunc)
@@ -263,17 +267,28 @@ func registerShardsInformation(
 	return nil
 }
 
+func computeMetricsForMessenger(
+	appStatusHandler core.AppStatusHandler,
+	netMessenger p2p.Messenger,
+	suffix string,
+) {
+	computeNumConnectedPeers(appStatusHandler, netMessenger, suffix)
+	computeConnectedPeers(appStatusHandler, netMessenger, suffix)
+}
+
 func computeNumConnectedPeers(
 	appStatusHandler core.AppStatusHandler,
 	netMessenger p2p.Messenger,
+	suffix string,
 ) {
 	numOfConnectedPeers := uint64(len(netMessenger.ConnectedAddresses()))
-	appStatusHandler.SetUInt64Value(common.MetricNumConnectedPeers, numOfConnectedPeers)
+	appStatusHandler.SetUInt64Value(common.SuffixedMetric(common.MetricNumConnectedPeers, suffix), numOfConnectedPeers)
 }
 
 func computeConnectedPeers(
 	appStatusHandler core.AppStatusHandler,
 	netMessenger p2p.Messenger,
+	suffix string,
 ) {
 	peersInfo := netMessenger.GetConnectedPeersInfo()
 
@@ -284,19 +299,19 @@ func computeConnectedPeers(
 		len(peersInfo.CrossShardObservers),
 		len(peersInfo.UnknownPeers),
 	)
-	appStatusHandler.SetStringValue(common.MetricNumConnectedPeersClassification, peerClassification)
-	appStatusHandler.SetStringValue(common.MetricP2PNumConnectedPeersClassification, peerClassification)
+	appStatusHandler.SetStringValue(common.SuffixedMetric(common.MetricNumConnectedPeersClassification, suffix), peerClassification)
+	appStatusHandler.SetStringValue(common.SuffixedMetric(common.MetricP2PNumConnectedPeersClassification, suffix), peerClassification)
 
-	setP2pConnectedPeersMetrics(appStatusHandler, peersInfo)
-	setCurrentP2pNodeAddresses(appStatusHandler, netMessenger)
+	setP2pConnectedPeersMetrics(appStatusHandler, peersInfo, suffix)
+	setCurrentP2pNodeAddresses(appStatusHandler, netMessenger, suffix)
 }
 
-func setP2pConnectedPeersMetrics(appStatusHandler core.AppStatusHandler, info *p2p.ConnectedPeersInfo) {
-	appStatusHandler.SetStringValue(common.MetricP2PUnknownPeers, sliceToString(info.UnknownPeers))
-	appStatusHandler.SetStringValue(common.MetricP2PIntraShardValidators, mapToString(info.IntraShardValidators))
-	appStatusHandler.SetStringValue(common.MetricP2PIntraShardObservers, mapToString(info.IntraShardObservers))
-	appStatusHandler.SetStringValue(common.MetricP2PCrossShardValidators, mapToString(info.CrossShardValidators))
-	appStatusHandler.SetStringValue(common.MetricP2PCrossShardObservers, mapToString(info.CrossShardObservers))
+func setP2pConnectedPeersMetrics(appStatusHandler core.AppStatusHandler, info *p2p.ConnectedPeersInfo, suffix string) {
+	appStatusHandler.SetStringValue(common.SuffixedMetric(common.MetricP2PUnknownPeers, suffix), sliceToString(info.UnknownPeers))
+	appStatusHandler.SetStringValue(common.SuffixedMetric(common.MetricP2PIntraShardValidators, suffix), mapToString(info.IntraShardValidators))
+	appStatusHandler.SetStringValue(common.SuffixedMetric(common.MetricP2PIntraShardObservers, suffix), mapToString(info.IntraShardObservers))
+	appStatusHandler.SetStringValue(common.SuffixedMetric(common.MetricP2PCrossShardValidators, suffix), mapToString(info.CrossShardValidators))
+	appStatusHandler.SetStringValue(common.SuffixedMetric(common.MetricP2PCrossShardObservers, suffix), mapToString(info.CrossShardObservers))
 }
 
 func sliceToString(input []string) string {
@@ -324,8 +339,9 @@ func mapToString(input map[uint32][]string) string {
 func setCurrentP2pNodeAddresses(
 	appStatusHandler core.AppStatusHandler,
 	netMessenger p2p.Messenger,
+	suffix string,
 ) {
-	appStatusHandler.SetStringValue(common.MetricP2PPeerInfo, sliceToString(netMessenger.Addresses()))
+	appStatusHandler.SetStringValue(common.SuffixedMetric(common.MetricP2PPeerInfo, suffix), sliceToString(netMessenger.Addresses()))
 }
 
 func registerPollProbableHighestNonce(

--- a/factory/status/statusComponentsHandler_test.go
+++ b/factory/status/statusComponentsHandler_test.go
@@ -170,109 +170,127 @@ func TestManagedStatusComponents_StartPolling(t *testing.T) {
 func TestComputeNumConnectedPeers(t *testing.T) {
 	t.Parallel()
 
-	netMes := &p2pmocks.MessengerStub{
-		ConnectedAddressesCalled: func() []string {
-			return []string{"addr1", "addr2", "addr3"}
-		},
-	}
-	appStatusHandler := &statusHandler.AppStatusHandlerStub{
-		SetUInt64ValueHandler: func(key string, value uint64) {
-			require.Equal(t, common.MetricNumConnectedPeers, key)
-			require.Equal(t, uint64(3), value)
-		},
-	}
+	t.Run("main network", testComputeNumConnectedPeers(""))
+	t.Run("full archive network", testComputeNumConnectedPeers(common.FullArchiveMetricSuffix))
+}
 
-	statusComp.ComputeNumConnectedPeers(appStatusHandler, netMes)
+func testComputeNumConnectedPeers(suffix string) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		netMes := &p2pmocks.MessengerStub{
+			ConnectedAddressesCalled: func() []string {
+				return []string{"addr1", "addr2", "addr3"}
+			},
+		}
+		appStatusHandler := &statusHandler.AppStatusHandlerStub{
+			SetUInt64ValueHandler: func(key string, value uint64) {
+				require.Equal(t, common.SuffixedMetric(common.MetricNumConnectedPeers, suffix), key)
+				require.Equal(t, uint64(3), value)
+			},
+		}
+
+		statusComp.ComputeNumConnectedPeers(appStatusHandler, netMes, suffix)
+	}
 }
 
 func TestComputeConnectedPeers(t *testing.T) {
 	t.Parallel()
 
-	netMes := &p2pmocks.MessengerStub{
-		GetConnectedPeersInfoCalled: func() *p2p.ConnectedPeersInfo {
-			return &p2p.ConnectedPeersInfo{
-				SelfShardID:  0,
-				UnknownPeers: []string{"unknown"},
-				Seeders:      []string{"seeder"},
-				IntraShardValidators: map[uint32][]string{
-					0: {"intra-v-0"},
-					1: {"intra-v-1"},
-				},
-				IntraShardObservers: map[uint32][]string{
-					0: {"intra-o-0"},
-					1: {"intra-o-1"},
-				},
-				CrossShardValidators: map[uint32][]string{
-					0: {"cross-v-0"},
-					1: {"cross-v-1"},
-				},
-				CrossShardObservers: map[uint32][]string{
-					0: {"cross-o-0"},
-					1: {"cross-o-1"},
-				},
-				NumValidatorsOnShard: map[uint32]int{
-					0: 1,
-					1: 1,
-				},
-				NumObserversOnShard: map[uint32]int{
-					0: 1,
-					1: 1,
-				},
-				NumPreferredPeersOnShard: map[uint32]int{
-					0: 0,
-					1: 0,
-				},
-				NumIntraShardValidators: 2,
-				NumIntraShardObservers:  2,
-				NumCrossShardValidators: 2,
-				NumCrossShardObservers:  2,
-			}
-		},
-		AddressesCalled: func() []string {
-			return []string{"intra-v-0", "intra-v-1", "intra-o-0", "intra-o-1", "cross-v-0", "cross-v-1"}
-		},
-	}
-	expectedPeerClassification := "intraVal:2,crossVal:2,intraObs:2,crossObs:2,unknown:1,"
-	cnt := 0
-	appStatusHandler := &statusHandler.AppStatusHandlerStub{
-		SetStringValueHandler: func(key string, value string) {
-			cnt++
-			switch cnt {
-			case 1:
-				require.Equal(t, common.MetricNumConnectedPeersClassification, key)
-				require.Equal(t, expectedPeerClassification, value)
-			case 2:
-				require.Equal(t, common.MetricP2PNumConnectedPeersClassification, key)
-				require.Equal(t, expectedPeerClassification, value)
-			case 3:
-				require.Equal(t, common.MetricP2PUnknownPeers, key)
-				require.Equal(t, "unknown", value)
-			case 4:
-				require.Equal(t, common.MetricP2PIntraShardValidators, key)
-				require.Equal(t, "intra-v-0,intra-v-1", value)
-			case 5:
-				require.Equal(t, common.MetricP2PIntraShardObservers, key)
-				require.Equal(t, "intra-o-0,intra-o-1", value)
-			case 6:
-				require.Equal(t, common.MetricP2PCrossShardValidators, key)
-				require.Equal(t, "cross-v-0,cross-v-1", value)
-			case 7:
-				require.Equal(t, common.MetricP2PCrossShardObservers, key)
-				require.Equal(t, "cross-o-0,cross-o-1", value)
-			case 8:
-				require.Equal(t, common.MetricP2PPeerInfo, key)
-				require.Equal(t, "intra-v-0,intra-v-1,intra-o-0,intra-o-1,cross-v-0,cross-v-1", value)
-			default:
-				require.Fail(t, "should not have been called")
-			}
-		},
-		SetUInt64ValueHandler: func(key string, value uint64) {
-			require.Equal(t, common.MetricNumConnectedPeers, key)
-			require.Equal(t, 3, key)
-		},
-	}
+	t.Run("main network", testComputeConnectedPeers(""))
+	t.Run("full archive network", testComputeConnectedPeers(common.FullArchiveMetricSuffix))
+}
 
-	statusComp.ComputeConnectedPeers(appStatusHandler, netMes)
+func testComputeConnectedPeers(suffix string) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		netMes := &p2pmocks.MessengerStub{
+			GetConnectedPeersInfoCalled: func() *p2p.ConnectedPeersInfo {
+				return &p2p.ConnectedPeersInfo{
+					SelfShardID:  0,
+					UnknownPeers: []string{"unknown"},
+					Seeders:      []string{"seeder"},
+					IntraShardValidators: map[uint32][]string{
+						0: {"intra-v-0"},
+						1: {"intra-v-1"},
+					},
+					IntraShardObservers: map[uint32][]string{
+						0: {"intra-o-0"},
+						1: {"intra-o-1"},
+					},
+					CrossShardValidators: map[uint32][]string{
+						0: {"cross-v-0"},
+						1: {"cross-v-1"},
+					},
+					CrossShardObservers: map[uint32][]string{
+						0: {"cross-o-0"},
+						1: {"cross-o-1"},
+					},
+					NumValidatorsOnShard: map[uint32]int{
+						0: 1,
+						1: 1,
+					},
+					NumObserversOnShard: map[uint32]int{
+						0: 1,
+						1: 1,
+					},
+					NumPreferredPeersOnShard: map[uint32]int{
+						0: 0,
+						1: 0,
+					},
+					NumIntraShardValidators: 2,
+					NumIntraShardObservers:  2,
+					NumCrossShardValidators: 2,
+					NumCrossShardObservers:  2,
+				}
+			},
+			AddressesCalled: func() []string {
+				return []string{"intra-v-0", "intra-v-1", "intra-o-0", "intra-o-1", "cross-v-0", "cross-v-1"}
+			},
+		}
+		expectedPeerClassification := "intraVal:2,crossVal:2,intraObs:2,crossObs:2,unknown:1,"
+		cnt := 0
+		appStatusHandler := &statusHandler.AppStatusHandlerStub{
+			SetStringValueHandler: func(key string, value string) {
+				cnt++
+				switch cnt {
+				case 1:
+					require.Equal(t, common.SuffixedMetric(common.MetricNumConnectedPeersClassification, suffix), key)
+					require.Equal(t, expectedPeerClassification, value)
+				case 2:
+					require.Equal(t, common.SuffixedMetric(common.MetricP2PNumConnectedPeersClassification, suffix), key)
+					require.Equal(t, expectedPeerClassification, value)
+				case 3:
+					require.Equal(t, common.SuffixedMetric(common.MetricP2PUnknownPeers, suffix), key)
+					require.Equal(t, "unknown", value)
+				case 4:
+					require.Equal(t, common.SuffixedMetric(common.MetricP2PIntraShardValidators, suffix), key)
+					require.Equal(t, "intra-v-0,intra-v-1", value)
+				case 5:
+					require.Equal(t, common.SuffixedMetric(common.MetricP2PIntraShardObservers, suffix), key)
+					require.Equal(t, "intra-o-0,intra-o-1", value)
+				case 6:
+					require.Equal(t, common.SuffixedMetric(common.MetricP2PCrossShardValidators, suffix), key)
+					require.Equal(t, "cross-v-0,cross-v-1", value)
+				case 7:
+					require.Equal(t, common.SuffixedMetric(common.MetricP2PCrossShardObservers, suffix), key)
+					require.Equal(t, "cross-o-0,cross-o-1", value)
+				case 8:
+					require.Equal(t, common.SuffixedMetric(common.MetricP2PPeerInfo, suffix), key)
+					require.Equal(t, "intra-v-0,intra-v-1,intra-o-0,intra-o-1,cross-v-0,cross-v-1", value)
+				default:
+					require.Fail(t, "should not have been called")
+				}
+			},
+			SetUInt64ValueHandler: func(key string, value uint64) {
+				require.Equal(t, common.SuffixedMetric(common.MetricNumConnectedPeers, suffix), key)
+				require.Equal(t, 3, key)
+			},
+		}
+
+		statusComp.ComputeConnectedPeers(appStatusHandler, netMes, suffix)
+	}
 }
 
 func TestManagedStatusComponents_IsInterfaceNil(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/gops v0.3.18
 	github.com/gorilla/websocket v1.5.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/multiversx/mx-chain-communication-go v1.0.6
+	github.com/multiversx/mx-chain-communication-go v1.0.7-0.20230918095306-97f7d8d179bf
 	github.com/multiversx/mx-chain-core-go v1.2.16
 	github.com/multiversx/mx-chain-crypto-go v1.2.8
 	github.com/multiversx/mx-chain-es-indexer-go v1.4.12

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/gops v0.3.18
 	github.com/gorilla/websocket v1.5.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/multiversx/mx-chain-communication-go v1.0.7-0.20230918095306-97f7d8d179bf
+	github.com/multiversx/mx-chain-communication-go v1.0.8
 	github.com/multiversx/mx-chain-core-go v1.2.16
 	github.com/multiversx/mx-chain-crypto-go v1.2.8
 	github.com/multiversx/mx-chain-es-indexer-go v1.4.12

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,8 @@ github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/n
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
 github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUYwbO0993uPI=
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
-github.com/multiversx/mx-chain-communication-go v1.0.6 h1:f2bizRoVuJXBWc32px7pCuzMx4Pgi2tKhUt8BkFV1Fg=
-github.com/multiversx/mx-chain-communication-go v1.0.6/go.mod h1:+oaUowpq+SqrEmAsMPGwhz44g7L81loWb6AiNQU9Ms4=
+github.com/multiversx/mx-chain-communication-go v1.0.7-0.20230918095306-97f7d8d179bf h1:lm0K1M8Lv4n5pRiLPm+pCnGpJAc2532nkDiY7fW+ljs=
+github.com/multiversx/mx-chain-communication-go v1.0.7-0.20230918095306-97f7d8d179bf/go.mod h1:+oaUowpq+SqrEmAsMPGwhz44g7L81loWb6AiNQU9Ms4=
 github.com/multiversx/mx-chain-core-go v1.2.16 h1:m0hUNmZQjGJxKDLQOHoM9jSaeDfVTbyd+mqiS8+NckE=
 github.com/multiversx/mx-chain-core-go v1.2.16/go.mod h1:BILOGHUOIG5dNNX8cgkzCNfDaVtoYrJRYcPnpxRMH84=
 github.com/multiversx/mx-chain-crypto-go v1.2.8 h1:wOgVlUaO5X4L8iEbFjcQcL8SZvv6WZ7LqH73BiRPhxU=

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,8 @@ github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/n
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
 github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUYwbO0993uPI=
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
-github.com/multiversx/mx-chain-communication-go v1.0.7-0.20230918095306-97f7d8d179bf h1:lm0K1M8Lv4n5pRiLPm+pCnGpJAc2532nkDiY7fW+ljs=
-github.com/multiversx/mx-chain-communication-go v1.0.7-0.20230918095306-97f7d8d179bf/go.mod h1:+oaUowpq+SqrEmAsMPGwhz44g7L81loWb6AiNQU9Ms4=
+github.com/multiversx/mx-chain-communication-go v1.0.8 h1:sTx4Vmx+QCpngUFq/LF/Ka8bevlK2vMxfclE284twfc=
+github.com/multiversx/mx-chain-communication-go v1.0.8/go.mod h1:+oaUowpq+SqrEmAsMPGwhz44g7L81loWb6AiNQU9Ms4=
 github.com/multiversx/mx-chain-core-go v1.2.16 h1:m0hUNmZQjGJxKDLQOHoM9jSaeDfVTbyd+mqiS8+NckE=
 github.com/multiversx/mx-chain-core-go v1.2.16/go.mod h1:BILOGHUOIG5dNNX8cgkzCNfDaVtoYrJRYcPnpxRMH84=
 github.com/multiversx/mx-chain-crypto-go v1.2.8 h1:wOgVlUaO5X4L8iEbFjcQcL8SZvv6WZ7LqH73BiRPhxU=

--- a/p2p/disabled/networkMessenger.go
+++ b/p2p/disabled/networkMessenger.go
@@ -185,6 +185,11 @@ func (netMes *networkMessenger) ProcessReceivedMessage(_ p2p.MessageP2P, _ core.
 	return nil
 }
 
+// SetDebugger returns nil as it is disabled
+func (netMes *networkMessenger) SetDebugger(_ p2p.Debugger) error {
+	return nil
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (netMes *networkMessenger) IsInterfaceNil() bool {
 	return netMes == nil

--- a/p2p/interface.go
+++ b/p2p/interface.go
@@ -131,3 +131,6 @@ type Logger = p2p.Logger
 
 // ConnectionsHandler defines the behaviour of a component able to handle connections
 type ConnectionsHandler = p2p.ConnectionsHandler
+
+// Debugger represent a p2p debugger able to print p2p statistics (messages received/sent per topic)
+type Debugger = p2p.Debugger

--- a/testscommon/p2pmocks/messengerStub.go
+++ b/testscommon/p2pmocks/messengerStub.go
@@ -45,6 +45,7 @@ type MessengerStub struct {
 	BroadcastOnChannelUsingPrivateKeyCalled func(channel string, topic string, buff []byte, pid core.PeerID, skBytes []byte)
 	SignUsingPrivateKeyCalled               func(skBytes []byte, payload []byte) ([]byte, error)
 	ProcessReceivedMessageCalled            func(message p2p.MessageP2P, fromConnectedPeer core.PeerID, source p2p.MessageHandler) error
+	SetDebuggerCalled                       func(debugger p2p.Debugger) error
 }
 
 // ID -
@@ -356,6 +357,14 @@ func (ms *MessengerStub) SignUsingPrivateKey(skBytes []byte, payload []byte) ([]
 func (ms *MessengerStub) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedPeer core.PeerID, source p2p.MessageHandler) error {
 	if ms.ProcessReceivedMessageCalled != nil {
 		return ms.ProcessReceivedMessageCalled(message, fromConnectedPeer, source)
+	}
+	return nil
+}
+
+// SetDebugger -
+func (ms *MessengerStub) SetDebugger(debugger p2p.Debugger) error {
+	if ms.SetDebuggerCalled != nil {
+		return ms.SetDebuggerCalled(debugger)
 	}
 	return nil
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- using the same logger on all messenger components led to difficulties during debugging
  
## Proposed changes
- added setter for p2p debugger, as it could be optional and set later on from node
- added p2p metrics for full archive network

## Testing procedure
- system test with some nodes on full archive network
- on full archive nodes, `/node/p2pstatus` must have metrics ending with _full_archive, which should reflect the actual state of the network

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
