### PR TITLE
Added fallback on topicRequestSender in case requests on full archive nodes fail

### DIFF
--- a/dataRetriever/mock/peerListCreatorStub.go
+++ b/dataRetriever/mock/peerListCreatorStub.go
@@ -12,12 +12,18 @@ type PeerListCreatorStub struct {
 
 // CrossShardPeerList -
 func (p *PeerListCreatorStub) CrossShardPeerList() []core.PeerID {
-	return p.CrossShardPeerListCalled()
+	if p.CrossShardPeerListCalled != nil {
+		return p.CrossShardPeerListCalled()
+	}
+	return make([]core.PeerID, 0)
 }
 
 // IntraShardPeerList -
 func (p *PeerListCreatorStub) IntraShardPeerList() []core.PeerID {
-	return p.IntraShardPeerListCalled()
+	if p.IntraShardPeerListCalled != nil {
+		return p.IntraShardPeerListCalled()
+	}
+	return make([]core.PeerID, 0)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface


### PR DESCRIPTION
## Reasoning behind the pull request
- there might be a possibility when running a regular node, 
  
## Proposed changes
- add a fallback option.. if the requests sent on full archive network fail, try on the regular one

## Testing procedure
- standard system test

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
