### PR TITLE
Non critical fixes for Sirius (patch 2)

### DIFF
--- a/storage/factory/dbConfigHandler.go
+++ b/storage/factory/dbConfigHandler.go
@@ -1,6 +1,7 @@
 package factory
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,10 @@ import (
 const (
 	dbConfigFileName = "config.toml"
 	defaultType      = "LvlDBSerial"
+)
+
+var (
+	errInvalidConfiguration = errors.New("invalid configuration")
 )
 
 type dbConfigHandler struct {
@@ -38,7 +43,7 @@ func NewDBConfigHandler(config config.DBConfig) *dbConfigHandler {
 // GetDBConfig will get the db config based on path
 func (dh *dbConfigHandler) GetDBConfig(path string) (*config.DBConfig, error) {
 	dbConfigFromFile := &config.DBConfig{}
-	err := core.LoadTomlFile(dbConfigFromFile, getPersisterConfigFilePath(path))
+	err := readCorrectConfigurationFromToml(dbConfigFromFile, getPersisterConfigFilePath(path))
 	if err == nil {
 		log.Debug("GetDBConfig: loaded db config from toml config file",
 			"config path", path,
@@ -79,6 +84,20 @@ func (dh *dbConfigHandler) GetDBConfig(path string) (*config.DBConfig, error) {
 	return dbConfig, nil
 }
 
+func readCorrectConfigurationFromToml(dbConfig *config.DBConfig, filePath string) error {
+	err := core.LoadTomlFile(dbConfig, filePath)
+	if err != nil {
+		return err
+	}
+
+	isInvalidConfig := len(dbConfig.Type) == 0 || dbConfig.MaxBatchSize <= 0 || dbConfig.BatchDelaySeconds <= 0
+	if isInvalidConfig {
+		return errInvalidConfiguration
+	}
+
+	return nil
+}
+
 // SaveDBConfigToFilePath will save the provided db config to specified path
 func (dh *dbConfigHandler) SaveDBConfigToFilePath(path string, dbConfig *config.DBConfig) error {
 	pathExists, err := checkIfDirExists(path)
@@ -91,13 +110,6 @@ func (dh *dbConfigHandler) SaveDBConfigToFilePath(path string, dbConfig *config.
 	}
 
 	configFilePath := getPersisterConfigFilePath(path)
-
-	loadedDBConfig := &config.DBConfig{}
-	err = core.LoadTomlFile(loadedDBConfig, configFilePath)
-	if err == nil {
-		// config file already exists, no need to save config
-		return nil
-	}
 
 	err = core.SaveTomlFile(dbConfig, configFilePath)
 	if err != nil {

--- a/storage/factory/dbConfigHandler_test.go
+++ b/storage/factory/dbConfigHandler_test.go
@@ -2,11 +2,13 @@ package factory_test
 
 import (
 	"os"
+	"path"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/storage/factory"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,6 +90,37 @@ func TestDBConfigHandler_GetDBConfig(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, expectedDBConfig, conf)
 	})
+	t.Run("empty config.toml file, load default db config", func(t *testing.T) {
+		t.Parallel()
+
+		testConfig := createDefaultDBConfig()
+		testConfig.BatchDelaySeconds = 37
+		testConfig.MaxBatchSize = 38
+		testConfig.MaxOpenFiles = 39
+		testConfig.ShardIDProviderType = "BinarySplit"
+		testConfig.NumShards = 4
+		pf := factory.NewDBConfigHandler(testConfig)
+
+		dirPath := t.TempDir()
+
+		f, _ := os.Create(path.Join(dirPath, factory.DBConfigFileName))
+		_ = f.Close()
+
+		expectedDBConfig := &config.DBConfig{
+			FilePath:            "",
+			Type:                factory.DefaultType,
+			BatchDelaySeconds:   testConfig.BatchDelaySeconds,
+			MaxBatchSize:        testConfig.MaxBatchSize,
+			MaxOpenFiles:        testConfig.MaxOpenFiles,
+			UseTmpAsFilePath:    false,
+			ShardIDProviderType: "",
+			NumShards:           0,
+		}
+
+		conf, err := pf.GetDBConfig(dirPath)
+		require.Nil(t, err)
+		require.Equal(t, expectedDBConfig, conf)
+	})
 	t.Run("empty dir, load db config from main config", func(t *testing.T) {
 		t.Parallel()
 
@@ -146,22 +179,33 @@ func TestDBConfigHandler_SaveDBConfigToFilePath(t *testing.T) {
 		err := pf.SaveDBConfigToFilePath("no/valid/path", &dbConfig)
 		require.Nil(t, err)
 	})
-
-	t.Run("config file already present, should not fail", func(t *testing.T) {
+	t.Run("config file already present, should not fail and should rewrite", func(t *testing.T) {
 		t.Parallel()
 
-		dbConfig := createDefaultDBConfig()
+		dbConfig1 := createDefaultDBConfig()
+		dbConfig1.MaxOpenFiles = 37
+		dbConfig1.Type = "dbconfig1"
 		dirPath := t.TempDir()
 		configPath := factory.GetPersisterConfigFilePath(dirPath)
 
-		err := core.SaveTomlFile(dbConfig, configPath)
+		err := core.SaveTomlFile(dbConfig1, configPath)
 		require.Nil(t, err)
 
-		pf := factory.NewDBConfigHandler(dbConfig)
-		err = pf.SaveDBConfigToFilePath(dirPath, &dbConfig)
+		pf := factory.NewDBConfigHandler(dbConfig1)
+
+		dbConfig2 := createDefaultDBConfig()
+		dbConfig2.MaxOpenFiles = 38
+		dbConfig2.Type = "dbconfig2"
+
+		err = pf.SaveDBConfigToFilePath(dirPath, &dbConfig2)
 		require.Nil(t, err)
+
+		loadedDBConfig := &config.DBConfig{}
+		err = core.LoadTomlFile(loadedDBConfig, path.Join(dirPath, "config.toml"))
+		require.Nil(t, err)
+
+		assert.Equal(t, dbConfig2, *loadedDBConfig)
 	})
-
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 

--- a/storage/factory/export_test.go
+++ b/storage/factory/export_test.go
@@ -8,6 +8,9 @@ import (
 // DefaultType exports the defaultType const to be used in tests
 const DefaultType = defaultType
 
+// DBConfigFileName exports the dbConfigFileName const to be used in tests
+const DBConfigFileName = dbConfigFileName
+
 // GetPersisterConfigFilePath -
 func GetPersisterConfigFilePath(path string) string {
 	return getPersisterConfigFilePath(path)

--- a/vm/systemSmartContracts/esdt.go
+++ b/vm/systemSmartContracts/esdt.go
@@ -1343,7 +1343,7 @@ func (e *esdt) getSpecialRoles(args *vmcommon.ContractCallInput) vmcommon.Return
 			rolesAsString = append(rolesAsString, string(role))
 		}
 
-		specialRoleAddress := e.addressPubKeyConverter.SilentEncode(specialRole.Address, log)
+		specialRoleAddress, _ := e.addressPubKeyConverter.Encode(specialRole.Address)
 
 		roles := strings.Join(rolesAsString, ",")
 		message := fmt.Sprintf("%s:%s", specialRoleAddress, roles)


### PR DESCRIPTION
## Reasoning behind the pull request
- there were some WARN logs generated by an observer node, originating from esdt.go L1346
- the node can not start if some of the storage DBs contain empty `config.toml` files 
  
## Proposed changes
- replaced the `SilentEncode` method with `Encode` method
- made the `dbConfigHandler` struct more robust by always rewriting a given configuration and testing the read configuration from the file so it won't be invalid

## Testing procedure
- standard system test
- import-db test

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
