### PR TITLE
[Sandbox] sketch frozen node box (stuck at a chosen previous round)

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/config/overridableConfig"
+	"github.com/multiversx/mx-chain-go/frozen"
 	"github.com/multiversx/mx-chain-go/node"
 	logger "github.com/multiversx/mx-chain-logger-go"
 	"github.com/multiversx/mx-chain-logger-go/file"
@@ -128,6 +129,8 @@ func startNodeRunner(c *cli.Context, log logger.Logger, baseVersion string, vers
 
 	cfgs.FlagsConfig.BaseVersion = baseVersion
 	cfgs.FlagsConfig.Version = version
+
+	frozen.Setup()
 
 	nodeRunner, errRunner := node.NewNodeRunner(cfgs)
 	if errRunner != nil {

--- a/frozen/frozen.go
+++ b/frozen/frozen.go
@@ -1,5 +1,31 @@
 package frozen
 
-var IsFrozen = true
-var ShouldOverrideHighestRound = true
-var HighestRound = int64(17437677)
+import (
+	"os"
+	"strconv"
+
+	logger "github.com/multiversx/mx-chain-logger-go"
+)
+
+var IsFrozen = false
+var ShouldOverrideHighestRound = false
+var HighestRound = int64(0)
+
+var log = logger.GetOrCreate("frozen")
+
+func Setup() {
+	envFrozen := os.Getenv("FROZEN")
+	envHighestRound := os.Getenv("HIGHEST_ROUND")
+
+	IsFrozen, _ = strconv.ParseBool(envFrozen)
+	ShouldOverrideHighestRound = len(envHighestRound) > 0
+	HighestRound, _ = strconv.ParseInt(envHighestRound, 10, 64)
+
+	if IsFrozen {
+		log.Warn("Frozen mode is enabled")
+	}
+
+	if ShouldOverrideHighestRound {
+		log.Warn("Highest round is overriden", "round", HighestRound)
+	}
+}

--- a/frozen/frozen.go
+++ b/frozen/frozen.go
@@ -1,0 +1,5 @@
+package frozen
+
+var IsFrozen = true
+var ShouldOverrideHighestRound = true
+var HighestRound = int64(17437677)

--- a/process/block/bootstrapStorage/bootstrapStorer.go
+++ b/process/block/bootstrapStorage/bootstrapStorer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/frozen"
 	"github.com/multiversx/mx-chain-go/storage"
 )
 
@@ -96,6 +97,10 @@ func (bs *bootstrapStorer) Get(round int64) (BootstrapData, error) {
 
 // GetHighestRound will return the highest round saved in storage
 func (bs *bootstrapStorer) GetHighestRound() int64 {
+	if frozen.ShouldOverrideHighestRound {
+		return frozen.HighestRound
+	}
+
 	roundBytes, err := bs.store.Get([]byte(common.HighestRoundFromBootStorage))
 	if err != nil {
 		return 0

--- a/process/smartContract/scQueryService.go
+++ b/process/smartContract/scQueryService.go
@@ -19,6 +19,7 @@ import (
 	"github.com/multiversx/mx-chain-go/common/holders"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/dblookupext"
+	"github.com/multiversx/mx-chain-go/frozen"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/smartContract/scrCommon"
 	"github.com/multiversx/mx-chain-go/sharding"
@@ -170,6 +171,10 @@ func (service *SCQueryService) ExecuteQuery(query *process.SCQuery) (*vmcommon.V
 }
 
 func (service *SCQueryService) shouldAllowQueriesExecution() bool {
+	if frozen.IsFrozen {
+		return true
+	}
+
 	select {
 	case <-service.allowExternalQueriesChan:
 		return true

--- a/process/sync/metablock.go
+++ b/process/sync/metablock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
+	"github.com/multiversx/mx-chain-go/frozen"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/storage"
@@ -148,6 +149,11 @@ func (boot *MetaBootstrap) StartSyncingBlocks() error {
 
 	var ctx context.Context
 	ctx, boot.cancelFunc = context.WithCancel(context.Background())
+
+	if frozen.IsFrozen {
+		return nil
+	}
+
 	go boot.syncBlocks(ctx)
 
 	return nil

--- a/process/sync/shardblock.go
+++ b/process/sync/shardblock.go
@@ -10,6 +10,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
+	"github.com/multiversx/mx-chain-go/frozen"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/storage"
 )
@@ -137,6 +138,10 @@ func (boot *ShardBootstrap) StartSyncingBlocks() error {
 	err := boot.handleAccountsTrieIteration()
 	if err != nil {
 		return fmt.Errorf("%w while handling accounts trie iteration", err)
+	}
+
+	if frozen.IsFrozen {
+		return nil
 	}
 
 	go boot.syncBlocks(ctx)

--- a/state/syncer/userAccountsSyncer.go
+++ b/state/syncer/userAccountsSyncer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/errChan"
+	"github.com/multiversx/mx-chain-go/frozen"
 	"github.com/multiversx/mx-chain-go/process/factory"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/state/accounts"
@@ -107,6 +108,10 @@ func NewUserAccountsSyncer(args ArgsNewUserAccountsSyncer) (*userAccountsSyncer,
 
 // SyncAccounts will launch the syncing method to gather all the data needed for userAccounts - it is a blocking method
 func (u *userAccountsSyncer) SyncAccounts(rootHash []byte, storageMarker common.StorageMarker) error {
+	if frozen.IsFrozen {
+		return nil
+	}
+
 	if check.IfNil(storageMarker) {
 		return ErrNilStorageMarker
 	}

--- a/state/syncer/validatorAccountsSyncer.go
+++ b/state/syncer/validatorAccountsSyncer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/frozen"
 	"github.com/multiversx/mx-chain-go/process/factory"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/trie/statistics"
@@ -62,6 +63,10 @@ func NewValidatorAccountsSyncer(args ArgsNewValidatorAccountsSyncer) (*validator
 
 // SyncAccounts will launch the syncing method to gather all the data needed for validatorAccounts - it is a blocking method
 func (v *validatorAccountsSyncer) SyncAccounts(rootHash []byte, storageMarker common.StorageMarker) error {
+	if frozen.IsFrozen {
+		return nil
+	}
+
 	if check.IfNil(storageMarker) {
 		return ErrNilStorageMarker
 	}

--- a/storage/pruning/pruningStorer.go
+++ b/storage/pruning/pruningStorer.go
@@ -15,6 +15,7 @@ import (
 	storageCore "github.com/multiversx/mx-chain-core-go/storage"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/epochStart/notifier"
+	"github.com/multiversx/mx-chain-go/frozen"
 	"github.com/multiversx/mx-chain-go/storage"
 	"github.com/multiversx/mx-chain-go/storage/clean"
 	"github.com/multiversx/mx-chain-go/storage/storageunit"
@@ -220,7 +221,12 @@ func initPersistersInEpoch(
 	var persisters []*persisterData
 	persistersMapByEpoch := make(map[uint32]*persisterData)
 
-	for epoch := int64(args.EpochsData.StartingEpoch); epoch >= 0; epoch-- {
+	oldestEpoch := int64(0)
+	if frozen.IsFrozen {
+		oldestEpoch = int64(args.EpochsData.StartingEpoch) - 1
+	}
+
+	for epoch := int64(args.EpochsData.StartingEpoch); epoch >= oldestEpoch; epoch-- {
 		if args.PersistersTracker.HasInitializedEnoughPersisters(epoch) {
 			break
 		}


### PR DESCRIPTION
Useful for performing VM queries at a certain point in the past.

```
export SANDBOX=~/sandbox
export ARCHIVES_URL=".../mainnet/shard-..."
export SHARD=1
export EPOCH=1210
export HIGHEST_ROUND=17437677

mkdir $SANDBOX && cd $SANDBOX
git clone https://github.com/multiversx/mx-chain-mainnet-config --branch=master --single-branch --depth=1 config
git clone https://github.com/multiversx/mx-chain-go --branch=sandbox-frozen --single-branch --depth=1

cd ./mx-chain-go/cmd/node && go build . && cp ./node $SANDBOX

cd $SANDBOX
# "Static" archive is not necessary
wget $ARCHIVES_URL/Epoch_${EPOCH}.tar
tar -xf Epoch_${EPOCH}.tar

mkdir -p $SANDBOX/db/1
mv $SANDBOX/Epoch_${EPOCH} $SANDBOX/db/1
```

Then, edit `prefs.toml`, section `BlockProcessingCutoff` (set the desired round `$HIGHEST_ROUND`):

```
[BlockProcessingCutoff]
   Enabled = true
   Mode = "pause"
   CutoffTrigger = "round"
   Value = 17437677
```

```
cd $SANDBOX
FROZEN=true ./node --log-level=*:DEBUG --use-log-view --log-save --destination-shard-as-observer=${SHARD} --start-in-epoch=false
```

Now perform VM queries against http://localhost:8080.