### PR TITLE
Load tls config into logviewer

### DIFF
--- a/cmd/logviewer/CLI.md
+++ b/cmd/logviewer/CLI.md
@@ -22,6 +22,9 @@ GLOBAL OPTIONS:
    --use-wss                  Will use wss instead of ws when creating the web socket
    --log-correlation          Boolean option for enabling log correlation elements.
    --log-logger-name          Boolean option for logger name in the logs.
+   --with-tls                 Will use tls connection with the server
+   --cert value               Certificate file for tls connection (default: "certificate.crt")
+   --cert-pk value            Certificate pk file for tls connection (default: "private_key.pem")
    --help, -h                 show help
    --version, -v              print the version
    

--- a/cmd/logviewer/tls.go
+++ b/cmd/logviewer/tls.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+)
+
+func loadTLSClientConfig(certFile string, keyFile string) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	certPool, err := createCertPool(cert)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      certPool,
+	}, nil
+}
+
+func createCertPool(cert tls.Certificate) (*x509.CertPool, error) {
+	certLeaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, err
+	}
+
+	certPool := x509.NewCertPool()
+	certPool.AddCert(certLeaf)
+
+	return certPool, nil
+}


### PR DESCRIPTION
## Reasoning behind the pull request
- Load tls certificate into log viewer to be used when using the ws dialer
  

## Testing procedure
- Tested with a generated certificate from sovereign bridge tx server and it works

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
