### PR TITLE
Fix snapshot in the wrong epoch

### DIFF
--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -1258,7 +1258,7 @@ func (sp *shardProcessor) snapShotEpochStartFromMeta(header data.ShardHeaderHand
 				log.Debug("using scheduled root hash for snapshotting", "schRootHash", schRootHash)
 				rootHash = schRootHash
 			}
-			epoch := header.GetEpoch()
+			epoch := sp.epochStartTrigger.MetaEpoch()
 			log.Debug("shard trie snapshot from epoch start shard data", "rootHash", rootHash, "epoch", epoch)
 			accounts.SnapshotState(rootHash, epoch)
 			sp.markSnapshotDoneInPeerAccounts()


### PR DESCRIPTION
## Reasoning behind the pull request
- There were some edge cases in which a snapshot would start right before the node would reach the next epoch, so there were 2 snapshots in the same epoch.
  
## Proposed changes
- Get the right epoch when starting a snapshot from the epochStartTrigger

## Testing procedure
- Normal testing procedure

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
