### PR TITLE
get last epoch from epoch start trigger info

### DIFF
--- a/process/sync/storageBootstrap/baseStorageBootstrapper.go
+++ b/process/sync/storageBootstrap/baseStorageBootstrapper.go
@@ -395,16 +395,16 @@ func (st *storageBootstrapper) applyBootInfos(bootInfos []bootstrapStorage.Boots
 		st.forkDetector.SetFinalToLastCheckpoint()
 	}
 
-	lastEpoch := bootInfos[0].GetLastHeader().Epoch
-	err = st.nodesCoordinator.LoadState(bootInfos[0].NodesCoordinatorConfigKey, lastEpoch)
-	if err != nil {
-		log.Debug("cannot load nodes coordinator state", "error", err.Error())
-		return err
-	}
-
 	err = st.epochStartTrigger.LoadState(bootInfos[0].EpochStartTriggerConfigKey)
 	if err != nil {
 		log.Debug("cannot load epoch start trigger state", "error", err.Error())
+		return err
+	}
+
+	lastEpoch := st.epochStartTrigger.MetaEpoch()
+	err = st.nodesCoordinator.LoadState(bootInfos[0].NodesCoordinatorConfigKey, lastEpoch)
+	if err != nil {
+		log.Debug("cannot load nodes coordinator state", "error", err.Error())
 		return err
 	}
 


### PR DESCRIPTION
## Reasoning behind the pull request
- Get last epoch from metachain epoch start trigger info, instead of last header from shard boostrap info
- the issue was happening when shuffling out and moving to another shard 
 
## Testing procedure
- Standard testing procedure

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
