### PR TITLE
Fixed web server closing when the web server is disabled

### DIFF
--- a/api/gin/webServer.go
+++ b/api/gin/webServer.go
@@ -281,8 +281,11 @@ func (ws *webServer) Close() error {
 		ws.cancelFunc()
 	}
 
+	var err error
 	ws.Lock()
-	err := ws.httpServer.Close()
+	if !check.IfNil(ws.httpServer) {
+		err = ws.httpServer.Close()
+	}
 	ws.Unlock()
 
 	if err != nil {


### PR DESCRIPTION
## Reasoning behind the pull request
- the node can panic if it was started with `-rest-api-interface off`
  
## Proposed changes
- fixed web server closing when the web server is disabled by testing if the server is nil

## Testing procedure
- standard system test
- start a node with `-rest-api-interface off`. When the log print `application is now running` is displayed, stop the node with CTRL-C. Panic should not occur.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
