### PR TITLE
added randSeed and prevRandSeed on api blocks

### DIFF
--- a/node/external/blockAPI/metaBlock.go
+++ b/node/external/blockAPI/metaBlock.go
@@ -235,6 +235,8 @@ func (mbp *metaAPIBlockProcessor) convertMetaBlockBytesToAPIBlock(hash []byte, b
 		SoftwareVersion:        hex.EncodeToString(blockHeader.GetSoftwareVersion()),
 		ReceiptsHash:           hex.EncodeToString(blockHeader.GetReceiptsHash()),
 		Reserved:               blockHeader.GetReserved(),
+		RandSeed:               hex.EncodeToString(blockHeader.GetRandSeed()),
+		PrevRandSeed:           hex.EncodeToString(blockHeader.GetPrevRandSeed()),
 	}
 
 	addScheduledInfoInBlock(blockHeader, apiMetaBlock)

--- a/node/external/blockAPI/shardBlock.go
+++ b/node/external/blockAPI/shardBlock.go
@@ -226,6 +226,8 @@ func (sbp *shardAPIBlockProcessor) convertShardBlockBytesToAPIBlock(hash []byte,
 		SoftwareVersion: hex.EncodeToString(blockHeader.GetSoftwareVersion()),
 		ReceiptsHash:    hex.EncodeToString(blockHeader.GetReceiptsHash()),
 		Reserved:        blockHeader.GetReserved(),
+		RandSeed:        hex.EncodeToString(blockHeader.GetRandSeed()),
+		PrevRandSeed:    hex.EncodeToString(blockHeader.GetPrevRandSeed()),
 	}
 
 	addScheduledInfoInBlock(blockHeader, apiBlock)


### PR DESCRIPTION
## Reasoning behind the pull request
- rand seed and prev rand seed are missing from the apiBlock
  
## Proposed changes
- add randSeed and prevRandSeed on the apiBlock

## Testing procedure
- request blocks from the node and from the proxy and the randSeed and prevRandSeed fields should be populated

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
