### PR TITLE
overridable configs fix

### DIFF
--- a/common/reflectcommon/structFieldsUpdate.go
+++ b/common/reflectcommon/structFieldsUpdate.go
@@ -96,6 +96,13 @@ func trySetTheNewValue(value *reflect.Value, newValue string) error {
 		}
 
 		value.Set(reflect.ValueOf(int(intVal)))
+	case reflect.Int32:
+		int32Val, err := strconv.ParseInt(newValue, 10, 32)
+		if err != nil {
+			return fmt.Errorf("%w: %s", errFunc(), err.Error())
+		}
+
+		value.Set(reflect.ValueOf(int32(int32Val)))
 	case reflect.Int64:
 		int64Val, err := strconv.ParseInt(newValue, 10, 64)
 		if err != nil {

--- a/common/reflectcommon/structFieldsUpdate_test.go
+++ b/common/reflectcommon/structFieldsUpdate_test.go
@@ -382,6 +382,20 @@ func TestAdaptStructureValueBasedOnPath(t *testing.T) {
 		require.Equal(t, expectedNewValue, cfg.StoragePruning.FullArchiveNumActivePersisters)
 	})
 
+	t.Run("should work and override int32 value", func(t *testing.T) {
+		t.Parallel()
+
+		path := "Antiflood.NumConcurrentResolverJobs"
+		cfg := &config.Config{}
+		cfg.Antiflood.NumConcurrentResolverJobs = int32(50)
+		expectedNewValue := int32(37)
+
+		err := AdaptStructureValueBasedOnPath(cfg, path, fmt.Sprintf("%d", expectedNewValue))
+		require.NoError(t, err)
+
+		require.Equal(t, expectedNewValue, cfg.Antiflood.NumConcurrentResolverJobs)
+	})
+
 	t.Run("should work and override string value on multiple levels depth", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Reasoning behind the pull request
- There was a bug when trying to override the `Antiflood.NumConcurrentResolverJobs` config
  
## Proposed changes
- Treat the case for `int32` config entries

## Testing procedure
- Normal testing procedure

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
