### PR TITLE
Fixed return value in the `MaxGasPriceSetGuardian` method on the disabled fee handler 

### DIFF
--- a/genesis/process/disabled/feeHandler.go
+++ b/genesis/process/disabled/feeHandler.go
@@ -49,7 +49,7 @@ func (fh *FeeHandler) ExtraGasLimitGuardedTx() uint64 {
 
 // MaxGasPriceSetGuardian returns 0
 func (fh *FeeHandler) MaxGasPriceSetGuardian() uint64 {
-	return 0
+	return math.MaxUint64
 }
 
 // MaxGasLimitPerBlock returns max uint64

--- a/testscommon/cryptoMocks/signerStub.go
+++ b/testscommon/cryptoMocks/signerStub.go
@@ -17,7 +17,11 @@ func (s *SignerStub) Sign(private crypto.PrivateKey, msg []byte) ([]byte, error)
 
 // Verify -
 func (s *SignerStub) Verify(public crypto.PublicKey, msg []byte, sig []byte) error {
-	return s.VerifyCalled(public, msg, sig)
+	if s.VerifyCalled != nil {
+		return s.VerifyCalled(public, msg, sig)
+	}
+
+	return nil
 }
 
 // IsInterfaceNil returns true if there is no value under the interface


### PR DESCRIPTION
## Reasoning behind the pull request
- bootstrap interceptors threw away SetGuardian transactions
  
## Proposed changes
- fixed the return value on `MaxGasPriceSetGuardian` method for the disabled fee handler

## Testing procedure
- standard system test, import-db testing

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
