### PR TITLE
Temporary fix for the single-key redundancy system

### DIFF
--- a/consensus/spos/bls/subroundStartRound.go
+++ b/consensus/spos/bls/subroundStartRound.go
@@ -155,6 +155,10 @@ func (sr *subroundStartRound) initCurrentRound() bool {
 			sr.ConsensusGroup(),
 			sr.RoundHandler().Index(),
 		)
+		// TODO refactor the usage of the single key & multikey redundancy system
+		if sr.NodeRedundancyHandler().IsMainMachineActive() {
+			return false
+		}
 	}
 
 	leader, err := sr.GetLeader()

--- a/consensus/spos/bls/subroundStartRound_test.go
+++ b/consensus/spos/bls/subroundStartRound_test.go
@@ -428,7 +428,7 @@ func TestSubroundStartRound_InitCurrentRoundShouldReturnFalseWhenGenerateNextCon
 	assert.False(t, r)
 }
 
-func TestSubroundStartRound_InitCurrentRoundShouldReturnTrueWhenMainMachineIsActive(t *testing.T) {
+func TestSubroundStartRound_InitCurrentRoundShouldReturnFalseWhenMainMachineIsActive(t *testing.T) {
 	t.Parallel()
 
 	nodeRedundancyMock := &mock.NodeRedundancyHandlerStub{
@@ -442,7 +442,7 @@ func TestSubroundStartRound_InitCurrentRoundShouldReturnTrueWhenMainMachineIsAct
 	srStartRound := *initSubroundStartRoundWithContainer(container)
 
 	r := srStartRound.InitCurrentRound()
-	assert.True(t, r)
+	assert.False(t, r)
 }
 
 func TestSubroundStartRound_InitCurrentRoundShouldReturnFalseWhenGetLeaderErr(t *testing.T) {


### PR DESCRIPTION
## Reasoning behind the pull request
- in single-key operation mode, the redundancy machines can generate forks
  
## Proposed changes
- cancel start subround in single key redundancy mode

## Testing procedure
- standard system test
- single key redundancy tests

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
