### PR TITLE
Added new flag + readme for starting p2p prometheus dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ sudo cp protoc-gen-gogoslick /usr/bin/
 Done
 
 ## Running p2p Prometheus dashboards
-1. Start the node with `--p2p-prometheus-metrics` flag. This exposes a metrics collection at http://localhost:5001/debug/metrics/prometheus.
+1. Start the node with `--p2p-prometheus-metrics` flag. This exposes a metrics collection at http://localhost:8080/debug/metrics/prometheus (port defined by -rest-api-interface flag, default 8080)
 2. Clone libp2p repository: `git clone https://github.com/libp2p/go-libp2p`
 3. `cd go-libp2p/dasboards/swarm` and under the 
-```json  
+```  
 "templating": {
    "list": [
 ```
 section, add the following lines:
-```json
+```
 {
   "hide": 0,
   "label": "datasource",
@@ -110,7 +110,7 @@ section, add the following lines:
 ```
 sudo docker compose -f docker-compose.base.yml -f docker-compose-linux.yml up --force-recreate
 ```
-**Note:** this command is not compatible with compose v1, thus an update to v2 would be needed. More details about the migration [here](https://docs.docker.com/compose/migrate/).
+**Note:** If you choose to install the new Docker version manually, please make sure that installation is done for all users of the system. Otherwise, the docker command will fail because it needs the super-user privileges.
 6. The preconfigured dashboards should be now available on Grafana at http://localhost:3000/dashboards
 
 ## Progress

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ section, add the following lines:
 ```
 sudo docker compose -f docker-compose.base.yml -f docker-compose-linux.yml up --force-recreate
 ```
+**Note:** this command is not compatible with compose v1, thus an update to v2 would be needed. More details about the migration [here](https://docs.docker.com/compose/migrate/).
 6. The preconfigured dashboards should be now available on Grafana at http://localhost:3000/dashboards
 
 ## Progress

--- a/README.md
+++ b/README.md
@@ -83,6 +83,35 @@ sudo cp protoc-gen-gogoslick /usr/bin/
 
 Done
 
+## Running p2p Prometheus dashboards
+1. Start the node with `--p2p-prometheus-metrics` flag. This exposes a metrics collection at http://localhost:5001/debug/metrics/prometheus.
+2. Clone libp2p repository: `git clone https://github.com/libp2p/go-libp2p`
+3. `cd go-libp2p/dasboards/swarm` and under the 
+```json  
+"templating": {
+   "list": [
+```
+section, add the following lines:
+```json
+{
+  "hide": 0,
+  "label": "datasource",
+  "name": "DS_PROMETHEUS",
+  "options": [],
+  "query": "prometheus",
+  "refresh": 1,
+  "regex": "",
+  "type": "datasource"
+},
+```
+(this step will be removed once it will be fixed on libp2p)
+4. `cd ..` to dashboards directory and update the port of `host.docker.internal` from `prometheus.yml` to node's Rest API port(default `8080`)
+5. From this directory, run the following docker compose command: 
+```
+sudo docker compose -f docker-compose.base.yml -f docker-compose-linux.yml up --force-recreate
+```
+6. The preconfigured dashboards should be now available on Grafana at http://localhost:3000/dashboards
+
 ## Progress
 
 ### Done

--- a/api/gin/common_test.go
+++ b/api/gin/common_test.go
@@ -22,7 +22,12 @@ func TestCommon_checkArgs(t *testing.T) {
 	err := checkArgs(args)
 	require.True(t, errors.Is(err, apiErrors.ErrCannotCreateGinWebServer))
 
-	args.Facade, err = initial.NewInitialNodeFacade("api interface", false, false, &testscommon.StatusMetricsStub{})
+	args.Facade, err = initial.NewInitialNodeFacade(initial.ArgInitialNodeFacade{
+		ApiInterface:                "api interface",
+		PprofEnabled:                false,
+		P2PPrometheusMetricsEnabled: false,
+		StatusMetricsHandler:        &testscommon.StatusMetricsStub{},
+	})
 	require.NoError(t, err)
 	err = checkArgs(args)
 	require.NoError(t, err)

--- a/api/gin/common_test.go
+++ b/api/gin/common_test.go
@@ -22,7 +22,7 @@ func TestCommon_checkArgs(t *testing.T) {
 	err := checkArgs(args)
 	require.True(t, errors.Is(err, apiErrors.ErrCannotCreateGinWebServer))
 
-	args.Facade, err = initial.NewInitialNodeFacade("api interface", false, &testscommon.StatusMetricsStub{})
+	args.Facade, err = initial.NewInitialNodeFacade("api interface", false, false, &testscommon.StatusMetricsStub{})
 	require.NoError(t, err)
 	err = checkArgs(args)
 	require.NoError(t, err)

--- a/api/gin/webServer.go
+++ b/api/gin/webServer.go
@@ -19,9 +19,12 @@ import (
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/facade"
 	logger "github.com/multiversx/mx-chain-logger-go"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var log = logger.GetOrCreate("api/gin")
+
+const prometheusMetricsRoute = "/debug/metrics/prometheus"
 
 // ArgsNewWebServer holds the arguments needed to create a new instance of webServer
 type ArgsNewWebServer struct {
@@ -226,6 +229,10 @@ func (ws *webServer) registerRoutes(ginRouter *gin.Engine) {
 
 	if ws.facade.PprofEnabled() {
 		pprof.Register(ginRouter)
+	}
+
+	if ws.facade.P2PPrometheusMetricsEnabled() {
+		ginRouter.GET(prometheusMetricsRoute, gin.WrapH(promhttp.Handler()))
 	}
 }
 

--- a/api/mock/facadeStub.go
+++ b/api/mock/facadeStub.go
@@ -93,6 +93,7 @@ type FacadeStub struct {
 	GetManagedKeysCalled                        func() []string
 	GetEligibleManagedKeysCalled                func() ([]string, error)
 	GetWaitingManagedKeysCalled                 func() ([]string, error)
+	P2PPrometheusMetricsEnabledCalled           func() bool
 }
 
 // GetTokenSupply -
@@ -608,6 +609,14 @@ func (f *FacadeStub) GetWaitingManagedKeys() ([]string, error) {
 		return f.GetWaitingManagedKeysCalled()
 	}
 	return make([]string, 0), nil
+}
+
+// P2PPrometheusMetricsEnabled -
+func (f *FacadeStub) P2PPrometheusMetricsEnabled() bool {
+	if f.P2PPrometheusMetricsEnabledCalled != nil {
+		return f.P2PPrometheusMetricsEnabledCalled()
+	}
+	return false
 }
 
 // Close -

--- a/api/shared/interface.go
+++ b/api/shared/interface.go
@@ -132,5 +132,6 @@ type FacadeHandler interface {
 	GetManagedKeys() []string
 	GetEligibleManagedKeys() ([]string, error)
 	GetWaitingManagedKeys() ([]string, error)
+	P2PPrometheusMetricsEnabled() bool
 	IsInterfaceNil() bool
 }

--- a/cmd/node/CLI.md
+++ b/cmd/node/CLI.md
@@ -73,6 +73,7 @@ GLOBAL OPTIONS:
    --logs-path directory                     This flag specifies the directory where the node will store logs.
    --operation-mode operation mode           String flag for specifying the desired operation mode(s) of the node, resulting in altering some configuration values accordingly. Possible values are: snapshotless-observer, full-archive, db-lookup-extension, historical-balances or `""` (empty). Multiple values can be separated via ,
    --repopulate-tokens-supplies              Boolean flag for repopulating the tokens supplies database. It will delete the current data, iterate over the entire trie and add he new obtained supplies
+   --p2p-prometheus-metrics                  Boolean option for enabling the /debug/metrics/prometheus route for p2p prometheus metrics
    --help, -h                                show help
    --version, -v                             print the version
    

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -407,6 +407,13 @@ var (
 		Name:  "repopulate-tokens-supplies",
 		Usage: "Boolean flag for repopulating the tokens supplies database. It will delete the current data, iterate over the entire trie and add he new obtained supplies",
 	}
+
+	// p2pPrometheusMetrics defines a flag for p2p prometheus metrics
+	// If enabled, it will open a new route, /debug/metrics/prometheus, where p2p prometheus metrics will be available
+	p2pPrometheusMetrics = cli.BoolFlag{
+		Name:  "p2p-prometheus-metrics",
+		Usage: "Boolean option for enabling the /debug/metrics/prometheus route for p2p prometheus metrics",
+	}
 )
 
 func getFlags() []cli.Flag {
@@ -469,6 +476,7 @@ func getFlags() []cli.Flag {
 		logsDirectory,
 		operationMode,
 		repopulateTokensSupplies,
+		p2pPrometheusMetrics,
 	}
 }
 
@@ -497,6 +505,7 @@ func getFlagsConfig(ctx *cli.Context, log logger.Logger) *config.ContextFlagsCon
 	flagsConfig.SerializeSnapshots = ctx.GlobalBool(serializeSnapshots.Name)
 	flagsConfig.OperationMode = ctx.GlobalString(operationMode.Name)
 	flagsConfig.RepopulateTokensSupplies = ctx.GlobalBool(repopulateTokensSupplies.Name)
+	flagsConfig.P2PPrometheusMetricsEnabled = ctx.GlobalBool(p2pPrometheusMetrics.Name)
 
 	if ctx.GlobalBool(noKey.Name) {
 		log.Warn("the provided -no-key option is deprecated and will soon be removed. To start a node without " +

--- a/cmd/seednode/CLI.md
+++ b/cmd/seednode/CLI.md
@@ -21,6 +21,7 @@ GLOBAL OPTIONS:
    --log-save                             Boolean option for enabling log saving. If set, it will automatically save all the logs into a file.
    --config [path]                        The [path] for the main configuration file. This TOML file contain the main configurations such as the marshalizer type (default: "./config/config.toml")
    --p2p-key-pem-file filepath            The filepath for the PEM file which contains the secret keys for the p2p key. If this is not specified a new key will be generated (internally) by default. (default: "./config/p2pKey.pem")
+   --p2p-prometheus-metrics               Boolean option for enabling the /debug/metrics/prometheus route for p2p prometheus metrics
    --help, -h                             show help
    --version, -v                          print the version
    

--- a/cmd/seednode/api/api.go
+++ b/cmd/seednode/api/api.go
@@ -9,25 +9,26 @@ import (
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/api/logs"
 	logger "github.com/multiversx/mx-chain-logger-go"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var log = logger.GetOrCreate("seednode/api")
 
 // Start will boot up the api and appropriate routes, handlers and validators
-func Start(restApiInterface string, marshalizer marshal.Marshalizer) error {
+func Start(restApiInterface string, marshalizer marshal.Marshalizer, p2pPrometheusMetricsEnabled bool) error {
 	ws := gin.Default()
 	ws.Use(cors.Default())
 
-	registerRoutes(ws, marshalizer)
+	registerRoutes(ws, marshalizer, p2pPrometheusMetricsEnabled)
 
 	return ws.Run(restApiInterface)
 }
 
-func registerRoutes(ws *gin.Engine, marshalizer marshal.Marshalizer) {
-	registerLoggerWsRoute(ws, marshalizer)
+func registerRoutes(ws *gin.Engine, marshalizer marshal.Marshalizer, p2pPrometheusMetricsEnabled bool) {
+	registerLoggerWsRoute(ws, marshalizer, p2pPrometheusMetricsEnabled)
 }
 
-func registerLoggerWsRoute(ws *gin.Engine, marshalizer marshal.Marshalizer) {
+func registerLoggerWsRoute(ws *gin.Engine, marshalizer marshal.Marshalizer, p2pPrometheusMetricsEnabled bool) {
 	upgrader := websocket.Upgrader{}
 
 	ws.GET("/log", func(c *gin.Context) {
@@ -49,4 +50,8 @@ func registerLoggerWsRoute(ws *gin.Engine, marshalizer marshal.Marshalizer) {
 
 		ls.StartSendingBlocking()
 	})
+
+	if p2pPrometheusMetricsEnabled {
+		ws.GET("/debug/metrics/prometheus", gin.WrapH(promhttp.Handler()))
+	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -285,8 +285,9 @@ type GeneralSettingsConfig struct {
 
 // FacadeConfig will hold different configuration option that will be passed to the node facade
 type FacadeConfig struct {
-	RestApiInterface string
-	PprofEnabled     bool
+	RestApiInterface            string
+	PprofEnabled                bool
+	P2PPrometheusMetricsEnabled bool
 }
 
 // StateTriesConfig will hold information about state tries

--- a/config/contextFlagsConfig.go
+++ b/config/contextFlagsConfig.go
@@ -27,6 +27,7 @@ type ContextFlagsConfig struct {
 	SerializeSnapshots           bool
 	OperationMode                string
 	RepopulateTokensSupplies     bool
+	P2PPrometheusMetricsEnabled  bool
 }
 
 // ImportDbConfig will hold the import-db parameters

--- a/facade/initial/initialNodeFacade.go
+++ b/facade/initial/initialNodeFacade.go
@@ -28,13 +28,14 @@ var emptyString = ""
 
 // initialNodeFacade represents a facade with no functionality
 type initialNodeFacade struct {
-	apiInterface         string
-	statusMetricsHandler external.StatusMetricsHandler
-	pprofEnabled         bool
+	apiInterface                string
+	statusMetricsHandler        external.StatusMetricsHandler
+	pprofEnabled                bool
+	p2pPrometheusMetricsEnabled bool
 }
 
 // NewInitialNodeFacade is the initial implementation of the facade interface
-func NewInitialNodeFacade(apiInterface string, pprofEnabled bool, statusMetricsHandler external.StatusMetricsHandler) (*initialNodeFacade, error) {
+func NewInitialNodeFacade(apiInterface string, pprofEnabled bool, p2pPrometheusMetricsEnabled bool, statusMetricsHandler external.StatusMetricsHandler) (*initialNodeFacade, error) {
 	if check.IfNil(statusMetricsHandler) {
 		return nil, facade.ErrNilStatusMetrics
 	}
@@ -45,9 +46,10 @@ func NewInitialNodeFacade(apiInterface string, pprofEnabled bool, statusMetricsH
 	}
 
 	return &initialNodeFacade{
-		apiInterface:         apiInterface,
-		statusMetricsHandler: initialStatusMetrics,
-		pprofEnabled:         pprofEnabled,
+		apiInterface:                apiInterface,
+		statusMetricsHandler:        initialStatusMetrics,
+		pprofEnabled:                pprofEnabled,
+		p2pPrometheusMetricsEnabled: p2pPrometheusMetricsEnabled,
 	}, nil
 }
 
@@ -76,7 +78,7 @@ func (inf *initialNodeFacade) SetSyncer(_ ntp.SyncTimer) {
 }
 
 // RestAPIServerDebugMode returns false
-//TODO: remove in the future
+// TODO: remove in the future
 func (inf *initialNodeFacade) RestAPIServerDebugMode() bool {
 	return false
 }
@@ -424,6 +426,11 @@ func (inf *initialNodeFacade) GetEligibleManagedKeys() ([]string, error) {
 // GetWaitingManagedKeys returns nil and error
 func (inf *initialNodeFacade) GetWaitingManagedKeys() ([]string, error) {
 	return nil, errNodeStarting
+}
+
+// P2PPrometheusMetricsEnabled returns either the p2p prometheus metrics are enabled or not
+func (inf *initialNodeFacade) P2PPrometheusMetricsEnabled() bool {
+	return inf.p2pPrometheusMetricsEnabled
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/facade/initial/initialNodeFacade.go
+++ b/facade/initial/initialNodeFacade.go
@@ -26,6 +26,14 @@ import (
 var errNodeStarting = errors.New("node is starting")
 var emptyString = ""
 
+// ArgInitialNodeFacade is the DTO used to create a new instance of initialNodeFacade
+type ArgInitialNodeFacade struct {
+	ApiInterface                string
+	PprofEnabled                bool
+	P2PPrometheusMetricsEnabled bool
+	StatusMetricsHandler        external.StatusMetricsHandler
+}
+
 // initialNodeFacade represents a facade with no functionality
 type initialNodeFacade struct {
 	apiInterface                string
@@ -35,21 +43,21 @@ type initialNodeFacade struct {
 }
 
 // NewInitialNodeFacade is the initial implementation of the facade interface
-func NewInitialNodeFacade(apiInterface string, pprofEnabled bool, p2pPrometheusMetricsEnabled bool, statusMetricsHandler external.StatusMetricsHandler) (*initialNodeFacade, error) {
-	if check.IfNil(statusMetricsHandler) {
+func NewInitialNodeFacade(args ArgInitialNodeFacade) (*initialNodeFacade, error) {
+	if check.IfNil(args.StatusMetricsHandler) {
 		return nil, facade.ErrNilStatusMetrics
 	}
 
-	initialStatusMetrics, err := NewInitialStatusMetricsProvider(statusMetricsHandler)
+	initialStatusMetrics, err := NewInitialStatusMetricsProvider(args.StatusMetricsHandler)
 	if err != nil {
 		return nil, err
 	}
 
 	return &initialNodeFacade{
-		apiInterface:                apiInterface,
+		apiInterface:                args.ApiInterface,
 		statusMetricsHandler:        initialStatusMetrics,
-		pprofEnabled:                pprofEnabled,
-		p2pPrometheusMetricsEnabled: p2pPrometheusMetricsEnabled,
+		pprofEnabled:                args.PprofEnabled,
+		p2pPrometheusMetricsEnabled: args.P2PPrometheusMetricsEnabled,
 	}, nil
 }
 

--- a/facade/initial/initialNodeFacade_test.go
+++ b/facade/initial/initialNodeFacade_test.go
@@ -11,20 +11,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func createInitialNodeFacadeArgs() ArgInitialNodeFacade {
+	return ArgInitialNodeFacade{
+		ApiInterface:                "127.0.0.1:8080",
+		PprofEnabled:                true,
+		P2PPrometheusMetricsEnabled: false,
+		StatusMetricsHandler:        &testscommon.StatusMetricsStub{},
+	}
+}
+
 func TestInitialNodeFacade(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil status metrics should error", func(t *testing.T) {
 		t.Parallel()
 
-		inf, err := NewInitialNodeFacade("127.0.0.1:8080", true, false, nil)
+		args := createInitialNodeFacadeArgs()
+		args.StatusMetricsHandler = nil
+		inf, err := NewInitialNodeFacade(args)
 		assert.Equal(t, facade.ErrNilStatusMetrics, err)
 		assert.Nil(t, inf)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		inf, err := NewInitialNodeFacade("127.0.0.1:8080", true, false, &testscommon.StatusMetricsStub{})
+		inf, err := NewInitialNodeFacade(createInitialNodeFacadeArgs())
 		assert.Nil(t, err)
 		assert.NotNil(t, inf)
 	})
@@ -40,7 +51,9 @@ func TestInitialNodeFacade_AllMethodsShouldNotPanic(t *testing.T) {
 	}()
 
 	apiInterface := "127.0.0.1:7799"
-	inf, err := NewInitialNodeFacade(apiInterface, true, false, &testscommon.StatusMetricsStub{})
+	args := createInitialNodeFacadeArgs()
+	args.ApiInterface = apiInterface
+	inf, err := NewInitialNodeFacade(args)
 	assert.Nil(t, err)
 
 	inf.SetSyncer(nil)
@@ -325,6 +338,6 @@ func TestInitialNodeFacade_IsInterfaceNil(t *testing.T) {
 	var inf *initialNodeFacade
 	assert.True(t, inf.IsInterfaceNil())
 
-	inf, _ = NewInitialNodeFacade("127.0.0.1:7799", true, false, &testscommon.StatusMetricsStub{})
+	inf, _ = NewInitialNodeFacade(createInitialNodeFacadeArgs())
 	assert.False(t, inf.IsInterfaceNil())
 }

--- a/facade/initial/initialNodeFacade_test.go
+++ b/facade/initial/initialNodeFacade_test.go
@@ -17,14 +17,14 @@ func TestInitialNodeFacade(t *testing.T) {
 	t.Run("nil status metrics should error", func(t *testing.T) {
 		t.Parallel()
 
-		inf, err := NewInitialNodeFacade("127.0.0.1:8080", true, nil)
+		inf, err := NewInitialNodeFacade("127.0.0.1:8080", true, false, nil)
 		assert.Equal(t, facade.ErrNilStatusMetrics, err)
 		assert.Nil(t, inf)
 	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		inf, err := NewInitialNodeFacade("127.0.0.1:8080", true, &testscommon.StatusMetricsStub{})
+		inf, err := NewInitialNodeFacade("127.0.0.1:8080", true, false, &testscommon.StatusMetricsStub{})
 		assert.Nil(t, err)
 		assert.NotNil(t, inf)
 	})
@@ -40,7 +40,7 @@ func TestInitialNodeFacade_AllMethodsShouldNotPanic(t *testing.T) {
 	}()
 
 	apiInterface := "127.0.0.1:7799"
-	inf, err := NewInitialNodeFacade(apiInterface, true, &testscommon.StatusMetricsStub{})
+	inf, err := NewInitialNodeFacade(apiInterface, true, false, &testscommon.StatusMetricsStub{})
 	assert.Nil(t, err)
 
 	inf.SetSyncer(nil)
@@ -325,6 +325,6 @@ func TestInitialNodeFacade_IsInterfaceNil(t *testing.T) {
 	var inf *initialNodeFacade
 	assert.True(t, inf.IsInterfaceNil())
 
-	inf, _ = NewInitialNodeFacade("127.0.0.1:7799", true, &testscommon.StatusMetricsStub{})
+	inf, _ = NewInitialNodeFacade("127.0.0.1:7799", true, false, &testscommon.StatusMetricsStub{})
 	assert.False(t, inf.IsInterfaceNil())
 }

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -36,7 +36,8 @@ import (
 const DefaultRestInterface = "localhost:8080"
 
 // DefaultRestPortOff is the default value that should be passed if it is desired
-//  to start the node without a REST endpoint available
+//
+//	to start the node without a REST endpoint available
 const DefaultRestPortOff = "off"
 
 var log = logger.GetOrCreate("facade")
@@ -163,7 +164,8 @@ func (nf *nodeFacade) RestAPIServerDebugMode() bool {
 
 // RestApiInterface returns the interface on which the rest API should start on, based on the config file provided.
 // The API will start on the DefaultRestInterface value unless a correct value is passed or
-//  the value is explicitly set to off, in which case it will not start at all
+//
+//	the value is explicitly set to off, in which case it will not start at all
 func (nf *nodeFacade) RestApiInterface() string {
 	if nf.config.RestApiInterface == "" {
 		return DefaultRestInterface
@@ -732,6 +734,11 @@ func (nf *nodeFacade) GetGasConfigs() (map[string]map[string]uint64, error) {
 	}
 
 	return gasConfigs, nil
+}
+
+// P2PPrometheusMetricsEnabled returns if p2p prometheus metrics should be enabled or not on the application
+func (nf *nodeFacade) P2PPrometheusMetricsEnabled() bool {
+	return nf.config.P2PPrometheusMetricsEnabled
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -36,8 +36,7 @@ import (
 const DefaultRestInterface = "localhost:8080"
 
 // DefaultRestPortOff is the default value that should be passed if it is desired
-//
-//	to start the node without a REST endpoint available
+// to start the node without a REST endpoint available
 const DefaultRestPortOff = "off"
 
 var log = logger.GetOrCreate("facade")
@@ -164,8 +163,7 @@ func (nf *nodeFacade) RestAPIServerDebugMode() bool {
 
 // RestApiInterface returns the interface on which the rest API should start on, based on the config file provided.
 // The API will start on the DefaultRestInterface value unless a correct value is passed or
-//
-//	the value is explicitly set to off, in which case it will not start at all
+// the value is explicitly set to off, in which case it will not start at all
 func (nf *nodeFacade) RestApiInterface() string {
 	if nf.config.RestApiInterface == "" {
 		return DefaultRestInterface

--- a/facade/nodeFacade_test.go
+++ b/facade/nodeFacade_test.go
@@ -50,8 +50,9 @@ func createMockArguments() ArgNodeFacade {
 			TrieOperationsDeadlineMilliseconds: 1,
 		},
 		FacadeConfig: config.FacadeConfig{
-			RestApiInterface: "127.0.0.1:8080",
-			PprofEnabled:     false,
+			RestApiInterface:            "127.0.0.1:8080",
+			PprofEnabled:                false,
+			P2PPrometheusMetricsEnabled: false,
 		},
 		ApiRoutesConfig: config.ApiRoutesConfig{APIPackages: map[string]config.APIPackageConfig{
 			"node": {
@@ -618,6 +619,16 @@ func TestNodeFacade_PprofEnabled(t *testing.T) {
 	nf, _ := NewNodeFacade(arg)
 
 	require.True(t, nf.PprofEnabled())
+}
+
+func TestNodeFacade_P2PPrometheusMetricsEnabled(t *testing.T) {
+	t.Parallel()
+
+	arg := createMockArguments()
+	arg.FacadeConfig.P2PPrometheusMetricsEnabled = true
+	nf, _ := NewNodeFacade(arg)
+
+	require.True(t, nf.P2PPrometheusMetricsEnabled())
 }
 
 func TestNodeFacade_RestAPIServerDebugMode(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/multiversx/mx-chain-vm-v1_4-go v1.4.89
 	github.com/pelletier/go-toml v1.9.3
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.14.0
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/stretchr/testify v1.8.4
 	github.com/urfave/cli v1.22.10
@@ -140,7 +141,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.89.0 // indirect
-	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -769,12 +769,14 @@ func (nr *nodeRunner) createHttpServer(managedStatusCoreComponents mainFactory.S
 	if check.IfNil(managedStatusCoreComponents) {
 		return nil, ErrNilStatusHandler
 	}
-	initialFacade, err := initial.NewInitialNodeFacade(
-		nr.configs.FlagsConfig.RestApiInterface,
-		nr.configs.FlagsConfig.EnablePprof,
-		nr.configs.FlagsConfig.P2PPrometheusMetricsEnabled,
-		managedStatusCoreComponents.StatusMetrics(),
-	)
+
+	argsInitialNodeFacade := initial.ArgInitialNodeFacade{
+		ApiInterface:                nr.configs.FlagsConfig.RestApiInterface,
+		PprofEnabled:                nr.configs.FlagsConfig.EnablePprof,
+		P2PPrometheusMetricsEnabled: nr.configs.FlagsConfig.P2PPrometheusMetricsEnabled,
+		StatusMetricsHandler:        managedStatusCoreComponents.StatusMetrics(),
+	}
+	initialFacade, err := initial.NewInitialNodeFacade(argsInitialNodeFacade)
 	if err != nil {
 		return nil, err
 	}

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -736,8 +736,9 @@ func (nr *nodeRunner) createApiFacade(
 		RestAPIServerDebugMode: flagsConfig.EnableRestAPIServerDebugMode,
 		WsAntifloodConfig:      configs.GeneralConfig.WebServerAntiflood,
 		FacadeConfig: config.FacadeConfig{
-			RestApiInterface: flagsConfig.RestApiInterface,
-			PprofEnabled:     flagsConfig.EnablePprof,
+			RestApiInterface:            flagsConfig.RestApiInterface,
+			PprofEnabled:                flagsConfig.EnablePprof,
+			P2PPrometheusMetricsEnabled: flagsConfig.P2PPrometheusMetricsEnabled,
 		},
 		ApiRoutesConfig: *configs.ApiRoutesConfig,
 		AccountsState:   currentNode.stateComponents.AccountsAdapter(),
@@ -768,7 +769,12 @@ func (nr *nodeRunner) createHttpServer(managedStatusCoreComponents mainFactory.S
 	if check.IfNil(managedStatusCoreComponents) {
 		return nil, ErrNilStatusHandler
 	}
-	initialFacade, err := initial.NewInitialNodeFacade(nr.configs.FlagsConfig.RestApiInterface, nr.configs.FlagsConfig.EnablePprof, managedStatusCoreComponents.StatusMetrics())
+	initialFacade, err := initial.NewInitialNodeFacade(
+		nr.configs.FlagsConfig.RestApiInterface,
+		nr.configs.FlagsConfig.EnablePprof,
+		nr.configs.FlagsConfig.P2PPrometheusMetricsEnabled,
+		managedStatusCoreComponents.StatusMetrics(),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- libp2p prometheus dashboards can be used for a useful overview over different metrics
  
## Proposed changes
- added new flag to start a new route `/debug/metrics/prometheus`
- updated readme with steps to start the dashboards

## Testing procedure
- standard system test + follow the [readme steps](https://github.com/multiversx/mx-chain-go/tree/prometheus_dashboards#running-p2p-prometheus-dashboards)

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
