### PR TITLE
Fixed managedPeersHolder for badly configured node

### DIFF
--- a/keysManagement/managedPeersHolder.go
+++ b/keysManagement/managedPeersHolder.go
@@ -22,7 +22,7 @@ var log = logger.GetOrCreate("keysManagement")
 type managedPeersHolder struct {
 	mut                              sync.RWMutex
 	defaultPeerInfoCurrentIndex      int
-	providedIdentity                 map[string]*peerInfo
+	providedIdentities               map[string]*peerInfo
 	data                             map[string]*peerInfo
 	pids                             map[core.PeerID]struct{}
 	keyGenerator                     crypto.KeyGenerator
@@ -64,7 +64,7 @@ func NewManagedPeersHolder(args ArgsManagedPeersHolder) (*managedPeersHolder, er
 		data:                             make(map[string]*peerInfo),
 	}
 
-	holder.providedIdentity, err = holder.createDataMap(args.PrefsConfig.NamedIdentity)
+	holder.providedIdentities, err = holder.createProvidedIdentitiesMap(args.PrefsConfig.NamedIdentity)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func checkManagedPeersHolderArgs(args ArgsManagedPeersHolder) error {
 	return nil
 }
 
-func (holder *managedPeersHolder) createDataMap(namedIdentities []config.NamedIdentity) (map[string]*peerInfo, error) {
+func (holder *managedPeersHolder) createProvidedIdentitiesMap(namedIdentities []config.NamedIdentity) (map[string]*peerInfo, error) {
 	dataMap := make(map[string]*peerInfo)
 
 	for _, identity := range namedIdentities {
@@ -161,7 +161,7 @@ func (holder *managedPeersHolder) AddManagedPeer(privateKeyBytes []byte) error {
 			ErrDuplicatedKey, hex.EncodeToString(privateKeyBytes), hex.EncodeToString(publicKeyBytes))
 	}
 
-	pInfo, found = holder.providedIdentity[string(publicKeyBytes)]
+	pInfo, found = holder.providedIdentities[string(publicKeyBytes)]
 	if !found {
 		pInfo = &peerInfo{
 			machineID:    generateRandomMachineID(),


### PR DESCRIPTION
## Reasoning behind the pull request
- fixed managed peers holder to avoid panics in case of a badly configured node where the identities are set but the actual .pem file containing the keys is not provided
  
## Proposed changes
- separated the curated & valid data map from the provided identities

## Testing procedure
- standard system test with multikey
- start a metachain node providing a named identity like
```
[[NamedIdentity]]
   # Identity represents the keybase/GitHub identity for the current NamedIdentity
   Identity = "test"
   # NodeName represents the name that will be given to the names of the current identity
   NodeName = "test"
   # BLSKeys represents the BLS keys assigned to the current NamedIdentity
   BLSKeys = [
      "<BLS1>",
      "<BLS2>",
...
      "<BLSn>"
   ]
```
where `<BLS1>`, `<BLS2>` ... `<BLSn>` are all BLS keys from the testnet in hex format
The node should sync and not panic.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
