### PR TITLE
Fixed managed peers holder

### DIFF
--- a/keysManagement/managedPeersHolder.go
+++ b/keysManagement/managedPeersHolder.go
@@ -163,7 +163,6 @@ func (holder *managedPeersHolder) AddManagedPeer(privateKeyBytes []byte) error {
 	pInfo, found = holder.providedIdentities[string(publicKeyBytes)]
 	if !found {
 		pInfo = &peerInfo{
-			handler:      common.NewRedundancyHandler(),
 			machineID:    generateRandomMachineID(),
 			nodeName:     generateNodeName(holder.defaultName, holder.defaultPeerInfoCurrentIndex),
 			nodeIdentity: holder.defaultIdentity,
@@ -171,6 +170,7 @@ func (holder *managedPeersHolder) AddManagedPeer(privateKeyBytes []byte) error {
 		holder.defaultPeerInfoCurrentIndex++
 	}
 
+	pInfo.handler = common.NewRedundancyHandler()
 	pInfo.pid = pid
 	pInfo.p2pPrivateKeyBytes = p2pPrivateKeyBytes
 	pInfo.privateKey = privateKey


### PR DESCRIPTION
## Reasoning behind the pull request
- node will panic in multikey mode if a key from allValidatorsKeys.pem is defined in the NamedIdentities section
  
## Proposed changes
- make sure each and every peerInfo instance contains a not nil redundancy handler

## Testing procedure
- standard system test
- start a node in multikey mode. A BLS key from the set should be defined in the NamedIdentities section. A node without this fix will panic after bootstrapping.  

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
