### PR TITLE
Implemented part 3 of the fix for db lookup extension and partial miniblocks

### DIFF
--- a/dblookupext/historyRepository.go
+++ b/dblookupext/historyRepository.go
@@ -506,17 +506,17 @@ func (hr *historyRepository) RevertBlock(blockHeader data.HeaderHandler, blockBo
 	return hr.esdtSuppliesHandler.RevertChanges(blockHeader, blockBody)
 
 	// TODO(next PR): this function should contain the following code:
-	// err := hr.esdtSuppliesHandler.RevertChanges(blockHeader, blockBody)
-	// if err != nil {
-	//		return err
-	//	}
+	//body, ok := blockBody.(*block.Body)
+	//if !ok {
+	//	return fmt.Errorf("%w in historyRepository.RevertBlock for provided blockBody", errWrongTypeAssertion)
+	//}
 	//
-	//	body, ok := blockBody.(*block.Body)
-	//	if !ok {
-	//		return fmt.Errorf("%w in historyRepository.RevertBlock for provided blockBody", errWrongTypeAssertion)
-	//	}
+	//err := hr.miniblocksHandler.blockReverted(blockHeader, body)
+	//if err != nil {
+	//	return err
+	//}
 	//
-	//	return hr.miniblocksHandler.blockReverted(blockHeader, body)
+	//return hr.esdtSuppliesHandler.RevertChanges(blockHeader, blockBody)
 }
 
 // GetESDTSupply will return the supply from the storage for the given token

--- a/dblookupext/miniblocksHandler.go
+++ b/dblookupext/miniblocksHandler.go
@@ -294,7 +294,7 @@ func (mh *miniblocksHandler) getMiniblockMetadataByMiniblockHash(miniblockHash [
 		return nil, err
 	}
 
-	return convertMiniblockMetadata(miniblockMetadata), nil
+	return convertMiniblockMetadataV1ToV2(miniblockMetadata), nil
 }
 
 func (mh *miniblocksHandler) retrieveMiniblockMetadata(miniblockHash []byte) (*MiniblockMetadataV2, error) {
@@ -318,9 +318,9 @@ func (mh *miniblocksHandler) getMiniblockMetadataByTxHash(txHash []byte) (*Minib
 	}
 
 	for _, mbInfo := range miniblockMetadata.MiniblocksInfo {
-		if findTxHashInMiniblockMetadataOnBlock(mbInfo, txHash) {
+		if existsTxHashInMiniblockMetadataOnBlock(mbInfo, txHash) {
 			miniblockMetadata.MiniblocksInfo = []*MiniblockMetadataOnBlock{mbInfo}
-			mbData := convertMiniblockMetadata(miniblockMetadata)
+			mbData := convertMiniblockMetadataV1ToV2(miniblockMetadata)
 			return mbData[0], nil
 		}
 	}
@@ -329,7 +329,7 @@ func (mh *miniblocksHandler) getMiniblockMetadataByTxHash(txHash []byte) (*Minib
 		ErrNotFoundInStorage, txHash, miniblockHash)
 }
 
-func convertMiniblockMetadata(miniblockMetadata *MiniblockMetadataV2) []*MiniblockMetadata {
+func convertMiniblockMetadataV1ToV2(miniblockMetadata *MiniblockMetadataV2) []*MiniblockMetadata {
 	result := make([]*MiniblockMetadata, 0, len(miniblockMetadata.MiniblocksInfo))
 	for _, mbInfo := range miniblockMetadata.MiniblocksInfo {
 		mbv1 := &MiniblockMetadata{
@@ -353,7 +353,7 @@ func convertMiniblockMetadata(miniblockMetadata *MiniblockMetadataV2) []*Miniblo
 	return result
 }
 
-func findTxHashInMiniblockMetadataOnBlock(mbInfo *MiniblockMetadataOnBlock, txHash []byte) bool {
+func existsTxHashInMiniblockMetadataOnBlock(mbInfo *MiniblockMetadataOnBlock, txHash []byte) bool {
 	if len(mbInfo.TxHashesWhenPartial) == 0 {
 		return true
 	}

--- a/dblookupext/miniblocksHandler.go
+++ b/dblookupext/miniblocksHandler.go
@@ -317,22 +317,16 @@ func (mh *miniblocksHandler) getMiniblockMetadataByTxHash(txHash []byte) (*Minib
 		return nil, err
 	}
 
-	found := false
 	for _, mbInfo := range miniblockMetadata.MiniblocksInfo {
 		if findTxHashInMiniblockMetadataOnBlock(mbInfo, txHash) {
 			miniblockMetadata.MiniblocksInfo = []*MiniblockMetadataOnBlock{mbInfo}
-			found = true
-			break
+			mbData := convertMiniblockMetadata(miniblockMetadata)
+			return mbData[0], nil
 		}
 	}
 
-	if !found {
-		return nil, fmt.Errorf("programming error, %w for txhash %x and mb hash %x",
-			ErrNotFoundInStorage, txHash, miniblockHash)
-	}
-
-	mbData := convertMiniblockMetadata(miniblockMetadata)
-	return mbData[0], nil // there will always be a single element in the slice due to the filtering inside the for loop
+	return nil, fmt.Errorf("programming error, %w for txhash %x and mb hash %x",
+		ErrNotFoundInStorage, txHash, miniblockHash)
 }
 
 func convertMiniblockMetadata(miniblockMetadata *MiniblockMetadataV2) []*MiniblockMetadata {

--- a/dblookupext/miniblocksHandler.go
+++ b/dblookupext/miniblocksHandler.go
@@ -275,10 +275,8 @@ func (mh *miniblocksHandler) removeMiniblockMetadata(
 	if len(loadedMiniblockMetadata.MiniblocksInfo) == 0 {
 		// we assume that the rollback is done in-sync with the node.
 		// TODO: refactor pruningStorer and add RemoveFromEpoch functionality
-		err = mh.miniblocksMetadataStorer.RemoveFromCurrentEpoch(miniblockHash)
-	} else {
-		err = mh.saveMiniblocksMetadata(miniblockHash, loadedMiniblockMetadata, header.GetEpoch())
+		return mh.miniblocksMetadataStorer.RemoveFromCurrentEpoch(miniblockHash)
 	}
 
-	return err
+	return mh.saveMiniblocksMetadata(miniblockHash, loadedMiniblockMetadata, header.GetEpoch())
 }

--- a/dblookupext/miniblocksHandler.go
+++ b/dblookupext/miniblocksHandler.go
@@ -17,33 +17,16 @@ type miniblocksHandler struct {
 	marshaller                       marshal.Marshalizer
 	hasher                           hashing.Hasher
 	epochIndex                       *epochByHashIndex
-	miniblockHashByTxHashIndexStorer storage.Storer
+	miniblockHashByTxHashIndexStorer storage.Storer // static storer
 	miniblocksMetadataStorer         storage.Storer
 }
 
-// blockCommitted will record the miniblocks information
-func (mh *miniblocksHandler) blockCommitted(header data.HeaderHandler, blockBody *block.Body) error {
-	headerHash, errCalculate := core.CalculateHash(mh.marshaller, mh.hasher, header)
-	if errCalculate != nil {
-		return fmt.Errorf("%w for header, header round %d", errCalculate, header.GetRound())
+func (mh *miniblocksHandler) commitMiniblock(header data.HeaderHandler, headerHash []byte, mb *block.MiniBlock) error {
+	miniblockHash, err := core.CalculateHash(mh.marshaller, mh.hasher, mb)
+	if err != nil {
+		return err
 	}
 
-	for index, mb := range blockBody.MiniBlocks {
-		miniblockHash, err := core.CalculateHash(mh.marshaller, mh.hasher, mb)
-		if err != nil {
-			return fmt.Errorf("%w for miniblock at index %d, header hash %x", err, index, headerHash)
-		}
-
-		err = mh.commitMiniblock(header, headerHash, mb, miniblockHash)
-		if err != nil {
-			return fmt.Errorf("%w for miniblock at index %d, mbHash %x, header hash %x", err, index, miniblockHash, headerHash)
-		}
-	}
-
-	return nil
-}
-
-func (mh *miniblocksHandler) commitMiniblock(header data.HeaderHandler, headerHash []byte, mb *block.MiniBlock, miniblockHash []byte) error {
 	miniblockHeader, err := mh.findMiniblockHandler(header, miniblockHash)
 	if err != nil {
 		return err
@@ -57,7 +40,7 @@ func (mh *miniblocksHandler) commitMiniblock(header data.HeaderHandler, headerHa
 		}
 	}
 
-	err = mh.commitExecutedTransactions(miniblockHeader, miniblockHash, mb, header.GetEpoch())
+	err = mh.commitExecutedTransactions(miniblockHeader, miniblockHash, mb)
 	if err != nil {
 		return err
 	}
@@ -76,10 +59,10 @@ func (mh *miniblocksHandler) findMiniblockHandler(header data.HeaderHandler, min
 }
 
 // commitExecutedTransactions will save only the transactions between the start and end index of the provided miniblockHeader
-func (mh *miniblocksHandler) commitExecutedTransactions(miniblockHeader data.MiniBlockHeaderHandler, miniblockHash []byte, mb *block.MiniBlock, epoch uint32) error {
+func (mh *miniblocksHandler) commitExecutedTransactions(miniblockHeader data.MiniBlockHeaderHandler, miniblockHash []byte, mb *block.MiniBlock) error {
 	txHashes := mh.getOrderedExecutedTxHashes(miniblockHeader, mb)
 	for _, txHash := range txHashes {
-		err := mh.miniblockHashByTxHashIndexStorer.PutInEpoch(txHash, miniblockHash, epoch)
+		err := mh.miniblockHashByTxHashIndexStorer.Put(txHash, miniblockHash)
 		if err != nil {
 			return fmt.Errorf("%w for tx hash %x, miniblock hash %x", err, txHash, miniblockHash)
 		}
@@ -279,4 +262,114 @@ func (mh *miniblocksHandler) removeMiniblockMetadata(
 	}
 
 	return mh.saveMiniblocksMetadata(miniblockHash, loadedMiniblockMetadata, header.GetEpoch())
+}
+
+func (mh *miniblocksHandler) loadAllExistingMiniblocksMetadata(miniblockHash []byte, epoch uint32) (*MiniblockMetadataV2, error) {
+	miniblockMetadataFirstEpoch, err := mh.loadExistingMiniblocksMetadata(miniblockHash, epoch)
+	if err != nil {
+		return nil, err
+	}
+	numTxHashes := 0
+	for _, mbInfo := range miniblockMetadataFirstEpoch.MiniblocksInfo {
+		numTxHashes += len(mbInfo.TxHashesWhenPartial)
+	}
+	if numTxHashes == 0 || numTxHashes == int(miniblockMetadataFirstEpoch.NumTxHashesInMiniblock) {
+		return miniblockMetadataFirstEpoch, nil
+	}
+
+	// we will try the next epoch, maybe we will find the rest of the miniblockMetadata info
+	miniblockMetadataNextEpoch, err := mh.loadExistingMiniblocksMetadata(miniblockHash, epoch+1)
+	if err != nil {
+		// no, return what we found
+		return miniblockMetadataFirstEpoch, nil
+	}
+	miniblockMetadataFirstEpoch.MiniblocksInfo = append(miniblockMetadataFirstEpoch.MiniblocksInfo, miniblockMetadataNextEpoch.MiniblocksInfo...)
+
+	return miniblockMetadataFirstEpoch, nil
+}
+
+func (mh *miniblocksHandler) getMiniblockMetadataByMiniblockHash(miniblockHash []byte) ([]*MiniblockMetadata, error) {
+	epoch, err := mh.epochIndex.getEpochByHash(miniblockHash)
+	if err != nil {
+		return nil, err
+	}
+
+	miniblockMetadata, err := mh.loadAllExistingMiniblocksMetadata(miniblockHash, epoch)
+	if err != nil {
+		return nil, err
+	}
+
+	return convertMiniblockMetadata(miniblockMetadata), nil
+}
+
+func (mh *miniblocksHandler) getMiniblockMetadataByTxHash(txHash []byte) (*MiniblockMetadata, error) {
+	miniblockHash, err := mh.miniblockHashByTxHashIndexStorer.Get(txHash)
+	if err != nil {
+		return nil, err
+	}
+
+	epoch, err := mh.epochIndex.getEpochByHash(miniblockHash)
+	if err != nil {
+		return nil, err
+	}
+
+	miniblockMetadata, err := mh.loadAllExistingMiniblocksMetadata(miniblockHash, epoch)
+	if err != nil {
+		return nil, err
+	}
+
+	found := false
+	for _, mbInfo := range miniblockMetadata.MiniblocksInfo {
+		if findTxHashInMiniblockMetadataOnBlock(mbInfo, txHash) {
+			miniblockMetadata.MiniblocksInfo = []*MiniblockMetadataOnBlock{mbInfo}
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("programming error, %w for txhash %x and mb hash %x",
+			ErrNotFoundInStorage, txHash, miniblockHash)
+	}
+
+	mbData := convertMiniblockMetadata(miniblockMetadata)
+	return mbData[0], nil // there will always be a single element in the slice due to the filtering inside the for loop
+}
+
+func convertMiniblockMetadata(miniblockMetadata *MiniblockMetadataV2) []*MiniblockMetadata {
+	result := make([]*MiniblockMetadata, 0, len(miniblockMetadata.MiniblocksInfo))
+	for _, mbInfo := range miniblockMetadata.MiniblocksInfo {
+		mbv1 := &MiniblockMetadata{
+			SourceShardID:                     miniblockMetadata.SourceShardID,
+			DestinationShardID:                miniblockMetadata.DestinationShardID,
+			Round:                             mbInfo.Round,
+			HeaderNonce:                       mbInfo.HeaderNonce,
+			HeaderHash:                        mbInfo.HeaderHash,
+			MiniblockHash:                     miniblockMetadata.MiniblockHash,
+			Epoch:                             mbInfo.Epoch,
+			NotarizedAtSourceInMetaNonce:      mbInfo.NotarizedAtSourceInMetaNonce,
+			NotarizedAtDestinationInMetaNonce: mbInfo.NotarizedAtDestinationInMetaNonce,
+			NotarizedAtSourceInMetaHash:       mbInfo.NotarizedAtSourceInMetaHash,
+			NotarizedAtDestinationInMetaHash:  mbInfo.NotarizedAtDestinationInMetaHash,
+			Type:                              miniblockMetadata.Type,
+		}
+
+		result = append(result, mbv1)
+	}
+
+	return result
+}
+
+func findTxHashInMiniblockMetadataOnBlock(mbInfo *MiniblockMetadataOnBlock, txHash []byte) bool {
+	if len(mbInfo.TxHashesWhenPartial) == 0 {
+		return true
+	}
+
+	for _, executedTxHash := range mbInfo.TxHashesWhenPartial {
+		if bytes.Equal(executedTxHash, txHash) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/dblookupext/miniblocksHandler.go
+++ b/dblookupext/miniblocksHandler.go
@@ -318,7 +318,7 @@ func (mh *miniblocksHandler) getMiniblockMetadataByTxHash(txHash []byte) (*Minib
 	}
 
 	for _, mbInfo := range miniblockMetadata.MiniblocksInfo {
-		if existsTxHashInMiniblockMetadataOnBlock(mbInfo, txHash) {
+		if hasTxHashInMiniblockMetadataOnBlock(mbInfo, txHash) {
 			miniblockMetadata.MiniblocksInfo = []*MiniblockMetadataOnBlock{mbInfo}
 			mbData := convertMiniblockMetadataV1ToV2(miniblockMetadata)
 			return mbData[0], nil
@@ -353,7 +353,7 @@ func convertMiniblockMetadataV1ToV2(miniblockMetadata *MiniblockMetadataV2) []*M
 	return result
 }
 
-func existsTxHashInMiniblockMetadataOnBlock(mbInfo *MiniblockMetadataOnBlock, txHash []byte) bool {
+func hasTxHashInMiniblockMetadataOnBlock(mbInfo *MiniblockMetadataOnBlock, txHash []byte) bool {
 	if len(mbInfo.TxHashesWhenPartial) == 0 {
 		return true
 	}

--- a/dblookupext/miniblocksHandler.go
+++ b/dblookupext/miniblocksHandler.go
@@ -289,17 +289,21 @@ func (mh *miniblocksHandler) loadAllExistingMiniblocksMetadata(miniblockHash []b
 }
 
 func (mh *miniblocksHandler) getMiniblockMetadataByMiniblockHash(miniblockHash []byte) ([]*MiniblockMetadata, error) {
-	epoch, err := mh.epochIndex.getEpochByHash(miniblockHash)
-	if err != nil {
-		return nil, err
-	}
-
-	miniblockMetadata, err := mh.loadAllExistingMiniblocksMetadata(miniblockHash, epoch)
+	miniblockMetadata, err := mh.retrieveMiniblockMetadata(miniblockHash)
 	if err != nil {
 		return nil, err
 	}
 
 	return convertMiniblockMetadata(miniblockMetadata), nil
+}
+
+func (mh *miniblocksHandler) retrieveMiniblockMetadata(miniblockHash []byte) (*MiniblockMetadataV2, error) {
+	epoch, err := mh.epochIndex.getEpochByHash(miniblockHash)
+	if err != nil {
+		return nil, err
+	}
+
+	return mh.loadAllExistingMiniblocksMetadata(miniblockHash, epoch)
 }
 
 func (mh *miniblocksHandler) getMiniblockMetadataByTxHash(txHash []byte) (*MiniblockMetadata, error) {
@@ -308,12 +312,7 @@ func (mh *miniblocksHandler) getMiniblockMetadataByTxHash(txHash []byte) (*Minib
 		return nil, err
 	}
 
-	epoch, err := mh.epochIndex.getEpochByHash(miniblockHash)
-	if err != nil {
-		return nil, err
-	}
-
-	miniblockMetadata, err := mh.loadAllExistingMiniblocksMetadata(miniblockHash, epoch)
+	miniblockMetadata, err := mh.retrieveMiniblockMetadata(miniblockHash)
 	if err != nil {
 		return nil, err
 	}

--- a/dblookupext/miniblocksHandler_test.go
+++ b/dblookupext/miniblocksHandler_test.go
@@ -30,9 +30,9 @@ func createMockMiniblocksHandler() *miniblocksHandler {
 	}
 }
 
-func checkTxs(miniblockHashByTxHashIndexStorer storage.Storer, epoch uint32, txHashes [][]byte, miniblockHash []byte) error {
+func checkTxs(miniblockHashByTxHashIndexStorer storage.Storer, txHashes [][]byte, miniblockHash []byte) error {
 	for _, txHash := range txHashes {
-		value, err := miniblockHashByTxHashIndexStorer.GetFromEpoch(txHash, epoch)
+		value, err := miniblockHashByTxHashIndexStorer.Get(txHash)
 		if err != nil {
 			return fmt.Errorf("%w for hash %s", err, txHash)
 		}
@@ -146,16 +146,13 @@ func TestMiniblocksHandler_blockCommitted(t *testing.T) {
 		mbHandler := createMockMiniblocksHandler()
 
 		header := generateHeader(37, 22933, *completeMiniblockHeader)
-		body := &block.Body{
-			MiniBlocks: []*block.MiniBlock{completeMiniblock},
-		}
 		headerHash, err := core.CalculateHash(testMarshaller, testHasher, header)
 		assert.Nil(t, err)
 
-		// commit header with completed miniblock and check everything was written
-		err = mbHandler.blockCommitted(header, body)
+		// commit the completed miniblock and check everything was written
+		err = mbHandler.commitMiniblock(header, headerHash, completeMiniblock)
 		assert.Nil(t, err)
-		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header.GetEpoch(), completeMiniblock.TxHashes, completeMiniblockHash)
+		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, completeMiniblock.TxHashes, completeMiniblockHash)
 		assert.Nil(t, err)
 		err = checkMiniblockHashInEpoch(mbHandler.epochIndex, completeMiniblockHash, header.Epoch)
 		assert.Nil(t, err)
@@ -185,38 +182,29 @@ func TestMiniblocksHandler_blockCommitted(t *testing.T) {
 		mbHandler := createMockMiniblocksHandler()
 
 		header1 := generateHeader(37, 22933, *completeMiniblockHeader, *partialMiniblockHeaders[0])
-		body1 := &block.Body{
-			MiniBlocks: []*block.MiniBlock{
-				completeMiniblock,
-				partialMiniblock,
-			},
-		}
 		headerHash1, err := core.CalculateHash(testMarshaller, testHasher, header1)
 		assert.Nil(t, err)
 
 		header2 := generateHeader(37, 22934, *partialMiniblockHeaders[1])
-		body2 := &block.Body{
-			MiniBlocks: []*block.MiniBlock{
-				partialMiniblock,
-			},
-		}
 		headerHash2, err := core.CalculateHash(testMarshaller, testHasher, header2)
 		assert.Nil(t, err)
 
-		// commit header1 with completed miniblock and check all transactions from that block were written
-		err = mbHandler.blockCommitted(header1, body1)
+		// commit header1 with completed miniblocks and check all transactions from that block were written
+		err = mbHandler.commitMiniblock(header1, headerHash1, completeMiniblock)
 		assert.Nil(t, err)
-		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), partialMiniblock.TxHashes[0:2], partialMiniblockHash)
+		err = mbHandler.commitMiniblock(header1, headerHash1, partialMiniblock)
 		assert.Nil(t, err)
-		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), completeMiniblock.TxHashes, completeMiniblockHash)
+		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, partialMiniblock.TxHashes[0:2], partialMiniblockHash)
+		assert.Nil(t, err)
+		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, completeMiniblock.TxHashes, completeMiniblockHash)
 		assert.Nil(t, err)
 
-		// commit header2 with completed miniblock and check all transactions from header 2 and header 1 were written
-		err = mbHandler.blockCommitted(header2, body2)
+		// commit header2 with patial miniblock and check all transactions from header 2 and header 1 were written
+		err = mbHandler.commitMiniblock(header2, headerHash2, partialMiniblock)
 		assert.Nil(t, err)
-		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), completeMiniblock.TxHashes, completeMiniblockHash)
+		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, completeMiniblock.TxHashes, completeMiniblockHash)
 		assert.Nil(t, err)
-		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), partialMiniblock.TxHashes[0:4], partialMiniblockHash)
+		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, partialMiniblock.TxHashes[0:4], partialMiniblockHash)
 		assert.Nil(t, err)
 
 		// check the miniblock hashes were written correctly
@@ -278,56 +266,42 @@ func TestMiniblocksHandler_blockCommitted(t *testing.T) {
 		mbHandler := createMockMiniblocksHandler()
 
 		header1 := generateHeader(37, 22933, *completeMiniblockHeader, *partialMiniblockHeaders[0])
-		body1 := &block.Body{
-			MiniBlocks: []*block.MiniBlock{
-				completeMiniblock,
-				partialMiniblock,
-			},
-		}
 		headerHash1, err := core.CalculateHash(testMarshaller, testHasher, header1)
 		assert.Nil(t, err)
 
 		header2 := generateHeader(37, 22934, *partialMiniblockHeaders[1])
-		body2 := &block.Body{
-			MiniBlocks: []*block.MiniBlock{
-				partialMiniblock,
-			},
-		}
 		headerHash2, err := core.CalculateHash(testMarshaller, testHasher, header2)
 		assert.Nil(t, err)
 
 		header3 := generateHeader(38, 22935, *partialMiniblockHeaders[2])
-		body3 := &block.Body{
-			MiniBlocks: []*block.MiniBlock{
-				partialMiniblock,
-			},
-		}
 		headerHash3, err := core.CalculateHash(testMarshaller, testHasher, header3)
 		assert.Nil(t, err)
 
 		// commit header1 with completed miniblock and check all transactions from that block were written
-		err = mbHandler.blockCommitted(header1, body1)
+		err = mbHandler.commitMiniblock(header1, headerHash1, completeMiniblock)
 		assert.Nil(t, err)
-		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), partialMiniblock.TxHashes[0:2], partialMiniblockHash)
+		err = mbHandler.commitMiniblock(header1, headerHash1, partialMiniblock)
 		assert.Nil(t, err)
-
-		// commit header2 with completed miniblock and check all transactions from header 2 and header 1 were written
-		err = mbHandler.blockCommitted(header2, body2)
-		assert.Nil(t, err)
-		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), completeMiniblock.TxHashes, completeMiniblockHash)
-		assert.Nil(t, err)
-		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), partialMiniblock.TxHashes[0:4], partialMiniblockHash)
+		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, partialMiniblock.TxHashes[0:2], partialMiniblockHash)
 		assert.Nil(t, err)
 
-		// commit header3 with completed miniblock and check all transactions from header 3, header 2 and header 1 were written in
+		// commit header2 with partial miniblock and check all transactions from header 2 and header 1 were written
+		err = mbHandler.commitMiniblock(header2, headerHash2, partialMiniblock)
+		assert.Nil(t, err)
+		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, completeMiniblock.TxHashes, completeMiniblockHash)
+		assert.Nil(t, err)
+		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, partialMiniblock.TxHashes[0:4], partialMiniblockHash)
+		assert.Nil(t, err)
+
+		// commit header3 with partial miniblock and check all transactions from header 3, header 2 and header 1 were written in
 		// the correct epochs
-		err = mbHandler.blockCommitted(header3, body3)
+		err = mbHandler.commitMiniblock(header3, headerHash3, partialMiniblock)
 		assert.Nil(t, err)
-		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), completeMiniblock.TxHashes, completeMiniblockHash)
+		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, completeMiniblock.TxHashes, completeMiniblockHash)
 		assert.Nil(t, err)
-		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), partialMiniblock.TxHashes[0:4], partialMiniblockHash)
+		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, partialMiniblock.TxHashes[0:4], partialMiniblockHash)
 		assert.Nil(t, err)
-		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header3.GetEpoch(), partialMiniblock.TxHashes[5:6], partialMiniblockHash)
+		err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, partialMiniblock.TxHashes[5:6], partialMiniblockHash)
 		assert.Nil(t, err)
 
 		// check the miniblock hashes were written correctly
@@ -527,12 +501,16 @@ func TestMiniblocksHandler_blockCommittedAndBlockReverted(t *testing.T) {
 			partialMiniblock,
 		},
 	}
+	headerHash3, err := core.CalculateHash(testMarshaller, testHasher, header3)
+	assert.Nil(t, err)
 
-	err = mbHandler.blockCommitted(header1, body1)
+	err = mbHandler.commitMiniblock(header1, headerHash1, completeMiniblock)
 	assert.Nil(t, err)
-	err = mbHandler.blockCommitted(header2, body2)
+	err = mbHandler.commitMiniblock(header1, headerHash1, partialMiniblock)
 	assert.Nil(t, err)
-	err = mbHandler.blockCommitted(header3, body3)
+	err = mbHandler.commitMiniblock(header2, headerHash2, partialMiniblock)
+	assert.Nil(t, err)
+	err = mbHandler.commitMiniblock(header3, headerHash3, partialMiniblock)
 	assert.Nil(t, err)
 
 	//we set the current epochs in storers, this will not be necessary when implementing RemoveFromEpoch
@@ -544,11 +522,11 @@ func TestMiniblocksHandler_blockCommittedAndBlockReverted(t *testing.T) {
 	err = mbHandler.blockReverted(header3, body3)
 	assert.Nil(t, err)
 
-	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), completeMiniblock.TxHashes, completeMiniblockHash)
+	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, completeMiniblock.TxHashes, completeMiniblockHash)
 	assert.Nil(t, err)
-	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), partialMiniblock.TxHashes[0:4], partialMiniblockHash)
+	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, partialMiniblock.TxHashes[0:4], partialMiniblockHash)
 	assert.Nil(t, err)
-	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header3.GetEpoch(), partialMiniblock.TxHashes[5:6], partialMiniblockHash)
+	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, partialMiniblock.TxHashes[5:6], partialMiniblockHash)
 	assert.NotNil(t, err) // these were reverted
 
 	// check the miniblock hashes were written correctly
@@ -620,11 +598,11 @@ func TestMiniblocksHandler_blockCommittedAndBlockReverted(t *testing.T) {
 	err = mbHandler.blockReverted(header2, body2)
 	assert.Nil(t, err)
 
-	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), completeMiniblock.TxHashes, completeMiniblockHash)
+	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, completeMiniblock.TxHashes, completeMiniblockHash)
 	assert.Nil(t, err)
-	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), partialMiniblock.TxHashes[0:4], partialMiniblockHash)
+	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, partialMiniblock.TxHashes[0:4], partialMiniblockHash)
 	assert.NotNil(t, err) // these were reverted
-	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header3.GetEpoch(), partialMiniblock.TxHashes[5:6], partialMiniblockHash)
+	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, partialMiniblock.TxHashes[5:6], partialMiniblockHash)
 	assert.NotNil(t, err) // these were reverted
 
 	// check the miniblock hashes were written correctly
@@ -668,11 +646,11 @@ func TestMiniblocksHandler_blockCommittedAndBlockReverted(t *testing.T) {
 	err = mbHandler.blockReverted(header1, body1)
 	assert.Nil(t, err)
 
-	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), completeMiniblock.TxHashes, completeMiniblockHash)
+	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, completeMiniblock.TxHashes, completeMiniblockHash)
 	assert.NotNil(t, err) // these were reverted
-	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header1.GetEpoch(), partialMiniblock.TxHashes[0:4], partialMiniblockHash)
+	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, partialMiniblock.TxHashes[0:4], partialMiniblockHash)
 	assert.NotNil(t, err) // these were reverted
-	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, header3.GetEpoch(), partialMiniblock.TxHashes[5:6], partialMiniblockHash)
+	err = checkTxs(mbHandler.miniblockHashByTxHashIndexStorer, partialMiniblock.TxHashes[5:6], partialMiniblockHash)
 	assert.NotNil(t, err) // these were reverted
 
 	// check the miniblock hashes are not present anymore
@@ -693,4 +671,116 @@ func TestMiniblocksHandler_blockCommittedAndBlockReverted(t *testing.T) {
 	recoveredMetadata, err = mbHandler.loadExistingMiniblocksMetadata(partialMiniblockHash, header3.GetEpoch())
 	assert.Nil(t, err)
 	assert.Equal(t, &MiniblockMetadataV2{}, recoveredMetadata) // revert occurred in epoch 38
+}
+
+func TestMiniblocksHandler_getMiniblockMetadataByTxHash(t *testing.T) {
+	t.Parallel()
+
+	completeMiniblock, completeMiniblockHash, completeMiniblockHeader := generateTestCompletedMiniblock()
+	partialMiniblock, partialMiniblockHash, partialMiniblockHeaders := generateTestPartialMiniblock()
+
+	mbHandler := createMockMiniblocksHandler()
+
+	header1 := generateHeader(37, 22933, *completeMiniblockHeader, *partialMiniblockHeaders[0])
+	headerHash1, err := core.CalculateHash(testMarshaller, testHasher, header1)
+	assert.Nil(t, err)
+
+	header2 := generateHeader(37, 22934, *partialMiniblockHeaders[1])
+	headerHash2, err := core.CalculateHash(testMarshaller, testHasher, header2)
+	assert.Nil(t, err)
+
+	header3 := generateHeader(38, 22935, *partialMiniblockHeaders[2])
+	headerHash3, err := core.CalculateHash(testMarshaller, testHasher, header3)
+	assert.Nil(t, err)
+
+	err = mbHandler.commitMiniblock(header1, headerHash1, completeMiniblock)
+	assert.Nil(t, err)
+
+	err = mbHandler.commitMiniblock(header1, headerHash1, partialMiniblock)
+	assert.Nil(t, err)
+
+	completedExecutedMiniblock := &MiniblockMetadata{
+		Round:         23033,
+		HeaderNonce:   22933,
+		HeaderHash:    headerHash1,
+		MiniblockHash: completeMiniblockHash,
+		Epoch:         37,
+	}
+	//all completed txs should return the completed miniblock
+	for _, txHash := range completeMiniblock.TxHashes {
+		mb, errGet := mbHandler.getMiniblockMetadataByTxHash(txHash)
+		assert.Nil(t, errGet)
+		assert.Equal(t, completedExecutedMiniblock, mb)
+	}
+
+	partiallyExecutedMiniblock1 := &MiniblockMetadata{
+		Round:         23033,
+		HeaderNonce:   22933,
+		HeaderHash:    headerHash1,
+		MiniblockHash: partialMiniblockHash,
+		Epoch:         37,
+	}
+	//the partial executed txs should return the partial miniblock
+	for i := partialMiniblockHeaders[0].GetIndexOfFirstTxProcessed(); i <= partialMiniblockHeaders[0].GetIndexOfLastTxProcessed(); i++ {
+		txHash := partialMiniblock.TxHashes[i]
+		mb, errGet := mbHandler.getMiniblockMetadataByTxHash(txHash)
+		assert.Nil(t, errGet)
+		assert.Equal(t, partiallyExecutedMiniblock1, mb)
+	}
+	//a transaction from the second partially executed miniblock should return error
+	indexForNotFound := partialMiniblockHeaders[1].GetIndexOfFirstTxProcessed()
+	txHashNotFound := partialMiniblock.TxHashes[indexForNotFound]
+	mb, errGet := mbHandler.getMiniblockMetadataByTxHash(txHashNotFound)
+	assert.NotNil(t, errGet)
+	assert.Nil(t, mb)
+
+	err = mbHandler.commitMiniblock(header2, headerHash2, partialMiniblock)
+	assert.Nil(t, err)
+	err = mbHandler.commitMiniblock(header3, headerHash3, partialMiniblock)
+	assert.Nil(t, err)
+
+	//we set the current epochs in storers, this will not be necessary when implementing RemoveFromEpoch
+	mbHandler.miniblocksMetadataStorer.(*genericMocks.StorerMock).SetCurrentEpoch(header3.Epoch)
+
+	//all completed txs should return the completed miniblock
+	for _, txHash := range completeMiniblock.TxHashes {
+		mb, errGet = mbHandler.getMiniblockMetadataByTxHash(txHash)
+		assert.Nil(t, errGet)
+		assert.Equal(t, completedExecutedMiniblock, mb)
+	}
+	//the partial executed txs should return the partial miniblock
+	for i := partialMiniblockHeaders[0].GetIndexOfFirstTxProcessed(); i <= partialMiniblockHeaders[0].GetIndexOfLastTxProcessed(); i++ {
+		txHash := partialMiniblock.TxHashes[i]
+		mb, errGet = mbHandler.getMiniblockMetadataByTxHash(txHash)
+		assert.Nil(t, errGet)
+		assert.Equal(t, partiallyExecutedMiniblock1, mb)
+	}
+
+	partiallyExecutedMiniblock2 := &MiniblockMetadata{
+		Round:         23034,
+		HeaderNonce:   22934,
+		HeaderHash:    headerHash2,
+		MiniblockHash: partialMiniblockHash,
+		Epoch:         37,
+	}
+	partiallyExecutedMiniblock3 := &MiniblockMetadata{
+		Round:         23035,
+		HeaderNonce:   22935,
+		HeaderHash:    headerHash3,
+		MiniblockHash: partialMiniblockHash,
+		Epoch:         38,
+	}
+	//the partial executed txs should return the partial miniblock
+	for i := partialMiniblockHeaders[1].GetIndexOfFirstTxProcessed(); i <= partialMiniblockHeaders[1].GetIndexOfLastTxProcessed(); i++ {
+		txHash := partialMiniblock.TxHashes[i]
+		mb, errGet = mbHandler.getMiniblockMetadataByTxHash(txHash)
+		assert.Nil(t, errGet)
+		assert.Equal(t, partiallyExecutedMiniblock2, mb)
+	}
+	for i := partialMiniblockHeaders[2].GetIndexOfFirstTxProcessed(); i <= partialMiniblockHeaders[2].GetIndexOfLastTxProcessed(); i++ {
+		txHash := partialMiniblock.TxHashes[i]
+		mb, errGet = mbHandler.getMiniblockMetadataByTxHash(txHash)
+		assert.Nil(t, errGet)
+		assert.Equal(t, partiallyExecutedMiniblock3, mb)
+	}
 }

--- a/dblookupext/miniblocksHandler_test.go
+++ b/dblookupext/miniblocksHandler_test.go
@@ -673,7 +673,7 @@ func TestMiniblocksHandler_blockCommittedAndBlockReverted(t *testing.T) {
 	assert.Equal(t, &MiniblockMetadataV2{}, recoveredMetadata) // revert occurred in epoch 38
 }
 
-func TestMiniblocksHandler_getMiniblockMetadataByTxHash(t *testing.T) {
+func TestMiniblocksHandler_getMiniblockMetadataByTxHashAndMbHash(t *testing.T) {
 	t.Parallel()
 
 	completeMiniblock, completeMiniblockHash, completeMiniblockHeader := generateTestCompletedMiniblock()
@@ -783,4 +783,12 @@ func TestMiniblocksHandler_getMiniblockMetadataByTxHash(t *testing.T) {
 		assert.Nil(t, errGet)
 		assert.Equal(t, partiallyExecutedMiniblock3, mb)
 	}
+
+	miniblocksMetadata, err := mbHandler.getMiniblockMetadataByMiniblockHash(completeMiniblockHash)
+	assert.Nil(t, err)
+	assert.Equal(t, []*MiniblockMetadata{completedExecutedMiniblock}, miniblocksMetadata)
+
+	miniblocksMetadata, err = mbHandler.getMiniblockMetadataByMiniblockHash(partialMiniblockHash)
+	assert.Nil(t, err)
+	assert.Equal(t, []*MiniblockMetadata{partiallyExecutedMiniblock1, partiallyExecutedMiniblock2, partiallyExecutedMiniblock3}, miniblocksMetadata)
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- implemented `getMiniblockMetadataByMiniblockHash` and `getMiniblockMetadataByTxHash` in the `miniblocksHandler`
- identified parts in `historyRepository` that will change in the upcoming PRs
  
## Proposed changes
- 
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
