### PR TITLE
process/txsimulator: expose VM logs in the simulation's results

### DIFF
--- a/process/txsimulator/data/data.go
+++ b/process/txsimulator/data/data.go
@@ -5,6 +5,14 @@ import (
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
+// SimulationResultsLogEntry is the data transfer object which will hold the VM logs for simulation a transaction's execution
+type SimulationResultsLogEntry struct {
+	Identifier []byte   `json:"identifier,omitempty"`
+	Address    []byte   `json:"address,omitempty"`
+	Topics     [][]byte `json:"topics,omitempty"`
+	Data       []byte   `json:"data,omitempty"`
+}
+
 // SimulationResults is the data transfer object which will hold results for simulation a transaction's execution
 type SimulationResults struct {
 	Status     transaction.TxStatus                           `json:"status,omitempty"`
@@ -12,5 +20,6 @@ type SimulationResults struct {
 	ScResults  map[string]*transaction.ApiSmartContractResult `json:"scResults,omitempty"`
 	Receipts   map[string]*transaction.ApiReceipt             `json:"receipts,omitempty"`
 	Hash       string                                         `json:"hash,omitempty"`
+	Logs       []SimulationResultsLogEntry                    `json:"logs,omitempty"`
 	VMOutput   *vmcommon.VMOutput                             `json:"-"`
 }

--- a/process/txsimulator/txSimulator.go
+++ b/process/txsimulator/txSimulator.go
@@ -107,6 +107,21 @@ func (ts *transactionSimulator) ProcessTx(tx *transaction.Transaction) (*txSimDa
 	vmOutput, ok := ts.getVMOutputOfTx(tx)
 	if ok {
 		results.VMOutput = vmOutput
+
+		var logs []txSimData.SimulationResultsLogEntry
+		for _, vmOutputLog := range vmOutput.Logs {
+			logs = append(
+				logs,
+				txSimData.SimulationResultsLogEntry{
+					Identifier: vmOutputLog.Identifier,
+					Address:    vmOutputLog.Address,
+					Topics:     vmOutputLog.Topics,
+					Data:       vmOutputLog.Data,
+				},
+			)
+		}
+
+		results.Logs = logs
 	}
 
 	return results, nil


### PR DESCRIPTION
## Reasoning behind the pull request
- Having logs when simulating transaction is a need
  
## Proposed changes
- Expose logs in the JSON result

## Testing procedure
That's the point, I don't see any integration test which checks a complete simulation flow. The only ones I see are those testing the facade. Do you have any testing procedure I can do regarding this PR?

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
