### PR TITLE
Outgoing operations pool

### DIFF
--- a/cmd/sovereignnode/config/sovereignConfig.toml
+++ b/cmd/sovereignnode/config/sovereignConfig.toml
@@ -30,6 +30,10 @@
     MainChainNotarizationStartRound = 11
 
 [OutgoingSubscribedEvents]
+    # Time to wait in seconds for outgoing operations that need to be bridged from sovereign chain to main chain.
+    # If no confirmation of bridged data is received after this time, next leader should retry sending data.
+    TimeToWaitForUnconfirmedOutGoingOperation = 30
+
     SubscribedEvents = [
     { Identifier = "bridgeOps", Addresses = ["erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"] }
 ]

--- a/cmd/sovereignnode/config/sovereignConfig.toml
+++ b/cmd/sovereignnode/config/sovereignConfig.toml
@@ -32,7 +32,7 @@
 [OutgoingSubscribedEvents]
     # Time to wait in seconds for outgoing operations that need to be bridged from sovereign chain to main chain.
     # If no confirmation of bridged data is received after this time, next leader should retry sending data.
-    TimeToWaitForUnconfirmedOutGoingOperation = 30
+    TimeToWaitForUnconfirmedOutGoingOperationInSeconds = 30
 
     SubscribedEvents = [
     { Identifier = "bridgeOps", Addresses = ["erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"] }

--- a/cmd/sovereignnode/go.mod
+++ b/cmd/sovereignnode/go.mod
@@ -6,7 +6,7 @@ go 1.20
 
 require (
 	github.com/google/gops v0.3.18
-	github.com/multiversx/mx-chain-core-go v1.2.17-0.20230929122110-e9bafb263bce
+	github.com/multiversx/mx-chain-core-go v1.2.17-0.20231027082845-8a2f422bfd1f
 	github.com/multiversx/mx-chain-go v1.5.13-0.20230814094948-35b80bdeb23e
 	github.com/multiversx/mx-chain-logger-go v1.0.13
 	github.com/multiversx/mx-chain-sovereign-notifier-go v0.0.0-20230929085947-df9b345f49ac

--- a/cmd/sovereignnode/go.mod
+++ b/cmd/sovereignnode/go.mod
@@ -6,7 +6,7 @@ go 1.20
 
 require (
 	github.com/google/gops v0.3.18
-	github.com/multiversx/mx-chain-core-go v1.2.17-0.20231027082845-8a2f422bfd1f
+	github.com/multiversx/mx-chain-core-go v1.2.17-0.20231101112442-37c38cea0b1f
 	github.com/multiversx/mx-chain-go v1.5.13-0.20230814094948-35b80bdeb23e
 	github.com/multiversx/mx-chain-logger-go v1.0.13
 	github.com/multiversx/mx-chain-sovereign-notifier-go v0.0.0-20230929085947-df9b345f49ac

--- a/cmd/sovereignnode/go.sum
+++ b/cmd/sovereignnode/go.sum
@@ -381,8 +381,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.0.8 h1:sTx4Vmx+QCpngUFq/LF/Ka8bevlK2vMxfclE284twfc=
 github.com/multiversx/mx-chain-communication-go v1.0.8/go.mod h1:+oaUowpq+SqrEmAsMPGwhz44g7L81loWb6AiNQU9Ms4=
-github.com/multiversx/mx-chain-core-go v1.2.17-0.20231027082845-8a2f422bfd1f h1:pGMdTIA9nMt7C34sOy4rp1wWX77tSiwQwyaLS3h5CR0=
-github.com/multiversx/mx-chain-core-go v1.2.17-0.20231027082845-8a2f422bfd1f/go.mod h1:BILOGHUOIG5dNNX8cgkzCNfDaVtoYrJRYcPnpxRMH84=
+github.com/multiversx/mx-chain-core-go v1.2.17-0.20231101112442-37c38cea0b1f h1:LnrRHvqqRjasG3xRRh7iRpm6rhIdfqibebcy/NdfWiw=
+github.com/multiversx/mx-chain-core-go v1.2.17-0.20231101112442-37c38cea0b1f/go.mod h1:BILOGHUOIG5dNNX8cgkzCNfDaVtoYrJRYcPnpxRMH84=
 github.com/multiversx/mx-chain-crypto-go v1.2.8 h1:wOgVlUaO5X4L8iEbFjcQcL8SZvv6WZ7LqH73BiRPhxU=
 github.com/multiversx/mx-chain-crypto-go v1.2.8/go.mod h1:fkaWKp1rbQN9wPKya5jeoRyC+c/SyN/NfggreyeBw+8=
 github.com/multiversx/mx-chain-es-indexer-go v1.4.14-0.20231005101216-4cb6f3eeaf05 h1:N/tIx299eTfwk2bv3wJT77VuMCUnh8V/30rShPxSgFU=

--- a/cmd/sovereignnode/go.sum
+++ b/cmd/sovereignnode/go.sum
@@ -381,8 +381,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.0.8 h1:sTx4Vmx+QCpngUFq/LF/Ka8bevlK2vMxfclE284twfc=
 github.com/multiversx/mx-chain-communication-go v1.0.8/go.mod h1:+oaUowpq+SqrEmAsMPGwhz44g7L81loWb6AiNQU9Ms4=
-github.com/multiversx/mx-chain-core-go v1.2.17-0.20230929122110-e9bafb263bce h1:dV53Am3PT3p3e0ksyAM0TlRiN+mSiIwB6i7j5+amv5M=
-github.com/multiversx/mx-chain-core-go v1.2.17-0.20230929122110-e9bafb263bce/go.mod h1:BILOGHUOIG5dNNX8cgkzCNfDaVtoYrJRYcPnpxRMH84=
+github.com/multiversx/mx-chain-core-go v1.2.17-0.20231027082845-8a2f422bfd1f h1:pGMdTIA9nMt7C34sOy4rp1wWX77tSiwQwyaLS3h5CR0=
+github.com/multiversx/mx-chain-core-go v1.2.17-0.20231027082845-8a2f422bfd1f/go.mod h1:BILOGHUOIG5dNNX8cgkzCNfDaVtoYrJRYcPnpxRMH84=
 github.com/multiversx/mx-chain-crypto-go v1.2.8 h1:wOgVlUaO5X4L8iEbFjcQcL8SZvv6WZ7LqH73BiRPhxU=
 github.com/multiversx/mx-chain-crypto-go v1.2.8/go.mod h1:fkaWKp1rbQN9wPKya5jeoRyC+c/SyN/NfggreyeBw+8=
 github.com/multiversx/mx-chain-es-indexer-go v1.4.14-0.20231005101216-4cb6f3eeaf05 h1:N/tIx299eTfwk2bv3wJT77VuMCUnh8V/30rShPxSgFU=

--- a/config/sovereignConfig.go
+++ b/config/sovereignConfig.go
@@ -10,7 +10,8 @@ type SovereignConfig struct {
 
 // OutgoingSubscribedEvents holds config for outgoing subscribed events
 type OutgoingSubscribedEvents struct {
-	SubscribedEvents []SubscribedEvent `toml:"SubscribedEvents"`
+	SubscribedEvents                          []SubscribedEvent `toml:"SubscribedEvents"`
+	TimeToWaitForUnconfirmedOutGoingOperation uint32            `toml:"TimeToWaitForUnconfirmedOutGoingOperation"`
 }
 
 // SubscribedEvent holds subscribed events config

--- a/config/sovereignConfig.go
+++ b/config/sovereignConfig.go
@@ -10,8 +10,8 @@ type SovereignConfig struct {
 
 // OutgoingSubscribedEvents holds config for outgoing subscribed events
 type OutgoingSubscribedEvents struct {
-	SubscribedEvents                          []SubscribedEvent `toml:"SubscribedEvents"`
-	TimeToWaitForUnconfirmedOutGoingOperation uint32            `toml:"TimeToWaitForUnconfirmedOutGoingOperation"`
+	SubscribedEvents                                   []SubscribedEvent `toml:"SubscribedEvents"`
+	TimeToWaitForUnconfirmedOutGoingOperationInSeconds uint32            `toml:"TimeToWaitForUnconfirmedOutGoingOperationInSeconds"`
 }
 
 // SubscribedEvent holds subscribed events config

--- a/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
+++ b/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
@@ -16,7 +16,7 @@ type cacheEntry struct {
 }
 
 // This is a cache which stores outgoing txs data at their specified hash.
-// Each entry in cache has an expiry time. We should Delete entries from this cache once the confirmation from the notifier
+// Each entry in cache has an expiry time. We should delete entries from this cache once the confirmation from the notifier
 // is received that the outgoing operation has been sent to main chain.
 // An unconfirmed operation is a tx data operation which has been stored in cache for longer than the time to wait for
 // unconfirmed outgoing operations.

--- a/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
+++ b/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
@@ -1,0 +1,63 @@
+package sovereign
+
+import (
+	"sync"
+	"time"
+)
+
+type cacheEntry struct {
+	data     []byte
+	expireAt time.Time
+}
+
+type outGoingOperationsPool struct {
+	mutex   sync.RWMutex
+	timeout time.Duration
+	cache   map[string]cacheEntry
+}
+
+func NewOutGoingOperationPool(expiryTime time.Duration) *outGoingOperationsPool {
+	return &outGoingOperationsPool{
+		timeout: expiryTime,
+		cache:   map[string]cacheEntry{},
+	}
+}
+
+func (op *outGoingOperationsPool) Add(hash []byte, data []byte) {
+	if _, exists := op.cache[string(hash)]; exists {
+		return
+	}
+
+	op.cache[string(hash)] = cacheEntry{
+		data:     data,
+		expireAt: time.Now().Add(op.timeout),
+	}
+}
+
+func (op *outGoingOperationsPool) Delete(hash []byte) {
+	op.mutex.Lock()
+	defer op.mutex.Unlock()
+
+	delete(op.cache, string(hash))
+}
+
+func (op *outGoingOperationsPool) Get(hash []byte) []byte {
+	op.mutex.Lock()
+	defer op.mutex.Unlock()
+
+	return op.cache[string(hash)].data
+}
+
+func (op *outGoingOperationsPool) GetUnconfirmedOperations() [][]byte {
+	ret := make([][]byte, 0)
+
+	op.mutex.Lock()
+	for _, entry := range op.cache {
+		if time.Now().After(entry.expireAt) {
+			ret = append(ret, entry.data)
+		}
+	}
+	op.mutex.Unlock()
+
+	return ret
+}

--- a/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
+++ b/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
@@ -21,6 +21,7 @@ type outGoingOperationsPool struct {
 	cache   map[string]cacheEntry
 }
 
+// NewOutGoingOperationPool creates a new outgoing operation pool able to store data with an expiry time
 func NewOutGoingOperationPool(expiryTime time.Duration) *outGoingOperationsPool {
 	log.Debug("NewOutGoingOperationPool", "time to wait for unconfirmed outgoing operations", expiryTime)
 
@@ -30,6 +31,7 @@ func NewOutGoingOperationPool(expiryTime time.Duration) *outGoingOperationsPool 
 	}
 }
 
+// Add adds the outgoing tx data at the specified hash in the internal cache
 func (op *outGoingOperationsPool) Add(hash []byte, data []byte) {
 	hashStr := string(hash)
 
@@ -46,6 +48,7 @@ func (op *outGoingOperationsPool) Add(hash []byte, data []byte) {
 	}
 }
 
+// Get returns the outgoing tx data at the specified hash
 func (op *outGoingOperationsPool) Get(hash []byte) []byte {
 	op.mutex.Lock()
 	defer op.mutex.Unlock()
@@ -53,6 +56,7 @@ func (op *outGoingOperationsPool) Get(hash []byte) []byte {
 	return op.cache[string(hash)].data
 }
 
+// Delete removes the outgoing tx data at the specified hash
 func (op *outGoingOperationsPool) Delete(hash []byte) {
 	op.mutex.Lock()
 	defer op.mutex.Unlock()
@@ -60,6 +64,10 @@ func (op *outGoingOperationsPool) Delete(hash []byte) {
 	delete(op.cache, string(hash))
 }
 
+// GetUnconfirmedOperations returns a list of unconfirmed operations.
+// An unconfirmed operation is a tx data operation which has been stored in cache for longer
+// than the time to wait for unconfirmed outgoing operations.
+// Returned list is sorted based on expiry time.
 func (op *outGoingOperationsPool) GetUnconfirmedOperations() [][]byte {
 	expiredEntries := make([]cacheEntry, 0)
 
@@ -83,6 +91,7 @@ func (op *outGoingOperationsPool) GetUnconfirmedOperations() [][]byte {
 	return ret
 }
 
+// IsInterfaceNil checks if the underlying pointer is nil
 func (op *outGoingOperationsPool) IsInterfaceNil() bool {
 	return op == nil
 }

--- a/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
+++ b/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
@@ -16,7 +16,7 @@ type cacheEntry struct {
 }
 
 // This is a cache which stores outgoing txs data at their specified hash.
-// Each entry in cache as an expiry time. We should Delete entries from this cache once the confirmation from the notifier
+// Each entry in cache has an expiry time. We should Delete entries from this cache once the confirmation from the notifier
 // is received that the outgoing operation has been sent to main chain.
 // An unconfirmed operation is a tx data operation which has been stored in cache for longer than the time to wait for
 // unconfirmed outgoing operations.

--- a/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
+++ b/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
@@ -40,18 +40,18 @@ func (op *outGoingOperationsPool) Add(hash []byte, data []byte) {
 	}
 }
 
-func (op *outGoingOperationsPool) Delete(hash []byte) {
-	op.mutex.Lock()
-	defer op.mutex.Unlock()
-
-	delete(op.cache, string(hash))
-}
-
 func (op *outGoingOperationsPool) Get(hash []byte) []byte {
 	op.mutex.Lock()
 	defer op.mutex.Unlock()
 
 	return op.cache[string(hash)].data
+}
+
+func (op *outGoingOperationsPool) Delete(hash []byte) {
+	op.mutex.Lock()
+	defer op.mutex.Unlock()
+
+	delete(op.cache, string(hash))
 }
 
 func (op *outGoingOperationsPool) GetUnconfirmedOperations() [][]byte {

--- a/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
+++ b/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
@@ -21,9 +21,6 @@ type cacheEntry struct {
 // An unconfirmed operation is a tx data operation which has been stored in cache for longer than the time to wait for
 // unconfirmed outgoing operations.
 // The leader of the next round should check if there are any unconfirmed operations and try to resend them.
-
-// TODO: [TBD] here a mechanism to check for unconfirmed operations inside the network as well in order not to double spend?
-// E.g.: are there truly unconfirmed operations or the leader is having trouble with his notifier and didn't receive the confirmation?
 type outGoingOperationsPool struct {
 	mutex   sync.RWMutex
 	timeout time.Duration

--- a/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
+++ b/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
@@ -4,7 +4,11 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	logger "github.com/multiversx/mx-chain-logger-go"
 )
+
+var log = logger.GetOrCreate("outgoing-operations-pool")
 
 type cacheEntry struct {
 	data     []byte
@@ -18,6 +22,8 @@ type outGoingOperationsPool struct {
 }
 
 func NewOutGoingOperationPool(expiryTime time.Duration) *outGoingOperationsPool {
+	log.Debug("NewOutGoingOperationPool", "time to wait for unconfirmed outgoing operations", expiryTime)
+
 	return &outGoingOperationsPool{
 		timeout: expiryTime,
 		cache:   map[string]cacheEntry{},

--- a/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
+++ b/dataRetriever/dataPool/sovereign/outGoingOperationPool.go
@@ -15,6 +15,15 @@ type cacheEntry struct {
 	expireAt time.Time
 }
 
+// This is a cache which stores outgoing txs data at their specified hash.
+// Each entry in cache as an expiry time. We should Delete entries from this cache once the confirmation from the notifier
+// is received that the outgoing operation has been sent to main chain.
+// An unconfirmed operation is a tx data operation which has been stored in cache for longer than the time to wait for
+// unconfirmed outgoing operations.
+// The leader of the next round should check if there are any unconfirmed operations and try to resend them.
+
+// TODO: [TBD] here a mechanism to check for unconfirmed operations inside the network as well in order not to double spend?
+// E.g.: are there truly unconfirmed operations or the leader is having trouble with his notifier and didn't receive the confirmation?
 type outGoingOperationsPool struct {
 	mutex   sync.RWMutex
 	timeout time.Duration

--- a/dataRetriever/dataPool/sovereign/outGoingOperationPool_test.go
+++ b/dataRetriever/dataPool/sovereign/outGoingOperationPool_test.go
@@ -75,7 +75,6 @@ func TestOutGoingOperationsPool_GetUnconfirmedOperations(t *testing.T) {
 	pool.Add(hash2, data2)
 
 	time.Sleep(expiryTime)
-
 	pool.Add(hash3, data3)
 	require.Equal(t, [][]byte{data1, data2}, pool.GetUnconfirmedOperations())
 
@@ -116,5 +115,6 @@ func TestOutGoingOperationsPool_ConcurrentOperations(t *testing.T) {
 		}(i)
 
 	}
+
 	wg.Wait()
 }

--- a/dataRetriever/dataPool/sovereign/outGoingOperationPool_test.go
+++ b/dataRetriever/dataPool/sovereign/outGoingOperationPool_test.go
@@ -1,0 +1,120 @@
+package sovereign
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOutGoingOperationPool(t *testing.T) {
+	t.Parallel()
+
+	pool := NewOutGoingOperationPool(time.Second)
+	require.False(t, pool.IsInterfaceNil())
+}
+
+func TestOutGoingOperationsPool_Add_Get_Delete(t *testing.T) {
+	t.Parallel()
+
+	pool := NewOutGoingOperationPool(time.Second)
+
+	hash1 := []byte("h1")
+	hash2 := []byte("h2")
+	hash3 := []byte("h3")
+
+	data1 := []byte("d1")
+	data2 := []byte("d2")
+	data3 := []byte("d3")
+
+	pool.Add(hash1, data1)
+	require.Equal(t, data1, pool.Get(hash1))
+	require.Empty(t, pool.Get(hash2))
+	require.Empty(t, pool.Get(hash3))
+
+	pool.Add(hash1, data2)
+	require.Equal(t, data1, pool.Get(hash1))
+
+	pool.Add(hash2, data2)
+	pool.Add(hash3, data3)
+
+	require.Equal(t, data1, pool.Get(hash1))
+	require.Equal(t, data2, pool.Get(hash2))
+	require.Equal(t, data3, pool.Get(hash3))
+
+	pool.Delete(hash2)
+	require.Equal(t, data1, pool.Get(hash1))
+	require.Empty(t, pool.Get(hash2))
+	require.Equal(t, data3, pool.Get(hash3))
+
+	pool.Delete(hash1)
+	pool.Delete(hash1)
+	pool.Delete(hash2)
+	require.Empty(t, pool.Get(hash1))
+	require.Empty(t, pool.Get(hash2))
+	require.Equal(t, data3, pool.Get(hash3))
+}
+
+func TestOutGoingOperationsPool_GetUnconfirmedOperations(t *testing.T) {
+	t.Parallel()
+
+	expiryTime := time.Millisecond * 100
+	pool := NewOutGoingOperationPool(expiryTime)
+
+	hash1 := []byte("h1")
+	hash2 := []byte("h2")
+	hash3 := []byte("h3")
+
+	data1 := []byte("d1")
+	data2 := []byte("d2")
+	data3 := []byte("d3")
+
+	pool.Add(hash1, data1)
+	pool.Add(hash2, data2)
+
+	time.Sleep(expiryTime)
+
+	pool.Add(hash3, data3)
+	require.Equal(t, [][]byte{data1, data2}, pool.GetUnconfirmedOperations())
+
+	time.Sleep(expiryTime)
+	require.Equal(t, [][]byte{data1, data2, data3}, pool.GetUnconfirmedOperations())
+}
+
+func TestOutGoingOperationsPool_ConcurrentOperations(t *testing.T) {
+	t.Parallel()
+
+	expiryTime := time.Millisecond * 100
+	pool := NewOutGoingOperationPool(expiryTime)
+
+	numOperations := 1000
+	wg := sync.WaitGroup{}
+	wg.Add(numOperations)
+	for i := 0; i < numOperations; i++ {
+
+		go func(index int) {
+			id := index % 4
+			hash := []byte(fmt.Sprintf("hash%d", id))
+			data := []byte(fmt.Sprintf("data%d", id))
+
+			switch id {
+			case 0:
+				pool.Add(hash, data)
+			case 1:
+				_ = pool.Get(hash)
+			case 2:
+				pool.Delete(hash)
+			case 3:
+				_ = pool.GetUnconfirmedOperations()
+			default:
+				require.Fail(t, "should not get another operation")
+			}
+
+			wg.Done()
+		}(i)
+
+	}
+	wg.Wait()
+}

--- a/dataRetriever/dataPool/sovereign/outGoingOperationPool_test.go
+++ b/dataRetriever/dataPool/sovereign/outGoingOperationPool_test.go
@@ -73,6 +73,7 @@ func TestOutGoingOperationsPool_GetUnconfirmedOperations(t *testing.T) {
 
 	pool.Add(hash1, data1)
 	pool.Add(hash2, data2)
+	require.Empty(t, pool.GetUnconfirmedOperations())
 
 	time.Sleep(expiryTime)
 	pool.Add(hash3, data3)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -658,3 +658,6 @@ var ErrNilTxPreProcessorCreator = errors.New("nil tx pre-processor creator has b
 
 // ErrNilOutgoingOperationsFormatter signals that a nil outgoing operations formatter has been provided
 var ErrNilOutgoingOperationsFormatter = errors.New("nil outgoing operations formatter has been provided")
+
+// ErrNilOutGoingOperationsPool signals that a nil outgoing operations pool has been provided
+var ErrNilOutGoingOperationsPool = errors.New("nil outgoing operations pool has been provided")

--- a/factory/processing/blockProcessorCreator.go
+++ b/factory/processing/blockProcessorCreator.go
@@ -506,11 +506,12 @@ func (pcf *processComponentsFactory) createBlockProcessor(
 			return nil, err
 		}
 
+		timeToWait := time.Second * time.Duration(pcf.config.SovereignConfig.OutgoingSubscribedEvents.TimeToWaitForUnconfirmedOutGoingOperation)
 		return block.NewSovereignChainBlockProcessor(block.ArgsSovereignChainBlockProcessor{
 			ShardProcessor:               shardProcessor,
 			ValidatorStatisticsProcessor: validatorStatisticsProcessor,
 			OutgoingOperationsFormatter:  outgoingOpFormatter,
-			OutGoingOperationsPool:       sovereignPool.NewOutGoingOperationPool(time.Second * 20),
+			OutGoingOperationsPool:       sovereignPool.NewOutGoingOperationPool(timeToWait),
 		})
 	default:
 		return nil, fmt.Errorf("%w type %v", customErrors.ErrUnimplementedChainRunType, pcf.chainRunType)

--- a/factory/processing/blockProcessorCreator.go
+++ b/factory/processing/blockProcessorCreator.go
@@ -506,7 +506,7 @@ func (pcf *processComponentsFactory) createBlockProcessor(
 			return nil, err
 		}
 
-		timeToWait := time.Second * time.Duration(pcf.config.SovereignConfig.OutgoingSubscribedEvents.TimeToWaitForUnconfirmedOutGoingOperation)
+		timeToWait := time.Second * time.Duration(pcf.config.SovereignConfig.OutgoingSubscribedEvents.TimeToWaitForUnconfirmedOutGoingOperationInSeconds)
 		return block.NewSovereignChainBlockProcessor(block.ArgsSovereignChainBlockProcessor{
 			ShardProcessor:               shardProcessor,
 			ValidatorStatisticsProcessor: validatorStatisticsProcessor,

--- a/factory/processing/blockProcessorCreator.go
+++ b/factory/processing/blockProcessorCreator.go
@@ -3,12 +3,14 @@ package processing
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	dataBlock "github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
+	sovereignPool "github.com/multiversx/mx-chain-go/dataRetriever/dataPool/sovereign"
 	debugFactory "github.com/multiversx/mx-chain-go/debug/factory"
 	"github.com/multiversx/mx-chain-go/epochStart"
 	metachainEpochStart "github.com/multiversx/mx-chain-go/epochStart/metachain"
@@ -508,6 +510,7 @@ func (pcf *processComponentsFactory) createBlockProcessor(
 			ShardProcessor:               shardProcessor,
 			ValidatorStatisticsProcessor: validatorStatisticsProcessor,
 			OutgoingOperationsFormatter:  outgoingOpFormatter,
+			OutGoingOperationsPool:       sovereignPool.NewOutGoingOperationPool(time.Second * 20),
 		})
 	default:
 		return nil, fmt.Errorf("%w type %v", customErrors.ErrUnimplementedChainRunType, pcf.chainRunType)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiversx/mx-chain-communication-go v1.0.8
-	github.com/multiversx/mx-chain-core-go v1.2.17-0.20230929122110-e9bafb263bce
+	github.com/multiversx/mx-chain-core-go v1.2.17-0.20231027082845-8a2f422bfd1f
 	github.com/multiversx/mx-chain-crypto-go v1.2.8
 	github.com/multiversx/mx-chain-es-indexer-go v1.4.14-0.20231005101216-4cb6f3eeaf05
 	github.com/multiversx/mx-chain-logger-go v1.0.13

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiversx/mx-chain-communication-go v1.0.8
-	github.com/multiversx/mx-chain-core-go v1.2.17-0.20231027082845-8a2f422bfd1f
+	github.com/multiversx/mx-chain-core-go v1.2.17-0.20231101112442-37c38cea0b1f
 	github.com/multiversx/mx-chain-crypto-go v1.2.8
 	github.com/multiversx/mx-chain-es-indexer-go v1.4.14-0.20231005101216-4cb6f3eeaf05
 	github.com/multiversx/mx-chain-logger-go v1.0.13

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.0.8 h1:sTx4Vmx+QCpngUFq/LF/Ka8bevlK2vMxfclE284twfc=
 github.com/multiversx/mx-chain-communication-go v1.0.8/go.mod h1:+oaUowpq+SqrEmAsMPGwhz44g7L81loWb6AiNQU9Ms4=
-github.com/multiversx/mx-chain-core-go v1.2.17-0.20230929122110-e9bafb263bce h1:dV53Am3PT3p3e0ksyAM0TlRiN+mSiIwB6i7j5+amv5M=
-github.com/multiversx/mx-chain-core-go v1.2.17-0.20230929122110-e9bafb263bce/go.mod h1:BILOGHUOIG5dNNX8cgkzCNfDaVtoYrJRYcPnpxRMH84=
+github.com/multiversx/mx-chain-core-go v1.2.17-0.20231027082845-8a2f422bfd1f h1:pGMdTIA9nMt7C34sOy4rp1wWX77tSiwQwyaLS3h5CR0=
+github.com/multiversx/mx-chain-core-go v1.2.17-0.20231027082845-8a2f422bfd1f/go.mod h1:BILOGHUOIG5dNNX8cgkzCNfDaVtoYrJRYcPnpxRMH84=
 github.com/multiversx/mx-chain-crypto-go v1.2.8 h1:wOgVlUaO5X4L8iEbFjcQcL8SZvv6WZ7LqH73BiRPhxU=
 github.com/multiversx/mx-chain-crypto-go v1.2.8/go.mod h1:fkaWKp1rbQN9wPKya5jeoRyC+c/SyN/NfggreyeBw+8=
 github.com/multiversx/mx-chain-es-indexer-go v1.4.14-0.20231005101216-4cb6f3eeaf05 h1:N/tIx299eTfwk2bv3wJT77VuMCUnh8V/30rShPxSgFU=

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.0.8 h1:sTx4Vmx+QCpngUFq/LF/Ka8bevlK2vMxfclE284twfc=
 github.com/multiversx/mx-chain-communication-go v1.0.8/go.mod h1:+oaUowpq+SqrEmAsMPGwhz44g7L81loWb6AiNQU9Ms4=
-github.com/multiversx/mx-chain-core-go v1.2.17-0.20231027082845-8a2f422bfd1f h1:pGMdTIA9nMt7C34sOy4rp1wWX77tSiwQwyaLS3h5CR0=
-github.com/multiversx/mx-chain-core-go v1.2.17-0.20231027082845-8a2f422bfd1f/go.mod h1:BILOGHUOIG5dNNX8cgkzCNfDaVtoYrJRYcPnpxRMH84=
+github.com/multiversx/mx-chain-core-go v1.2.17-0.20231101112442-37c38cea0b1f h1:LnrRHvqqRjasG3xRRh7iRpm6rhIdfqibebcy/NdfWiw=
+github.com/multiversx/mx-chain-core-go v1.2.17-0.20231101112442-37c38cea0b1f/go.mod h1:BILOGHUOIG5dNNX8cgkzCNfDaVtoYrJRYcPnpxRMH84=
 github.com/multiversx/mx-chain-crypto-go v1.2.8 h1:wOgVlUaO5X4L8iEbFjcQcL8SZvv6WZ7LqH73BiRPhxU=
 github.com/multiversx/mx-chain-crypto-go v1.2.8/go.mod h1:fkaWKp1rbQN9wPKya5jeoRyC+c/SyN/NfggreyeBw+8=
 github.com/multiversx/mx-chain-es-indexer-go v1.4.14-0.20231005101216-4cb6f3eeaf05 h1:N/tIx299eTfwk2bv3wJT77VuMCUnh8V/30rShPxSgFU=

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -2439,7 +2439,7 @@ func (tpn *TestProcessorNode) initBlockProcessor(stateCheckpointModulus uint) {
 			tpn.BlockProcessor, err = block.NewSovereignChainBlockProcessor(block.ArgsSovereignChainBlockProcessor{
 				ValidatorStatisticsProcessor: tpn.ValidatorStatisticsProcessor,
 				ShardProcessor:               bp,
-				OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
+				OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterMock{},
 				OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
 			})
 		} else {

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -2440,6 +2440,7 @@ func (tpn *TestProcessorNode) initBlockProcessor(stateCheckpointModulus uint) {
 				ValidatorStatisticsProcessor: tpn.ValidatorStatisticsProcessor,
 				ShardProcessor:               bp,
 				OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
+				OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolStub{},
 			})
 		} else {
 			tpn.BlockProcessor = bp

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -2440,7 +2440,7 @@ func (tpn *TestProcessorNode) initBlockProcessor(stateCheckpointModulus uint) {
 				ValidatorStatisticsProcessor: tpn.ValidatorStatisticsProcessor,
 				ShardProcessor:               bp,
 				OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
-				OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolStub{},
+				OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
 			})
 		} else {
 			tpn.BlockProcessor = bp

--- a/process/block/displayBlock.go
+++ b/process/block/displayBlock.go
@@ -226,18 +226,22 @@ func (txc *transactionCounter) displayOutGoingTxData(
 	}
 
 	lines = append(lines, display.NewLineData(false, []string{
+		"OutGoing mini block header",
 		"Hash",
 		logger.DisplayByteSlice(outGoingTxData.GetHash())}),
 	)
 	lines = append(lines, display.NewLineData(false, []string{
+		"",
 		"OutGoingTxDataHash",
 		logger.DisplayByteSlice(outGoingTxData.GetOutGoingOperationsHash())}),
 	)
 	lines = append(lines, display.NewLineData(false, []string{
+		"",
 		"AggregatedSignatureOutGoingOperations",
 		logger.DisplayByteSlice(outGoingTxData.GetAggregatedSignatureOutGoingOperations())}),
 	)
 	lines = append(lines, display.NewLineData(false, []string{
+		"",
 		"LeaderSignatureOutGoingOperations",
 		logger.DisplayByteSlice(outGoingTxData.GetLeaderSignatureOutGoingOperations())}),
 	)

--- a/process/block/displayBlock.go
+++ b/process/block/displayBlock.go
@@ -212,41 +212,35 @@ func (txc *transactionCounter) displaySovereignChainHeader(
 	header sovereignChainHeader,
 ) []*display.LineData {
 	lines = txc.displayExtendedShardHeaderHashesIncluded(lines, header.GetExtendedShardHeaderHashes())
-	lines = txc.displayOutGoingTxData(lines, header.GetOutGoingOperationHashes())
+	lines = txc.displayOutGoingTxData(lines, header.GetOutGoingMiniBlockHeaderHandler())
 
 	return lines
 }
 
 func (txc *transactionCounter) displayOutGoingTxData(
 	lines []*display.LineData,
-	outGoingTxDataHashes [][]byte,
+	outGoingTxData data.OutGoingMiniBlockHeaderHandler,
 ) []*display.LineData {
-	if len(outGoingTxDataHashes) == 0 {
+	if check.IfNil(outGoingTxData) {
 		return lines
 	}
 
-	part := "OutGoingTxDataHash"
-	for i := 0; i < len(outGoingTxDataHashes); i++ {
-		if i == 0 || i >= len(outGoingTxDataHashes)-1 {
-			lines = append(lines, display.NewLineData(false, []string{
-				part,
-				fmt.Sprintf("OutGoingTxDataHash_%d", i+1),
-				logger.DisplayByteSlice(outGoingTxDataHashes[i])}))
-
-			part = ""
-			continue
-		}
-
-		if i == 1 {
-			lines = append(lines, display.NewLineData(false, []string{
-				part,
-				"...",
-				"...",
-			}))
-
-			part = ""
-		}
-	}
+	lines = append(lines, display.NewLineData(false, []string{
+		"Hash",
+		logger.DisplayByteSlice(outGoingTxData.GetHash())}),
+	)
+	lines = append(lines, display.NewLineData(false, []string{
+		"OutGoingTxDataHash",
+		logger.DisplayByteSlice(outGoingTxData.GetOutGoingOperationsHash())}),
+	)
+	lines = append(lines, display.NewLineData(false, []string{
+		"AggregatedSignatureOutGoingOperations",
+		logger.DisplayByteSlice(outGoingTxData.GetAggregatedSignatureOutGoingOperations())}),
+	)
+	lines = append(lines, display.NewLineData(false, []string{
+		"LeaderSignatureOutGoingOperations",
+		logger.DisplayByteSlice(outGoingTxData.GetLeaderSignatureOutGoingOperations())}),
+	)
 
 	lines[len(lines)-1].HorizontalRuleAfter = true
 

--- a/process/block/displayBlock_test.go
+++ b/process/block/displayBlock_test.go
@@ -102,6 +102,54 @@ func TestDisplayBlock_DisplayMetaHashesIncluded(t *testing.T) {
 	assert.Equal(t, len(header.MetaBlockHashes), len(lines))
 }
 
+func TestDisplayBlock_DisplaySovereignChainHeader(t *testing.T) {
+	t.Parallel()
+
+	shardLines := make([]*display.LineData, 0)
+
+	extendedShardHeaderHashes := [][]byte{[]byte("hash1"), []byte("hash2"), []byte("hash3")}
+	outGoingTxDataHashes := [][]byte{[]byte("outGoingTxDataHash1"), []byte("outGoingTxDataHash2"), []byte("outGoingTxDataHash3")}
+
+	sovChainHeader := &block.SovereignChainHeader{
+		OutGoingOperationHashes:   outGoingTxDataHashes,
+		ExtendedShardHeaderHashes: extendedShardHeaderHashes,
+	}
+
+	args := createMockArgsTransactionCounter()
+	txCounter, _ := NewTransactionCounter(args)
+	lines := txCounter.displaySovereignChainHeader(
+		shardLines,
+		sovChainHeader,
+	)
+
+	require.Equal(t, []*display.LineData{
+		{
+			Values:              []string{"ExtendedShardHeaderHashes", "ExtendedShardHeaderHash_1", hex.EncodeToString(extendedShardHeaderHashes[0])},
+			HorizontalRuleAfter: false,
+		},
+		{
+			Values:              []string{"", "...", "..."},
+			HorizontalRuleAfter: false,
+		},
+		{
+			Values:              []string{"", "ExtendedShardHeaderHash_3", hex.EncodeToString(extendedShardHeaderHashes[2])},
+			HorizontalRuleAfter: true,
+		},
+		{
+			Values:              []string{"OutGoingTxDataHash", "OutGoingTxDataHash_1", hex.EncodeToString(outGoingTxDataHashes[0])},
+			HorizontalRuleAfter: false,
+		},
+		{
+			Values:              []string{"", "...", "..."},
+			HorizontalRuleAfter: false,
+		},
+		{
+			Values:              []string{"", "OutGoingTxDataHash_3", hex.EncodeToString(outGoingTxDataHashes[2])},
+			HorizontalRuleAfter: true,
+		},
+	}, lines)
+}
+
 func TestDisplayBlock_DisplayExtendedShardHeaderHashesIncluded(t *testing.T) {
 	t.Parallel()
 

--- a/process/block/displayBlock_test.go
+++ b/process/block/displayBlock_test.go
@@ -140,19 +140,19 @@ func TestDisplayBlock_DisplaySovereignChainHeader(t *testing.T) {
 			HorizontalRuleAfter: true,
 		},
 		{
-			Values:              []string{"Hash", hex.EncodeToString(outGoingMbHeader.GetHash())},
+			Values:              []string{"OutGoing mini block header", "Hash", hex.EncodeToString(outGoingMbHeader.GetHash())},
 			HorizontalRuleAfter: false,
 		},
 		{
-			Values:              []string{"OutGoingTxDataHash", hex.EncodeToString(outGoingMbHeader.GetOutGoingOperationsHash())},
+			Values:              []string{"", "OutGoingTxDataHash", hex.EncodeToString(outGoingMbHeader.GetOutGoingOperationsHash())},
 			HorizontalRuleAfter: false,
 		},
 		{
-			Values:              []string{"AggregatedSignatureOutGoingOperations", hex.EncodeToString(outGoingMbHeader.GetAggregatedSignatureOutGoingOperations())},
+			Values:              []string{"", "AggregatedSignatureOutGoingOperations", hex.EncodeToString(outGoingMbHeader.GetAggregatedSignatureOutGoingOperations())},
 			HorizontalRuleAfter: false,
 		},
 		{
-			Values:              []string{"LeaderSignatureOutGoingOperations", hex.EncodeToString(outGoingMbHeader.GetLeaderSignatureOutGoingOperations())},
+			Values:              []string{"", "LeaderSignatureOutGoingOperations", hex.EncodeToString(outGoingMbHeader.GetLeaderSignatureOutGoingOperations())},
 			HorizontalRuleAfter: true,
 		},
 	}, lines)

--- a/process/block/displayBlock_test.go
+++ b/process/block/displayBlock_test.go
@@ -108,10 +108,14 @@ func TestDisplayBlock_DisplaySovereignChainHeader(t *testing.T) {
 	shardLines := make([]*display.LineData, 0)
 
 	extendedShardHeaderHashes := [][]byte{[]byte("hash1"), []byte("hash2"), []byte("hash3")}
-	outGoingTxDataHashes := [][]byte{[]byte("outGoingTxDataHash1"), []byte("outGoingTxDataHash2"), []byte("outGoingTxDataHash3")}
-
+	outGoingMbHeader := &block.OutGoingMiniBlockHeader{
+		Hash:                                  []byte("outGoingTxDataHash"),
+		OutGoingOperationsHash:                []byte("outGoingOperationsHash"),
+		AggregatedSignatureOutGoingOperations: []byte("aggregatedSig"),
+		LeaderSignatureOutGoingOperations:     []byte("leaderSig"),
+	}
 	sovChainHeader := &block.SovereignChainHeader{
-		OutGoingOperationHashes:   outGoingTxDataHashes,
+		OutGoingMiniBlockHeader:   outGoingMbHeader,
 		ExtendedShardHeaderHashes: extendedShardHeaderHashes,
 	}
 
@@ -136,15 +140,19 @@ func TestDisplayBlock_DisplaySovereignChainHeader(t *testing.T) {
 			HorizontalRuleAfter: true,
 		},
 		{
-			Values:              []string{"OutGoingTxDataHash", "OutGoingTxDataHash_1", hex.EncodeToString(outGoingTxDataHashes[0])},
+			Values:              []string{"Hash", hex.EncodeToString(outGoingMbHeader.GetHash())},
 			HorizontalRuleAfter: false,
 		},
 		{
-			Values:              []string{"", "...", "..."},
+			Values:              []string{"OutGoingTxDataHash", hex.EncodeToString(outGoingMbHeader.GetOutGoingOperationsHash())},
 			HorizontalRuleAfter: false,
 		},
 		{
-			Values:              []string{"", "OutGoingTxDataHash_3", hex.EncodeToString(outGoingTxDataHashes[2])},
+			Values:              []string{"AggregatedSignatureOutGoingOperations", hex.EncodeToString(outGoingMbHeader.GetAggregatedSignatureOutGoingOperations())},
+			HorizontalRuleAfter: false,
+		},
+		{
+			Values:              []string{"LeaderSignatureOutGoingOperations", hex.EncodeToString(outGoingMbHeader.GetLeaderSignatureOutGoingOperations())},
 			HorizontalRuleAfter: true,
 		},
 	}, lines)

--- a/process/block/export_test.go
+++ b/process/block/export_test.go
@@ -564,3 +564,7 @@ func (bp *baseProcessor) SetNonceOfFirstCommittedBlock(nonce uint64) {
 func (schv *sovereignChainHeaderValidator) CalculateHeaderHash(headerHandler data.HeaderHandler) ([]byte, error) {
 	return schv.calculateHeaderHashFunc(headerHandler)
 }
+
+func (scbp *sovereignChainBlockProcessor) CreateAndSetOutGoingMiniBlock(headerHandler data.HeaderHandler, createdBlockBody *block.Body) error {
+	return scbp.createAndSetOutGoingMiniBlock(headerHandler, createdBlockBody)
+}

--- a/process/block/interface.go
+++ b/process/block/interface.go
@@ -38,3 +38,10 @@ type extendedShardHeaderHashesGetter interface {
 type crossNotarizer interface {
 	getLastCrossNotarizedHeaders() []bootstrapStorage.BootstrapHeaderInfo
 }
+
+type OutGoingOperationsPool interface {
+	Add(hash []byte, data []byte)
+	Get(hash []byte) []byte
+	Delete(hash []byte)
+	GetUnconfirmedOperations() [][]byte
+}

--- a/process/block/interface.go
+++ b/process/block/interface.go
@@ -31,8 +31,9 @@ type validatorStatsRootHashGetter interface {
 	GetValidatorStatsRootHash() []byte
 }
 
-type extendedShardHeaderHashesGetter interface {
+type sovereignChainHeader interface {
 	GetExtendedShardHeaderHashes() [][]byte
+	GetOutGoingOperationHashes() [][]byte
 }
 
 type crossNotarizer interface {

--- a/process/block/interface.go
+++ b/process/block/interface.go
@@ -44,4 +44,5 @@ type OutGoingOperationsPool interface {
 	Get(hash []byte) []byte
 	Delete(hash []byte)
 	GetUnconfirmedOperations() [][]byte
+	IsInterfaceNil() bool
 }

--- a/process/block/interface.go
+++ b/process/block/interface.go
@@ -33,7 +33,7 @@ type validatorStatsRootHashGetter interface {
 
 type sovereignChainHeader interface {
 	GetExtendedShardHeaderHashes() [][]byte
-	GetOutGoingOperationHashes() [][]byte
+	GetOutGoingMiniBlockHeaderHandler() data.OutGoingMiniBlockHeaderHandler
 }
 
 type crossNotarizer interface {

--- a/process/block/interface.go
+++ b/process/block/interface.go
@@ -39,6 +39,7 @@ type crossNotarizer interface {
 	getLastCrossNotarizedHeaders() []bootstrapStorage.BootstrapHeaderInfo
 }
 
+// OutGoingOperationsPool defines the behavior of a timed cache for outgoing operations
 type OutGoingOperationsPool interface {
 	Add(hash []byte, data []byte)
 	Get(hash []byte) []byte

--- a/process/block/sovereign/interface.go
+++ b/process/block/sovereign/interface.go
@@ -5,7 +5,7 @@ import "github.com/multiversx/mx-chain-core-go/data"
 // OutgoingOperationsFormatter collects relevant outgoing events for bridge from the logs and creates an outgoing data
 // that needs to be signed by validators to bridge tokens
 type OutgoingOperationsFormatter interface {
-	CreateOutgoingTxData(logs []*data.LogData) []byte
+	CreateOutgoingTxData(logs []*data.LogData) [][]byte
 	IsInterfaceNil() bool
 }
 

--- a/process/block/sovereign/interface.go
+++ b/process/block/sovereign/interface.go
@@ -2,10 +2,10 @@ package sovereign
 
 import "github.com/multiversx/mx-chain-core-go/data"
 
-// OutgoingOperationsFormatter collects relevant outgoing events for bridge from the logs and creates an outgoing data
+// OutgoingOperationsFormatter collects relevant outgoing events for bridge from the logs and creates outgoing data
 // that needs to be signed by validators to bridge tokens
 type OutgoingOperationsFormatter interface {
-	CreateOutgoingTxData(logs []*data.LogData) [][]byte
+	CreateOutgoingTxsData(logs []*data.LogData) [][]byte
 	IsInterfaceNil() bool
 }
 

--- a/process/block/sovereign/outgoingOperations.go
+++ b/process/block/sovereign/outgoingOperations.go
@@ -84,10 +84,10 @@ func checkEmptyAddresses(addresses map[string]string) error {
 
 // CreateOutgoingTxData collects relevant outgoing events(based on subscribed addresses and topics) for bridge from the
 // logs and creates an outgoing data that needs to be signed by validators to bridge tokens
-func (op *outgoingOperations) CreateOutgoingTxData(logs []*data.LogData) []byte {
+func (op *outgoingOperations) CreateOutgoingTxData(logs []*data.LogData) [][]byte {
 	outgoingEvents := op.createOutgoingEvents(logs)
 	if len(outgoingEvents) == 0 {
-		return make([]byte, 0)
+		return make([][]byte, 0)
 	}
 
 	txData := []byte(bridgeOpPrefix + "@" + fmt.Sprintf("%d", op.roundHandler.Index()))
@@ -98,7 +98,8 @@ func (op *outgoingOperations) CreateOutgoingTxData(logs []*data.LogData) []byte 
 		txData = append(txData, ev.GetData()...)
 	}
 
-	return txData
+	// TODO: Check gas limit here and split tx data in multiple batches if required
+	return [][]byte{txData}
 }
 
 func (op *outgoingOperations) createOutgoingEvents(logs []*data.LogData) []data.EventHandler {

--- a/process/block/sovereign/outgoingOperations.go
+++ b/process/block/sovereign/outgoingOperations.go
@@ -27,6 +27,7 @@ type outgoingOperations struct {
 
 // TODO: We should create a common base functionality from this component. Similar behavior is also found in
 // mx-chain-sovereign-notifier-go in the sovereignNotifier.go file. This applies for the factory as well
+// Task: MX-14721
 
 // NewOutgoingOperationsFormatter creates an outgoing operations formatter
 func NewOutgoingOperationsFormatter(subscribedEvents []SubscribedEvent, roundHandler RoundHandler) (*outgoingOperations, error) {
@@ -99,6 +100,7 @@ func (op *outgoingOperations) CreateOutgoingTxsData(logs []*data.LogData) [][]by
 	}
 
 	// TODO: Check gas limit here and split tx data in multiple batches if required
+	// Task: MX-14720
 	return [][]byte{txData}
 }
 

--- a/process/block/sovereign/outgoingOperations.go
+++ b/process/block/sovereign/outgoingOperations.go
@@ -82,9 +82,9 @@ func checkEmptyAddresses(addresses map[string]string) error {
 	return nil
 }
 
-// CreateOutgoingTxData collects relevant outgoing events(based on subscribed addresses and topics) for bridge from the
-// logs and creates an outgoing data that needs to be signed by validators to bridge tokens
-func (op *outgoingOperations) CreateOutgoingTxData(logs []*data.LogData) [][]byte {
+// CreateOutgoingTxsData collects relevant outgoing events(based on subscribed addresses and topics) for bridge from the
+// logs and creates outgoing data that needs to be signed by validators to bridge tokens
+func (op *outgoingOperations) CreateOutgoingTxsData(logs []*data.LogData) [][]byte {
 	outgoingEvents := op.createOutgoingEvents(logs)
 	if len(outgoingEvents) == 0 {
 		return make([][]byte, 0)

--- a/process/block/sovereign/outgoingOperations_test.go
+++ b/process/block/sovereign/outgoingOperations_test.go
@@ -141,7 +141,7 @@ func TestOutgoingOperations_CreateOutgoingTxData(t *testing.T) {
 		},
 	}
 
-	outgoingTxData := creator.CreateOutgoingTxData(logs)
+	outgoingTxData := creator.CreateOutgoingTxsData(logs)
 	expectedTxData := []byte("bridgeOps@123@rcv1@token1@nonce1@functionToCall1@arg1@arg2@50000@rcv2@token2@nonce2@value2@token3@nonce3@functionToCall2@arg2@40000@rcv3@token4@nonce4@functionToCall3@arg3@arg4@55000")
 	require.Equal(t, [][]byte{expectedTxData}, outgoingTxData)
 }

--- a/process/block/sovereign/outgoingOperations_test.go
+++ b/process/block/sovereign/outgoingOperations_test.go
@@ -143,5 +143,5 @@ func TestOutgoingOperations_CreateOutgoingTxData(t *testing.T) {
 
 	outgoingTxData := creator.CreateOutgoingTxData(logs)
 	expectedTxData := []byte("bridgeOps@123@rcv1@token1@nonce1@functionToCall1@arg1@arg2@50000@rcv2@token2@nonce2@value2@token3@nonce3@functionToCall2@arg2@40000@rcv3@token4@nonce4@functionToCall3@arg3@arg4@55000")
-	require.Equal(t, expectedTxData, outgoingTxData)
+	require.Equal(t, [][]byte{expectedTxData}, outgoingTxData)
 }

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -43,6 +43,7 @@ type sovereignChainBlockProcessor struct {
 	outGoingOperationsPool       OutGoingOperationsPool
 }
 
+// ArgsSovereignChainBlockProcessor is a struct placeholder for args needed to create a new sovereign chain block processor
 type ArgsSovereignChainBlockProcessor struct {
 	ShardProcessor               *shardProcessor
 	ValidatorStatisticsProcessor process.ValidatorStatisticsProcessor
@@ -880,7 +881,7 @@ func (scbp *sovereignChainBlockProcessor) setOutGoingOperation(headerHandler dat
 
 	sovereignChainHeader, ok := headerHandler.(data.SovereignChainHeaderHandler)
 	if !ok {
-		return process.ErrWrongTypeAssertion
+		return fmt.Errorf("%w in sovereignChainBlockProcessor.setOutGoingOperation", process.ErrWrongTypeAssertion)
 	}
 
 	err = sovereignChainHeader.SetOutGoingOperationHashes([][]byte{hash})

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -871,7 +871,6 @@ func (scbp *sovereignChainBlockProcessor) processSovereignBlockTransactions(
 func (scbp *sovereignChainBlockProcessor) createAndSetOutGoingMiniBlock(headerHandler data.HeaderHandler, createdBlockBody *block.Body) error {
 	logs := scbp.txCoordinator.GetAllCurrentLogs()
 	outGoingOperations := scbp.outgoingOperationsFormatter.CreateOutgoingTxsData(logs)
-	outGoingOperations = [][]byte{[]byte("bridgeOps@1234@rcv1@token1@val1"), []byte("bridgeOps@1235@rcv2@token2@val2")}
 	if len(outGoingOperations) == 0 {
 		return nil
 	}

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -869,6 +869,10 @@ func (scbp *sovereignChainBlockProcessor) processSovereignBlockTransactions(
 func (scbp *sovereignChainBlockProcessor) setOutGoingOperation(headerHandler data.HeaderHandler) error {
 	logs := scbp.txCoordinator.GetAllCurrentLogs()
 	outGoingOp := scbp.outgoingOperationsFormatter.CreateOutgoingTxData(logs)
+	if len(outGoingOp) == 0 {
+		return nil
+	}
+
 	hash, err := core.CalculateHash(scbp.marshalizer, scbp.hasher, outGoingOp)
 	if err != nil {
 		return err

--- a/process/block/sovereignChainBlock_test.go
+++ b/process/block/sovereignChainBlock_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
 	"github.com/multiversx/mx-chain-go/testscommon/sovereign"
 	"github.com/multiversx/mx-chain-go/testscommon/storage"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,11 +83,11 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ShardProcessor:               nil,
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
-			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolStub{},
+			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
 		})
 
-		assert.Nil(t, scbp)
-		assert.ErrorIs(t, err, process.ErrNilBlockProcessor)
+		require.Nil(t, scbp)
+		require.ErrorIs(t, err, process.ErrNilBlockProcessor)
 	})
 
 	t.Run("should error when validator statistics is nil", func(t *testing.T) {
@@ -100,11 +99,11 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ShardProcessor:               sp,
 			ValidatorStatisticsProcessor: nil,
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
-			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolStub{},
+			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
 		})
 
-		assert.Nil(t, scbp)
-		assert.ErrorIs(t, err, process.ErrNilValidatorStatistics)
+		require.Nil(t, scbp)
+		require.ErrorIs(t, err, process.ErrNilValidatorStatistics)
 	})
 
 	t.Run("should error when outgoing operations formatter is nil", func(t *testing.T) {
@@ -116,11 +115,11 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ShardProcessor:               sp,
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  nil,
-			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolStub{},
+			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
 		})
 
-		assert.Nil(t, scbp)
-		assert.ErrorIs(t, err, errors.ErrNilOutgoingOperationsFormatter)
+		require.Nil(t, scbp)
+		require.ErrorIs(t, err, errors.ErrNilOutgoingOperationsFormatter)
 	})
 
 	t.Run("should error when outgoing operation pool is nil", func(t *testing.T) {
@@ -148,11 +147,11 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ShardProcessor:               sp,
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
-			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolStub{},
+			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
 		})
 
-		assert.Nil(t, scbp)
-		assert.ErrorIs(t, err, process.ErrWrongTypeAssertion)
+		require.Nil(t, scbp)
+		require.ErrorIs(t, err, process.ErrWrongTypeAssertion)
 	})
 
 	t.Run("should error when type assertion to extendedShardHeaderRequestHandler fails", func(t *testing.T) {
@@ -168,11 +167,11 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ShardProcessor:               sp,
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
-			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolStub{},
+			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
 		})
 
-		assert.Nil(t, scbp)
-		assert.ErrorIs(t, err, process.ErrWrongTypeAssertion)
+		require.Nil(t, scbp)
+		require.ErrorIs(t, err, process.ErrWrongTypeAssertion)
 	})
 
 	t.Run("should work", func(t *testing.T) {
@@ -184,11 +183,11 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ShardProcessor:               sp,
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
-			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolStub{},
+			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
 		})
 
-		assert.NotNil(t, scbp)
-		assert.Nil(t, err)
+		require.NotNil(t, scbp)
+		require.Nil(t, err)
 	})
 }
 
@@ -221,7 +220,7 @@ func TestSovereignChainBlockProcessor_createAndSetOutGoingMiniBlock(t *testing.T
 	}
 
 	poolAddCt := 0
-	outGoingOperationsPool := &sovereign.OutGoingOperationsPoolStub{
+	outGoingOperationsPool := &sovereign.OutGoingOperationsPoolMock{
 		AddCalled: func(hash []byte, data []byte) {
 			defer func() {
 				poolAddCt++
@@ -259,6 +258,7 @@ func TestSovereignChainBlockProcessor_createAndSetOutGoingMiniBlock(t *testing.T
 
 	err := scbp.CreateAndSetOutGoingMiniBlock(sovChainHdr, blockBody)
 	require.Nil(t, err)
+	require.Equal(t, 2, poolAddCt)
 
 	expectedOutGoingMb := &block.MiniBlock{
 		TxHashes:        [][]byte{bridgeOp1Hash, bridgeOp2Hash},

--- a/process/block/sovereignChainBlock_test.go
+++ b/process/block/sovereignChainBlock_test.go
@@ -55,6 +55,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ShardProcessor:               nil,
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
+			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolStub{},
 		})
 
 		assert.Nil(t, scbp)
@@ -70,6 +71,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ShardProcessor:               sp,
 			ValidatorStatisticsProcessor: nil,
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
+			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolStub{},
 		})
 
 		assert.Nil(t, scbp)
@@ -85,6 +87,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ShardProcessor:               sp,
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
+			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolStub{},
 		})
 
 		assert.Nil(t, scbp)
@@ -104,6 +107,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ShardProcessor:               sp,
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
+			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolStub{},
 		})
 
 		assert.Nil(t, scbp)
@@ -133,6 +137,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ShardProcessor:               sp,
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
+			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolStub{},
 		})
 
 		assert.NotNil(t, scbp)

--- a/process/block/sovereignChainBlock_test.go
+++ b/process/block/sovereignChainBlock_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-go/dataRetriever/requestHandlers"
 	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/process"
@@ -13,6 +16,7 @@ import (
 	"github.com/multiversx/mx-chain-go/testscommon"
 	dataRetrieverMock "github.com/multiversx/mx-chain-go/testscommon/dataRetriever"
 	"github.com/multiversx/mx-chain-go/testscommon/economicsmocks"
+	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
 	"github.com/multiversx/mx-chain-go/testscommon/sovereign"
 	"github.com/multiversx/mx-chain-go/testscommon/storage"
@@ -20,17 +24,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func createSovChainBlockProcessorArgs() blproc.ArgShardProcessor {
+	shardArguments := CreateSovereignChainShardTrackerMockArguments()
+	sbt, _ := track.NewShardBlockTrack(shardArguments)
+
+	rrh, _ := requestHandlers.NewResolverRequestHandler(
+		&dataRetrieverMock.RequestersFinderStub{},
+		&mock.RequestedItemsHandlerStub{},
+		&testscommon.WhiteListHandlerStub{},
+		1,
+		0,
+		time.Second,
+	)
+
+	coreComp, dataComp, bootstrapComp, statusComp := createComponentHolderMocks()
+	coreComp.Hash = &hashingMocks.HasherMock{}
+
+	arguments := CreateMockArguments(coreComp, dataComp, bootstrapComp, statusComp)
+	arguments.BlockTracker, _ = track.NewSovereignChainShardBlockTrack(sbt)
+	arguments.RequestHandler, _ = requestHandlers.NewSovereignResolverRequestHandler(rrh)
+
+	return arguments
+}
+
 // CreateSovereignChainShardTrackerMockArguments -
 func CreateSovereignChainShardTrackerMockArguments() track.ArgShardTracker {
 	argsHeaderValidator := blproc.ArgsHeaderValidator{
-		Hasher:      &testscommon.HasherStub{},
+		Hasher:      &hashingMocks.HasherMock{},
 		Marshalizer: &marshallerMock.MarshalizerMock{},
 	}
 	headerValidator, _ := blproc.NewHeaderValidator(argsHeaderValidator)
 
 	arguments := track.ArgShardTracker{
 		ArgBaseTracker: track.ArgBaseTracker{
-			Hasher:           &testscommon.HasherStub{},
+			Hasher:           &hashingMocks.HasherMock{},
 			HeaderValidator:  headerValidator,
 			Marshalizer:      &marshallerMock.MarshalizerStub{},
 			RequestHandler:   &testscommon.ExtendedShardHeaderRequestHandlerStub{},
@@ -151,21 +178,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		shardArguments := CreateSovereignChainShardTrackerMockArguments()
-		sbt, _ := track.NewShardBlockTrack(shardArguments)
-
-		rrh, _ := requestHandlers.NewResolverRequestHandler(
-			&dataRetrieverMock.RequestersFinderStub{},
-			&mock.RequestedItemsHandlerStub{},
-			&testscommon.WhiteListHandlerStub{},
-			1,
-			0,
-			time.Second,
-		)
-
-		arguments := CreateMockArguments(createComponentHolderMocks())
-		arguments.BlockTracker, _ = track.NewSovereignChainShardBlockTrack(sbt)
-		arguments.RequestHandler, _ = requestHandlers.NewSovereignResolverRequestHandler(rrh)
+		arguments := createSovChainBlockProcessorArgs()
 		sp, _ := blproc.NewShardProcessor(arguments)
 		scbp, err := blproc.NewSovereignChainBlockProcessor(blproc.ArgsSovereignChainBlockProcessor{
 			ShardProcessor:               sp,
@@ -177,6 +190,104 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 		assert.NotNil(t, scbp)
 		assert.Nil(t, err)
 	})
+}
+
+func TestSovereignChainBlockProcessor_createAndSetOutGoingMiniBlock(t *testing.T) {
+	arguments := createSovChainBlockProcessorArgs()
+
+	expectedLogs := []*data.LogData{
+		{
+			TxHash: "txHash1",
+		},
+	}
+	arguments.TxCoordinator = &testscommon.TransactionCoordinatorMock{
+		GetAllCurrentLogsCalled: func() []*data.LogData {
+			return expectedLogs
+		},
+	}
+	bridgeOp1 := []byte("bridgeOp@123@rcv1@token1@val1")
+	bridgeOp2 := []byte("bridgeOp@124@rcv2@token2@val2")
+
+	hasher := arguments.CoreComponents.Hasher()
+	bridgeOp1Hash := hasher.Compute(string(bridgeOp1))
+	bridgeOp2Hash := hasher.Compute(string(bridgeOp2))
+	bridgeOpsHash := hasher.Compute(string(append(bridgeOp1Hash, bridgeOp2Hash...)))
+
+	outgoingOperationsFormatter := &sovereign.OutgoingOperationsFormatterStub{
+		CreateOutgoingTxDataCalled: func(logs []*data.LogData) [][]byte {
+			require.Equal(t, expectedLogs, logs)
+			return [][]byte{bridgeOp1, bridgeOp2}
+		},
+	}
+
+	poolAddCt := 0
+	outGoingOperationsPool := &sovereign.OutGoingOperationsPoolStub{
+		AddCalled: func(hash []byte, data []byte) {
+			defer func() {
+				poolAddCt++
+			}()
+
+			switch poolAddCt {
+			case 0:
+				require.Equal(t, bridgeOp1Hash, hash)
+				require.Equal(t, bridgeOp1, data)
+			case 1:
+				require.Equal(t, bridgeOp2Hash, hash)
+				require.Equal(t, bridgeOp2, data)
+			default:
+				require.Fail(t, "should not add in pool any other operation")
+			}
+		},
+	}
+
+	sp, _ := blproc.NewShardProcessor(arguments)
+	scbp, _ := blproc.NewSovereignChainBlockProcessor(blproc.ArgsSovereignChainBlockProcessor{
+		ShardProcessor:               sp,
+		ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
+		OutgoingOperationsFormatter:  outgoingOperationsFormatter,
+		OutGoingOperationsPool:       outGoingOperationsPool,
+	})
+
+	sovChainHdr := &block.SovereignChainHeader{}
+	blockBody := &block.Body{
+		MiniBlocks: []*block.MiniBlock{
+			{
+				ReceiverShardID: core.SovereignChainShardId,
+				SenderShardID:   core.MainChainShardId,
+			},
+		},
+	}
+
+	err := scbp.CreateAndSetOutGoingMiniBlock(sovChainHdr, blockBody)
+	require.Nil(t, err)
+
+	expectedOutGoingMb := &block.MiniBlock{
+		TxHashes:        [][]byte{bridgeOp1Hash, bridgeOp2Hash},
+		ReceiverShardID: core.MainChainShardId,
+		SenderShardID:   arguments.BootstrapComponents.ShardCoordinator().SelfId(),
+	}
+	expectedBlockBody := &block.Body{
+		MiniBlocks: []*block.MiniBlock{
+			{
+				ReceiverShardID: core.SovereignChainShardId,
+				SenderShardID:   core.MainChainShardId,
+			},
+			expectedOutGoingMb,
+		},
+	}
+	require.Equal(t, expectedBlockBody, blockBody)
+
+	expectedOutGoingMbHash, err := core.CalculateHash(arguments.CoreComponents.InternalMarshalizer(), hasher, expectedOutGoingMb)
+	require.Nil(t, err)
+
+	expectedSovChainHeader := &block.SovereignChainHeader{
+		OutGoingMiniBlockHeader: &block.OutGoingMiniBlockHeader{
+			Hash:                   expectedOutGoingMbHash,
+			OutGoingOperationsHash: bridgeOpsHash,
+		},
+	}
+	require.Equal(t, expectedSovChainHeader, sovChainHdr)
+
 }
 
 //TODO: More unit tests should be added. Created PR https://multiversxlabs.atlassian.net/browse/MX-14149

--- a/process/block/sovereignChainBlock_test.go
+++ b/process/block/sovereignChainBlock_test.go
@@ -287,7 +287,6 @@ func TestSovereignChainBlockProcessor_createAndSetOutGoingMiniBlock(t *testing.T
 		},
 	}
 	require.Equal(t, expectedSovChainHeader, sovChainHdr)
-
 }
 
 //TODO: More unit tests should be added. Created PR https://multiversxlabs.atlassian.net/browse/MX-14149

--- a/process/block/sovereignChainBlock_test.go
+++ b/process/block/sovereignChainBlock_test.go
@@ -249,13 +249,12 @@ func TestSovereignChainBlockProcessor_createAndSetOutGoingMiniBlock(t *testing.T
 	})
 
 	sovChainHdr := &block.SovereignChainHeader{}
+	processedMb := &block.MiniBlock{
+		ReceiverShardID: core.SovereignChainShardId,
+		SenderShardID:   core.MainChainShardId,
+	}
 	blockBody := &block.Body{
-		MiniBlocks: []*block.MiniBlock{
-			{
-				ReceiverShardID: core.SovereignChainShardId,
-				SenderShardID:   core.MainChainShardId,
-			},
-		},
+		MiniBlocks: []*block.MiniBlock{processedMb},
 	}
 
 	err := scbp.CreateAndSetOutGoingMiniBlock(sovChainHdr, blockBody)
@@ -267,13 +266,7 @@ func TestSovereignChainBlockProcessor_createAndSetOutGoingMiniBlock(t *testing.T
 		SenderShardID:   arguments.BootstrapComponents.ShardCoordinator().SelfId(),
 	}
 	expectedBlockBody := &block.Body{
-		MiniBlocks: []*block.MiniBlock{
-			{
-				ReceiverShardID: core.SovereignChainShardId,
-				SenderShardID:   core.MainChainShardId,
-			},
-			expectedOutGoingMb,
-		},
+		MiniBlocks: []*block.MiniBlock{processedMb, expectedOutGoingMb},
 	}
 	require.Equal(t, expectedBlockBody, blockBody)
 

--- a/process/block/sovereignChainBlock_test.go
+++ b/process/block/sovereignChainBlock_test.go
@@ -82,7 +82,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 		scbp, err := blproc.NewSovereignChainBlockProcessor(blproc.ArgsSovereignChainBlockProcessor{
 			ShardProcessor:               nil,
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
-			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
+			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterMock{},
 			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
 		})
 
@@ -98,7 +98,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 		scbp, err := blproc.NewSovereignChainBlockProcessor(blproc.ArgsSovereignChainBlockProcessor{
 			ShardProcessor:               sp,
 			ValidatorStatisticsProcessor: nil,
-			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
+			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterMock{},
 			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
 		})
 
@@ -130,7 +130,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 		scbp, err := blproc.NewSovereignChainBlockProcessor(blproc.ArgsSovereignChainBlockProcessor{
 			ShardProcessor:               sp,
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
-			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
+			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterMock{},
 			OutGoingOperationsPool:       nil,
 		})
 
@@ -146,7 +146,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 		scbp, err := blproc.NewSovereignChainBlockProcessor(blproc.ArgsSovereignChainBlockProcessor{
 			ShardProcessor:               sp,
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
-			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
+			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterMock{},
 			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
 		})
 
@@ -166,7 +166,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 		scbp, err := blproc.NewSovereignChainBlockProcessor(blproc.ArgsSovereignChainBlockProcessor{
 			ShardProcessor:               sp,
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
-			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
+			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterMock{},
 			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
 		})
 
@@ -182,7 +182,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 		scbp, err := blproc.NewSovereignChainBlockProcessor(blproc.ArgsSovereignChainBlockProcessor{
 			ShardProcessor:               sp,
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
-			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterStub{},
+			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterMock{},
 			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
 		})
 
@@ -212,7 +212,7 @@ func TestSovereignChainBlockProcessor_createAndSetOutGoingMiniBlock(t *testing.T
 	bridgeOp2Hash := hasher.Compute(string(bridgeOp2))
 	bridgeOpsHash := hasher.Compute(string(append(bridgeOp1Hash, bridgeOp2Hash...)))
 
-	outgoingOperationsFormatter := &sovereign.OutgoingOperationsFormatterStub{
+	outgoingOperationsFormatter := &sovereign.OutgoingOperationsFormatterMock{
 		CreateOutgoingTxDataCalled: func(logs []*data.LogData) [][]byte {
 			require.Equal(t, expectedLogs, logs)
 			return [][]byte{bridgeOp1, bridgeOp2}

--- a/testscommon/sovereign/outGoingOperationsPool.go
+++ b/testscommon/sovereign/outGoingOperationsPool.go
@@ -2,10 +2,14 @@ package sovereign
 
 // OutGoingOperationsPoolStub -
 type OutGoingOperationsPoolStub struct {
+	AddCalled func(hash []byte, data []byte)
 }
 
 // Add -
-func (stub *OutGoingOperationsPoolStub) Add(_ []byte, _ []byte) {
+func (stub *OutGoingOperationsPoolStub) Add(hash []byte, data []byte) {
+	if stub.AddCalled != nil {
+		stub.AddCalled(hash, data)
+	}
 }
 
 // Get -

--- a/testscommon/sovereign/outGoingOperationsPool.go
+++ b/testscommon/sovereign/outGoingOperationsPool.go
@@ -1,0 +1,28 @@
+package sovereign
+
+// OutGoingOperationsPoolStub -
+type OutGoingOperationsPoolStub struct {
+}
+
+// Add -
+func (stub *OutGoingOperationsPoolStub) Add(_ []byte, _ []byte) {
+}
+
+// Get -
+func (stub *OutGoingOperationsPoolStub) Get(_ []byte) []byte {
+	return nil
+}
+
+// Delete -
+func (stub *OutGoingOperationsPoolStub) Delete(_ []byte) {
+}
+
+// GetUnconfirmedOperations -
+func (stub *OutGoingOperationsPoolStub) GetUnconfirmedOperations() [][]byte {
+	return nil
+}
+
+// IsInterfaceNil -
+func (stub *OutGoingOperationsPoolStub) IsInterfaceNil() bool {
+	return stub == nil
+}

--- a/testscommon/sovereign/outGoingOperationsPool.go
+++ b/testscommon/sovereign/outGoingOperationsPool.go
@@ -1,32 +1,32 @@
 package sovereign
 
-// OutGoingOperationsPoolStub -
-type OutGoingOperationsPoolStub struct {
+// OutGoingOperationsPoolMock -
+type OutGoingOperationsPoolMock struct {
 	AddCalled func(hash []byte, data []byte)
 }
 
 // Add -
-func (stub *OutGoingOperationsPoolStub) Add(hash []byte, data []byte) {
-	if stub.AddCalled != nil {
-		stub.AddCalled(hash, data)
+func (mock *OutGoingOperationsPoolMock) Add(hash []byte, data []byte) {
+	if mock.AddCalled != nil {
+		mock.AddCalled(hash, data)
 	}
 }
 
 // Get -
-func (stub *OutGoingOperationsPoolStub) Get(_ []byte) []byte {
+func (mock *OutGoingOperationsPoolMock) Get(_ []byte) []byte {
 	return nil
 }
 
 // Delete -
-func (stub *OutGoingOperationsPoolStub) Delete(_ []byte) {
+func (mock *OutGoingOperationsPoolMock) Delete(_ []byte) {
 }
 
 // GetUnconfirmedOperations -
-func (stub *OutGoingOperationsPoolStub) GetUnconfirmedOperations() [][]byte {
+func (mock *OutGoingOperationsPoolMock) GetUnconfirmedOperations() [][]byte {
 	return nil
 }
 
 // IsInterfaceNil -
-func (stub *OutGoingOperationsPoolStub) IsInterfaceNil() bool {
-	return stub == nil
+func (mock *OutGoingOperationsPoolMock) IsInterfaceNil() bool {
+	return mock == nil
 }

--- a/testscommon/sovereign/outgoingOperationsFormatterMock.go
+++ b/testscommon/sovereign/outgoingOperationsFormatterMock.go
@@ -2,13 +2,13 @@ package sovereign
 
 import "github.com/multiversx/mx-chain-core-go/data"
 
-// OutgoingOperationsFormatterStub -
-type OutgoingOperationsFormatterStub struct {
+// OutgoingOperationsFormatterMock -
+type OutgoingOperationsFormatterMock struct {
 	CreateOutgoingTxDataCalled func(logs []*data.LogData) [][]byte
 }
 
-// CreateOutgoingTxData -
-func (stub *OutgoingOperationsFormatterStub) CreateOutgoingTxsData(logs []*data.LogData) [][]byte {
+// CreateOutgoingTxsData -
+func (stub *OutgoingOperationsFormatterMock) CreateOutgoingTxsData(logs []*data.LogData) [][]byte {
 	if stub.CreateOutgoingTxDataCalled != nil {
 		return stub.CreateOutgoingTxDataCalled(logs)
 	}
@@ -17,6 +17,6 @@ func (stub *OutgoingOperationsFormatterStub) CreateOutgoingTxsData(logs []*data.
 }
 
 // IsInterfaceNil -
-func (stub *OutgoingOperationsFormatterStub) IsInterfaceNil() bool {
+func (stub *OutgoingOperationsFormatterMock) IsInterfaceNil() bool {
 	return stub == nil
 }

--- a/testscommon/sovereign/outgoingOperationsFormatterStub.go
+++ b/testscommon/sovereign/outgoingOperationsFormatterStub.go
@@ -4,11 +4,11 @@ import "github.com/multiversx/mx-chain-core-go/data"
 
 // OutgoingOperationsFormatterStub -
 type OutgoingOperationsFormatterStub struct {
-	CreateOutgoingTxDataCalled func(logs []*data.LogData) []byte
+	CreateOutgoingTxDataCalled func(logs []*data.LogData) [][]byte
 }
 
 // CreateOutgoingTxData -
-func (stub *OutgoingOperationsFormatterStub) CreateOutgoingTxData(logs []*data.LogData) []byte {
+func (stub *OutgoingOperationsFormatterStub) CreateOutgoingTxData(logs []*data.LogData) [][]byte {
 	if stub.CreateOutgoingTxDataCalled != nil {
 		return stub.CreateOutgoingTxDataCalled(logs)
 	}

--- a/testscommon/sovereign/outgoingOperationsFormatterStub.go
+++ b/testscommon/sovereign/outgoingOperationsFormatterStub.go
@@ -8,7 +8,7 @@ type OutgoingOperationsFormatterStub struct {
 }
 
 // CreateOutgoingTxData -
-func (stub *OutgoingOperationsFormatterStub) CreateOutgoingTxData(logs []*data.LogData) [][]byte {
+func (stub *OutgoingOperationsFormatterStub) CreateOutgoingTxsData(logs []*data.LogData) [][]byte {
 	if stub.CreateOutgoingTxDataCalled != nil {
 		return stub.CreateOutgoingTxDataCalled(logs)
 	}

--- a/testscommon/transactionCoordinatorMock.go
+++ b/testscommon/transactionCoordinatorMock.go
@@ -33,10 +33,15 @@ type TransactionCoordinatorMock struct {
 	GetAllIntermediateTxsCalled                          func() map[block.Type]map[string]data.TransactionHandler
 	AddTxsFromMiniBlocksCalled                           func(miniBlocks block.MiniBlockSlice)
 	AddTransactionsCalled                                func(txHandlers []data.TransactionHandler, blockType block.Type)
+	GetAllCurrentLogsCalled                              func() []*data.LogData
 }
 
 // GetAllCurrentLogs -
 func (tcm *TransactionCoordinatorMock) GetAllCurrentLogs() []*data.LogData {
+	if tcm.GetAllCurrentLogsCalled != nil {
+		return tcm.GetAllCurrentLogsCalled()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request
- Added outgoing operations pool. This is a cache which stores outgoing txs data at their specified hash. Each entry in cache has an expiry time. We should `Delete` entries from this cache once the confirmation from the notifier is received that the outgoing operation has been sent to main chain. An unconfirmed operation is a tx data operation which has been stored in cache for longer than the time to wait for unconfirmed outgoing operations. The leader of the next round should check if there are any unconfirmed operations and try to resend them. [TBD] here a mechanism to check if the unconfirmed operations are truly missing or the leader is having trouble with his notifier and didn't receive the confirmation
  
## Proposed changes
- Integrated this pool in sovereign chain block processor.

## Testing procedure
![image](https://github.com/multiversx/mx-chain-go/assets/82832880/9a8d1dbe-84fa-4fe2-8c89-0bdb18d35561)

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
