### PR TITLE
Proper fix for redundancy

### DIFF
--- a/consensus/spos/bls/subroundBlock.go
+++ b/consensus/spos/bls/subroundBlock.go
@@ -63,7 +63,8 @@ func checkNewSubroundBlockParams(
 
 // doBlockJob method does the job of the subround Block
 func (sr *subroundBlock) doBlockJob(ctx context.Context) bool {
-	if !sr.IsSelfLeaderInCurrentRound() && !sr.IsMultiKeyLeaderInCurrentRound() { // is NOT self leader in this round?
+	isSelfLeader := sr.IsSelfLeaderInCurrentRound() && sr.ShouldConsiderSelfKeyInConsensus()
+	if !isSelfLeader && !sr.IsMultiKeyLeaderInCurrentRound() { // is NOT self leader in this round?
 		return false
 	}
 

--- a/consensus/spos/bls/subroundStartRound.go
+++ b/consensus/spos/bls/subroundStartRound.go
@@ -155,10 +155,8 @@ func (sr *subroundStartRound) initCurrentRound() bool {
 			sr.ConsensusGroup(),
 			sr.RoundHandler().Index(),
 		)
-		// TODO refactor the usage of the single key & multikey redundancy system
-		if sr.NodeRedundancyHandler().IsMainMachineActive() {
-			return false
-		}
+		// we should not return here, the multikey redundancy system relies on it
+		// the NodeRedundancyHandler "thinks" it is in redundancy mode even if we use the multikey redundancy system
 	}
 
 	leader, err := sr.GetLeader()

--- a/consensus/spos/bls/subroundStartRound_test.go
+++ b/consensus/spos/bls/subroundStartRound_test.go
@@ -428,7 +428,7 @@ func TestSubroundStartRound_InitCurrentRoundShouldReturnFalseWhenGenerateNextCon
 	assert.False(t, r)
 }
 
-func TestSubroundStartRound_InitCurrentRoundShouldReturnFalseWhenMainMachineIsActive(t *testing.T) {
+func TestSubroundStartRound_InitCurrentRoundShouldReturnTrueWhenMainMachineIsActive(t *testing.T) {
 	t.Parallel()
 
 	nodeRedundancyMock := &mock.NodeRedundancyHandlerStub{
@@ -442,7 +442,7 @@ func TestSubroundStartRound_InitCurrentRoundShouldReturnFalseWhenMainMachineIsAc
 	srStartRound := *initSubroundStartRoundWithContainer(container)
 
 	r := srStartRound.InitCurrentRound()
-	assert.False(t, r)
+	assert.True(t, r)
 }
 
 func TestSubroundStartRound_InitCurrentRoundShouldReturnFalseWhenGetLeaderErr(t *testing.T) {


### PR DESCRIPTION
## Reasoning behind the pull request
- multikey redundancy stopped working after merging this PR https://github.com/multiversx/mx-chain-go/pull/5808
  
## Proposed changes
- proper fix for redundancy 

## Testing procedure
- standard system test
- single-key & multi-key redundancy tests

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
