### PR TITLE
Extra endpoint `chan_simulator` SetState

### DIFF
--- a/node/chainSimulator/chainSimulator.go
+++ b/node/chainSimulator/chainSimulator.go
@@ -176,7 +176,7 @@ func (s *simulator) GetInitialWalletKeys() *dtos.InitialWalletKeys {
 }
 
 // SetState will set the provided state for a given address
-func (s *simulator) SetState(address string, state map[string][]byte) error {
+func (s *simulator) SetState(address string, state map[string]string) error {
 	addressConverter := s.nodes[core.MetachainShardId].GetCoreComponents().AddressPubKeyConverter()
 	addressBytes, err := addressConverter.Decode(address)
 	if err != nil {

--- a/node/chainSimulator/chainSimulator.go
+++ b/node/chainSimulator/chainSimulator.go
@@ -1,9 +1,11 @@
 package chainSimulator
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/core/sharding"
 	"github.com/multiversx/mx-chain-core-go/data/endProcess"
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/node/chainSimulator/components"
@@ -171,6 +173,23 @@ func (s *simulator) GetRestAPIInterfaces() map[uint32]string {
 // GetInitialWalletKeys will return the initial wallet keys
 func (s *simulator) GetInitialWalletKeys() *dtos.InitialWalletKeys {
 	return s.initialWalletKeys
+}
+
+// SetState will set the provided state for a given address
+func (s *simulator) SetState(address string, state map[string][]byte) error {
+	addressConverter := s.nodes[core.MetachainShardId].GetCoreComponents().AddressPubKeyConverter()
+	addressBytes, err := addressConverter.Decode(address)
+	if err != nil {
+		return err
+	}
+
+	shardID := sharding.ComputeShardID(addressBytes, s.numOfShards)
+	testNode, ok := s.nodes[shardID]
+	if !ok {
+		return fmt.Errorf("cannot find a test node for the computed shard id, computed shard id: %d", shardID)
+	}
+
+	return testNode.SetState(addressBytes, state)
 }
 
 // Close will stop and close the simulator

--- a/node/chainSimulator/components/testOnlyProcessingNode.go
+++ b/node/chainSimulator/components/testOnlyProcessingNode.go
@@ -403,7 +403,17 @@ func (node *testOnlyProcessingNode) SetState(address []byte, keyValueMap map[str
 		}
 	}
 
-	return accountsAdapter.SaveAccount(account)
+	err = accountsAdapter.SaveAccount(account)
+	if err != nil {
+		return err
+	}
+
+	_, err = accountsAdapter.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Close will call the Close methods on all inner components

--- a/node/chainSimulator/components/testOnlyProcessingNode.go
+++ b/node/chainSimulator/components/testOnlyProcessingNode.go
@@ -3,6 +3,7 @@ package components
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	chainData "github.com/multiversx/mx-chain-core-go/data"
@@ -390,11 +391,11 @@ func (node *testOnlyProcessingNode) SetState(address []byte, keyValueMap map[str
 	for keyHex, valueHex := range keyValueMap {
 		keyDecoded, errK := hex.DecodeString(keyHex)
 		if errK != nil {
-			return errK
+			return fmt.Errorf("cannot decode key, error: %w", err)
 		}
 		valueDecoded, errV := hex.DecodeString(valueHex)
 		if errV != nil {
-			return errV
+			return fmt.Errorf("cannot decode value, error: %w", err)
 		}
 
 		err = userAccount.SaveKeyValue(keyDecoded, valueDecoded)

--- a/node/chainSimulator/components/testOnlyProcessingNode.go
+++ b/node/chainSimulator/components/testOnlyProcessingNode.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"encoding/hex"
 	"errors"
 
 	"github.com/multiversx/mx-chain-core-go/core"
@@ -374,7 +375,7 @@ func (node *testOnlyProcessingNode) collectClosableComponents(apiInterface APICo
 }
 
 // SetState will set the provided state for the given address
-func (node *testOnlyProcessingNode) SetState(address []byte, keyValueMap map[string][]byte) error {
+func (node *testOnlyProcessingNode) SetState(address []byte, keyValueMap map[string]string) error {
 	accountsAdapter := node.StateComponentsHolder.AccountsAdapter()
 	account, err := accountsAdapter.LoadAccount(address)
 	if err != nil {
@@ -386,8 +387,17 @@ func (node *testOnlyProcessingNode) SetState(address []byte, keyValueMap map[str
 		return errors.New("cannot cast AccountHandler to UserAccountHandler")
 	}
 
-	for key, value := range keyValueMap {
-		err = userAccount.SaveKeyValue([]byte(key), value)
+	for keyHex, valueHex := range keyValueMap {
+		keyDecoded, errK := hex.DecodeString(keyHex)
+		if errK != nil {
+			return errK
+		}
+		valueDecoded, errV := hex.DecodeString(valueHex)
+		if errV != nil {
+			return errV
+		}
+
+		err = userAccount.SaveKeyValue(keyDecoded, valueDecoded)
 		if err != nil {
 			return err
 		}

--- a/node/chainSimulator/components/testOnlyProcessingNode_test.go
+++ b/node/chainSimulator/components/testOnlyProcessingNode_test.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -81,4 +82,27 @@ func TestNewTestOnlyProcessingNode(t *testing.T) {
 		err = node.ProcessComponentsHolder.BlockProcessor().CommitBlock(header, block)
 		assert.Nil(t, err)
 	})
+}
+
+func TestOnlyProcessingNodeSetStateShouldError(t *testing.T) {
+	args := createMockArgsTestOnlyProcessingNode(t)
+	node, err := NewTestOnlyProcessingNode(args)
+	require.Nil(t, err)
+
+	address := "erd1qtc600lryvytxuy4h7vn7xmsy5tw6vuw3tskr75cwnmv4mnyjgsq6e5zgj"
+	addressBytes, _ := node.CoreComponentsHolder.AddressPubKeyConverter().Decode(address)
+
+	keyValueMap := map[string]string{
+		"nonHex": "01",
+	}
+	err = node.SetState(addressBytes, keyValueMap)
+	require.NotNil(t, err)
+	require.True(t, strings.Contains(err.Error(), "cannot decode key"))
+
+	keyValueMap = map[string]string{
+		"01": "nonHex",
+	}
+	err = node.SetState(addressBytes, keyValueMap)
+	require.NotNil(t, err)
+	require.True(t, strings.Contains(err.Error(), "cannot decode value"))
 }

--- a/node/chainSimulator/process/interface.go
+++ b/node/chainSimulator/process/interface.go
@@ -18,6 +18,7 @@ type NodeHandler interface {
 	GetCoreComponents() factory.CoreComponentsHolder
 	GetStateComponents() factory.StateComponentsHolder
 	GetFacadeHandler() shared.FacadeHandler
+	SetState(addressBytes []byte, state map[string][]byte) error
 	Close() error
 	IsInterfaceNil() bool
 }

--- a/node/chainSimulator/process/interface.go
+++ b/node/chainSimulator/process/interface.go
@@ -18,7 +18,7 @@ type NodeHandler interface {
 	GetCoreComponents() factory.CoreComponentsHolder
 	GetStateComponents() factory.StateComponentsHolder
 	GetFacadeHandler() shared.FacadeHandler
-	SetState(addressBytes []byte, state map[string][]byte) error
+	SetState(addressBytes []byte, state map[string]string) error
 	Close() error
 	IsInterfaceNil() bool
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- Extended  chain simulator with an extra function that can set state of an account
  

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
