### PR TITLE
chore: fixed create release workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -109,10 +109,10 @@ jobs:
 
       - name: Create release
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          hub release create --draft --message="Release draft from Github Actions" vNext
+          gh release create --draft --notes="Release draft from Github Actions" vNext
           sleep 10
           for i in $(find ./assets -name '*.tgz' -type f); do
-            hub release edit --attach=${i} --message="" vNext
+            gh release upload vNext ${i}
           done

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Create release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
           hub release create --draft --message="Release draft from Github Actions" vNext
           sleep 10


### PR DESCRIPTION
## Reasoning behind the pull request
- create release workflow stopped working
  
## Proposed changes
- replace the usage of `hub` application with the official one (`gh`)

## Testing procedure
- create a draft release

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
