### PR TITLE
switch to current block randomness for ordering transactions

### DIFF
--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -281,6 +281,9 @@
     # NFTStopCreateEnableEpoch represents the epoch when NFT stop create feature is enabled
     NFTStopCreateEnableEpoch = 3
 
+    # CurrentRandomnessOnSortingEnableEpoch represents the epoch when the current randomness on sorting is enabled
+    CurrentRandomnessOnSortingEnableEpoch = 4
+
     # BLSMultiSignerEnableEpoch represents the activation epoch for different types of BLS multi-signers
     BLSMultiSignerEnableEpoch = [
         { EnableEpoch = 0, Type = "no-KOSK" },

--- a/common/constants.go
+++ b/common/constants.go
@@ -994,5 +994,6 @@ const (
 	BalanceWaitingListsFlag                            core.EnableEpochFlag = "BalanceWaitingListsFlag"
 	WaitingListFixFlag                                 core.EnableEpochFlag = "WaitingListFixFlag"
 	NFTStopCreateFlag                                  core.EnableEpochFlag = "NFTStopCreateFlag"
+	CurrentRandomnessOnSortingFlag                     core.EnableEpochFlag = "CurrentRandomnessOnSortingFlag"
 	// all new flags must be added to createAllFlagsMap method, as part of enableEpochsHandler allFlagsDefined
 )

--- a/common/enablers/enableEpochsHandler.go
+++ b/common/enablers/enableEpochsHandler.go
@@ -683,6 +683,12 @@ func (handler *enableEpochsHandler) createAllFlagsMap() {
 			},
 			activationEpoch: handler.enableEpochsConfig.NFTStopCreateEnableEpoch,
 		},
+		common.CurrentRandomnessOnSortingFlag: {
+			isActiveInEpoch: func(epoch uint32) bool {
+				return epoch >= handler.enableEpochsConfig.CurrentRandomnessOnSortingEnableEpoch
+			},
+			activationEpoch: handler.enableEpochsConfig.CurrentRandomnessOnSortingEnableEpoch,
+		},
 	}
 }
 

--- a/config/epochConfig.go
+++ b/config/epochConfig.go
@@ -106,6 +106,7 @@ type EnableEpochs struct {
 	FixDelegationChangeOwnerOnAccountEnableEpoch      uint32
 	DynamicGasCostForDataTrieStorageLoadEnableEpoch   uint32
 	NFTStopCreateEnableEpoch                          uint32
+	CurrentRandomnessOnSortingEnableEpoch             uint32
 	BLSMultiSignerEnableEpoch                         []MultiSignerConfig
 }
 

--- a/integrationTests/factory/componentsHelper.go
+++ b/integrationTests/factory/componentsHelper.go
@@ -56,10 +56,13 @@ func CreateDefaultConfig(tb testing.TB) *config.Configs {
 	configs.ExternalConfig = externalConfig
 	configs.EpochConfig = epochConfig
 	configs.RoundConfig = roundConfig
+	workingDir := tb.TempDir()
+	dbDir := tb.TempDir()
+	logsDir := tb.TempDir()
 	configs.FlagsConfig = &config.ContextFlagsConfig{
-		WorkingDir:  tb.TempDir(),
-		DbDir:       "dbDir",
-		LogsDir:     "logsDir",
+		WorkingDir:  workingDir,
+		DbDir:       dbDir,
+		LogsDir:     logsDir,
 		UseLogView:  true,
 		BaseVersion: BaseVersion,
 		Version:     Version,

--- a/integrationTests/multiShard/block/executingRewardMiniblocks/executingRewardMiniblocks_test.go
+++ b/integrationTests/multiShard/block/executingRewardMiniblocks/executingRewardMiniblocks_test.go
@@ -14,6 +14,7 @@ import (
 	testBlock "github.com/multiversx/mx-chain-go/integrationTests/multiShard/block"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/state"
+	logger "github.com/multiversx/mx-chain-logger-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,6 +26,8 @@ func TestExecuteBlocksWithTransactionsAndCheckRewards(t *testing.T) {
 	if testing.Short() {
 		t.Skip("this is not a short test")
 	}
+
+	_ = logger.SetLogLevel("process:TRACE")
 
 	nodesPerShard := 4
 	nbMetaNodes := 2

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -928,7 +928,12 @@ func (mp *metaProcessor) createBlockBody(metaBlock data.HeaderHandler, haveTime 
 		"nonce", metaBlock.GetNonce(),
 	)
 
-	miniBlocks, err := mp.createMiniBlocks(haveTime, metaBlock.GetPrevRandSeed())
+	randomness := metaBlock.GetPrevRandSeed()
+	if mp.enableEpochsHandler.IsFlagEnabled(common.CurrentRandomnessOnSortingFlag) {
+		randomness = metaBlock.GetRandSeed()
+	}
+
+	miniBlocks, err := mp.createMiniBlocks(haveTime, randomness)
 	if err != nil {
 		return nil, err
 	}

--- a/process/block/preprocess/transactions.go
+++ b/process/block/preprocess/transactions.go
@@ -332,7 +332,11 @@ func (txs *transactions) ProcessBlockTransactions(
 	}
 
 	if txs.isBodyFromMe(body) {
-		return txs.processTxsFromMe(body, haveTime, header.GetPrevRandSeed())
+		randomness := header.GetPrevRandSeed()
+		if txs.enableEpochsHandler.IsFlagEnabled(common.CurrentRandomnessOnSortingFlag) {
+			randomness = header.GetRandSeed()
+		}
+		return txs.processTxsFromMe(body, haveTime, randomness)
 	}
 
 	return process.ErrInvalidBody

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -875,7 +875,12 @@ func (sp *shardProcessor) createBlockBody(shardHdr data.HeaderHandler, haveTime 
 		"nonce", shardHdr.GetNonce(),
 	)
 
-	miniBlocks, processedMiniBlocksDestMeInfo, err := sp.createMiniBlocks(haveTime, shardHdr.GetPrevRandSeed())
+	randomness := shardHdr.GetPrevRandSeed()
+	if sp.enableEpochsHandler.IsFlagEnabled(common.CurrentRandomnessOnSortingFlag) {
+		randomness = shardHdr.GetRandSeed()
+	}
+
+	miniBlocks, processedMiniBlocksDestMeInfo, err := sp.createMiniBlocks(haveTime, randomness)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- using the current randomness instead of previous randomness increases resistance against front running.
  
## Proposed changes
- switch to the current randomness for sorting transactions

## Testing procedure
- full system test
- system test with upgrade

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
