### PR TITLE
use new payload for revert in http integration

### DIFF
--- a/outport/notifier/eventNotifier.go
+++ b/outport/notifier/eventNotifier.go
@@ -1,7 +1,6 @@
 package notifier
 
 import (
-	"encoding/hex"
 	"fmt"
 
 	"github.com/multiversx/mx-chain-core-go/core"
@@ -22,14 +21,6 @@ const (
 	revertEventsEndpoint    = "/events/revert"
 	finalizedEventsEndpoint = "/events/finalized"
 )
-
-// RevertBlock holds revert event data
-type RevertBlock struct {
-	Hash  string `json:"hash"`
-	Nonce uint64 `json:"nonce"`
-	Round uint64 `json:"round"`
-	Epoch uint32 `json:"epoch"`
-}
 
 type eventNotifier struct {
 	httpClient     httpClientHandler
@@ -87,19 +78,7 @@ func (en *eventNotifier) SaveBlock(args *outport.OutportBlock) error {
 
 // RevertIndexedBlock converts revert data in order to be pushed to subscribers
 func (en *eventNotifier) RevertIndexedBlock(blockData *outport.BlockData) error {
-	headerHandler, err := en.getHeaderFromBytes(core.HeaderType(blockData.HeaderType), blockData.HeaderBytes)
-	if err != nil {
-		return err
-	}
-
-	revertBlock := RevertBlock{
-		Hash:  hex.EncodeToString(blockData.HeaderHash),
-		Nonce: headerHandler.GetNonce(),
-		Round: headerHandler.GetRound(),
-		Epoch: headerHandler.GetEpoch(),
-	}
-
-	err = en.httpClient.Post(revertEventsEndpoint, revertBlock)
+	err := en.httpClient.Post(revertEventsEndpoint, blockData)
 	if err != nil {
 		return fmt.Errorf("%w in eventNotifier.RevertIndexedBlock while posting event data", err)
 	}

--- a/outport/notifier/eventNotifier.go
+++ b/outport/notifier/eventNotifier.go
@@ -3,10 +3,7 @@ package notifier
 import (
 	"fmt"
 
-	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
-	"github.com/multiversx/mx-chain-core-go/data"
-	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/outport"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	logger "github.com/multiversx/mx-chain-logger-go"
@@ -66,7 +63,9 @@ func checkEventNotifierArgs(args ArgsEventNotifier) error {
 
 // SaveBlock converts block data in order to be pushed to subscribers
 func (en *eventNotifier) SaveBlock(args *outport.OutportBlock) error {
-	log.Debug("eventNotifier: SaveBlock called at block", "block hash", args.BlockData.HeaderHash)
+	if args.BlockData != nil {
+		log.Debug("eventNotifier: SaveBlock called at block", "block hash", args.BlockData.HeaderHash)
+	}
 
 	err := en.httpClient.Post(pushEventEndpoint, args)
 	if err != nil {
@@ -139,13 +138,4 @@ func (en *eventNotifier) RegisterHandler(_ func() error, _ string) error {
 // SetCurrentSettings will do nothing
 func (en *eventNotifier) SetCurrentSettings(_ outport.OutportConfig) error {
 	return nil
-}
-
-func (en *eventNotifier) getHeaderFromBytes(headerType core.HeaderType, headerBytes []byte) (header data.HeaderHandler, err error) {
-	creator, err := en.blockContainer.Get(headerType)
-	if err != nil {
-		return nil, err
-	}
-
-	return block.GetHeaderFromBytes(en.marshalizer, creator, headerBytes)
 }

--- a/outport/notifier/eventNotifier_test.go
+++ b/outport/notifier/eventNotifier_test.go
@@ -1,6 +1,7 @@
 package notifier_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -66,117 +67,191 @@ func TestNewEventNotifier(t *testing.T) {
 		en, err := notifier.NewEventNotifier(createMockEventNotifierArgs())
 		require.Nil(t, err)
 		require.NotNil(t, en)
+
+		require.NotNil(t, en.GetMarshaller())
 	})
 }
 
 func TestSaveBlock(t *testing.T) {
 	t.Parallel()
 
-	args := createMockEventNotifierArgs()
+	t.Run("should return err if http request failed", func(t *testing.T) {
+		t.Parallel()
 
-	txHash1 := "txHash1"
-	scrHash1 := "scrHash1"
+		args := createMockEventNotifierArgs()
 
-	wasCalled := false
-	args.HttpClient = &mock.HTTPClientStub{
-		PostCalled: func(route string, payload interface{}) error {
-			saveBlockData := payload.(*outport.OutportBlock)
-
-			require.Equal(t, saveBlockData.TransactionPool.Logs[0].TxHash, txHash1)
-			for txHash := range saveBlockData.TransactionPool.Transactions {
-				require.Equal(t, txHash1, txHash)
-			}
-
-			for scrHash := range saveBlockData.TransactionPool.SmartContractResults {
-				require.Equal(t, scrHash1, scrHash)
-			}
-
-			wasCalled = true
-			return nil
-		},
-	}
-
-	en, _ := notifier.NewEventNotifier(args)
-
-	saveBlockData := &outport.OutportBlock{
-		BlockData: &outport.BlockData{
-			HeaderHash: []byte{},
-		},
-		TransactionPool: &outport.TransactionPool{
-			Transactions: map[string]*outport.TxInfo{
-				txHash1: nil,
+		expectedErr := errors.New("expected error")
+		args.HttpClient = &mock.HTTPClientStub{
+			PostCalled: func(route string, payload interface{}) error {
+				return expectedErr
 			},
-			SmartContractResults: map[string]*outport.SCRInfo{
-				scrHash1: nil,
+		}
+
+		en, _ := notifier.NewEventNotifier(args)
+
+		saveBlockData := &outport.OutportBlock{BlockData: &outport.BlockData{}}
+
+		err := en.SaveBlock(saveBlockData)
+		require.Error(t, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockEventNotifierArgs()
+
+		txHash1 := "txHash1"
+		scrHash1 := "scrHash1"
+
+		wasCalled := false
+		args.HttpClient = &mock.HTTPClientStub{
+			PostCalled: func(route string, payload interface{}) error {
+				saveBlockData := payload.(*outport.OutportBlock)
+
+				require.Equal(t, saveBlockData.TransactionPool.Logs[0].TxHash, txHash1)
+				for txHash := range saveBlockData.TransactionPool.Transactions {
+					require.Equal(t, txHash1, txHash)
+				}
+
+				for scrHash := range saveBlockData.TransactionPool.SmartContractResults {
+					require.Equal(t, scrHash1, scrHash)
+				}
+
+				wasCalled = true
+				return nil
 			},
-			Logs: []*outport.LogData{
-				{
-					TxHash: txHash1,
-					Log:    &transaction.Log{},
+		}
+
+		en, _ := notifier.NewEventNotifier(args)
+
+		saveBlockData := &outport.OutportBlock{
+			BlockData: &outport.BlockData{
+				HeaderHash: []byte{},
+			},
+			TransactionPool: &outport.TransactionPool{
+				Transactions: map[string]*outport.TxInfo{
+					txHash1: nil,
+				},
+				SmartContractResults: map[string]*outport.SCRInfo{
+					scrHash1: nil,
+				},
+				Logs: []*outport.LogData{
+					{
+						TxHash: txHash1,
+						Log:    &transaction.Log{},
+					},
 				},
 			},
-		},
-	}
+		}
 
-	err := en.SaveBlock(saveBlockData)
-	require.Nil(t, err)
+		err := en.SaveBlock(saveBlockData)
+		require.Nil(t, err)
 
-	require.True(t, wasCalled)
+		require.True(t, wasCalled)
+	})
 }
 
 func TestRevertIndexedBlock(t *testing.T) {
 	t.Parallel()
 
-	args := createMockEventNotifierArgs()
+	t.Run("should return err if http request failed", func(t *testing.T) {
+		t.Parallel()
 
-	header := &block.Header{
-		Nonce: 1,
-		Round: 2,
-		Epoch: 3,
-	}
-	headerBytes, _ := args.Marshaller.Marshal(header)
+		args := createMockEventNotifierArgs()
 
-	blockData := &outport.BlockData{
-		HeaderBytes: headerBytes,
-		Body:        &block.Body{},
-		HeaderType:  string(core.ShardHeaderV1),
-	}
+		expectedErr := errors.New("expected error")
+		args.HttpClient = &mock.HTTPClientStub{
+			PostCalled: func(route string, payload interface{}) error {
+				return expectedErr
+			},
+		}
 
-	wasCalled := false
-	args.HttpClient = &mock.HTTPClientStub{
-		PostCalled: func(route string, payload interface{}) error {
-			require.Equal(t, blockData, payload)
-			wasCalled = true
-			return nil
-		},
-	}
-	en, _ := notifier.NewEventNotifier(args)
+		en, _ := notifier.NewEventNotifier(args)
 
-	err := en.RevertIndexedBlock(blockData)
-	require.Nil(t, err)
-	require.True(t, wasCalled)
+		blockData := &outport.BlockData{}
+
+		err := en.RevertIndexedBlock(blockData)
+		require.Error(t, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockEventNotifierArgs()
+
+		header := &block.Header{
+			Nonce: 1,
+			Round: 2,
+			Epoch: 3,
+		}
+		headerBytes, _ := args.Marshaller.Marshal(header)
+
+		blockData := &outport.BlockData{
+			HeaderBytes: headerBytes,
+			Body:        &block.Body{},
+			HeaderType:  string(core.ShardHeaderV1),
+		}
+
+		wasCalled := false
+		args.HttpClient = &mock.HTTPClientStub{
+			PostCalled: func(route string, payload interface{}) error {
+				require.Equal(t, blockData, payload)
+				wasCalled = true
+				return nil
+			},
+		}
+		en, _ := notifier.NewEventNotifier(args)
+
+		err := en.RevertIndexedBlock(blockData)
+		require.Nil(t, err)
+		require.True(t, wasCalled)
+	})
 }
 
 func TestFinalizedBlock(t *testing.T) {
 	t.Parallel()
 
-	args := createMockEventNotifierArgs()
+	t.Run("should return err if http request failed", func(t *testing.T) {
+		t.Parallel()
 
-	wasCalled := false
-	args.HttpClient = &mock.HTTPClientStub{
-		PostCalled: func(route string, payload interface{}) error {
-			wasCalled = true
-			return nil
-		},
-	}
+		args := createMockEventNotifierArgs()
 
-	en, _ := notifier.NewEventNotifier(args)
+		expectedErr := errors.New("expected error")
+		args.HttpClient = &mock.HTTPClientStub{
+			PostCalled: func(route string, payload interface{}) error {
+				return expectedErr
+			},
+		}
 
-	hash := []byte("headerHash")
-	err := en.FinalizedBlock(&outport.FinalizedBlock{HeaderHash: hash})
-	require.Nil(t, err)
+		en, _ := notifier.NewEventNotifier(args)
 
-	require.True(t, wasCalled)
+		finalizedData := &outport.FinalizedBlock{}
+
+		err := en.FinalizedBlock(finalizedData)
+		require.Error(t, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockEventNotifierArgs()
+
+		wasCalled := false
+		args.HttpClient = &mock.HTTPClientStub{
+			PostCalled: func(route string, payload interface{}) error {
+				wasCalled = true
+				return nil
+			},
+		}
+
+		en, _ := notifier.NewEventNotifier(args)
+
+		hash := []byte("headerHash")
+		err := en.FinalizedBlock(&outport.FinalizedBlock{HeaderHash: hash})
+		require.Nil(t, err)
+
+		require.True(t, wasCalled)
+	})
 }
 
 func TestMockFunctions(t *testing.T) {
@@ -203,6 +278,12 @@ func TestMockFunctions(t *testing.T) {
 	require.Nil(t, err)
 
 	err = en.SaveAccounts(nil)
+	require.Nil(t, err)
+
+	err = en.RegisterHandler(nil, "")
+	require.Nil(t, err)
+
+	err = en.SetCurrentSettings(outport.OutportConfig{})
 	require.Nil(t, err)
 
 	err = en.Close()


### PR DESCRIPTION
## Reasoning behind the pull request
- Handle notifier revert data with new data payload structure

## Testing procedure
- Test the following 2 scenarios on system tests that includes block reverts:
    - HTTP integration: observer + notifer with old http integration enabled
    - WebSocket integration: observer + notifier with WS integration enabled
         - WebScoket integration is available only after upgrade

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
