### PR TITLE
FIX: Remove enforced config protections

### DIFF
--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -309,7 +309,7 @@
         # - Enable epoch = StakingV4Step3EnableEpoch
         # - NodesToShufflePerShard = same as previous entry in MaxNodesChangeEnableEpoch
         # - MaxNumNodes = (MaxNumNodesFromPreviousEpochEnable - (numOfShards+1)*NodesToShufflePerShard)
-        { EpochEnable = 6, MaxNumNodes = 50, NodesToShufflePerShard = 2 },
+        { EpochEnable = 6, MaxNumNodes = 48, NodesToShufflePerShard = 2 },
     ]
 
 [GasSchedule]

--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -309,7 +309,7 @@
         # - Enable epoch = StakingV4Step3EnableEpoch
         # - NodesToShufflePerShard = same as previous entry in MaxNodesChangeEnableEpoch
         # - MaxNumNodes = (MaxNumNodesFromPreviousEpochEnable - (numOfShards+1)*NodesToShufflePerShard)
-        { EpochEnable = 6, MaxNumNodes = 48, NodesToShufflePerShard = 2 },
+        { EpochEnable = 6, MaxNumNodes = 50, NodesToShufflePerShard = 2 },
     ]
 
 [GasSchedule]

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -106,11 +106,6 @@ func startNodeRunner(c *cli.Context, log logger.Logger, baseVersion string, vers
 		return errCfgOverride
 	}
 
-	errCheckEpochsCfg := config.SanityCheckEnableEpochsStakingV4(cfgs)
-	if errCheckEpochsCfg != nil {
-		return errCheckEpochsCfg
-	}
-
 	if !check.IfNil(fileLogging) {
 		timeLogLifeSpan := time.Second * time.Duration(cfgs.GeneralConfig.Logs.LogFileLifeSpanInSec)
 		sizeLogLifeSpanInMB := uint64(cfgs.GeneralConfig.Logs.LogFileLifeSpanInMB)

--- a/config/configChecker.go
+++ b/config/configChecker.go
@@ -28,11 +28,6 @@ func checkMaxNodesConfig(
 	nodesSetup NodesSetupHandler,
 	maxNodesConfig MaxNodesChangeConfig,
 ) error {
-	nodesToShufflePerShard := maxNodesConfig.NodesToShufflePerShard
-	if nodesToShufflePerShard == 0 {
-		return errZeroNodesToShufflePerShard
-	}
-
 	maxNumNodes := maxNodesConfig.MaxNumNodes
 	minNumNodesWithHysteresis := nodesSetup.MinNumberOfNodesWithHysteresis()
 	if maxNumNodes < minNumNodesWithHysteresis {
@@ -60,7 +55,7 @@ func areStakingV4StepsInOrder(enableEpochsCfg EnableEpochs) bool {
 func checkStakingV4MaxNodesChangeCfg(enableEpochsCfg EnableEpochs, numOfShards uint32) error {
 	maxNodesChangeCfg := enableEpochsCfg.MaxNodesChangeEnableEpoch
 	if len(maxNodesChangeCfg) <= 1 {
-		return errNotEnoughMaxNodesChanges
+		return nil
 	}
 
 	maxNodesConfigAdaptedForStakingV4 := false

--- a/config/configChecker.go
+++ b/config/configChecker.go
@@ -35,12 +35,12 @@ func checkStakingV4MaxNodesChangeCfg(enableEpochsCfg EnableEpochs, numOfShards u
 			if idx == 0 {
 				return fmt.Errorf("found config change in MaxNodesChangeEnableEpoch for StakingV4Step3EnableEpoch = %d, but %w ",
 					enableEpochsCfg.StakingV4Step3EnableEpoch, errNoMaxNodesConfigBeforeStakingV4)
-			} else {
-				prevMaxNodesChange := maxNodesChangeCfg[idx-1]
-				err := checkMaxNodesChangedCorrectly(prevMaxNodesChange, currMaxNodesChangeCfg, numOfShards)
-				if err != nil {
-					return err
-				}
+			}
+
+			prevMaxNodesChange := maxNodesChangeCfg[idx-1]
+			err := checkMaxNodesChangedCorrectly(prevMaxNodesChange, currMaxNodesChangeCfg, numOfShards)
+			if err != nil {
+				return err
 			}
 
 			break
@@ -100,38 +100,5 @@ func checkMaxNodesConfig(
 			errInvalidMaxMinNodes, maxNumNodes, minNumNodesWithHysteresis)
 	}
 
-	numShards := nodesSetup.NumberOfShards()
-	waitingListPerShard := (maxNumNodes - minNumNodesWithHysteresis) / (numShards + 1)
-	if nodesToShufflePerShard > waitingListPerShard {
-		return fmt.Errorf("%w, nodesToShufflePerShard: %d, waitingListPerShard: %d",
-			errInvalidNodesToShuffle, nodesToShufflePerShard, waitingListPerShard)
-	}
-
-	if minNumNodesWithHysteresis > nodesSetup.MinNumberOfNodes() {
-		return checkHysteresis(nodesSetup, nodesToShufflePerShard)
-	}
-
 	return nil
-}
-
-func checkHysteresis(nodesSetup NodesSetupHandler, numToShufflePerShard uint32) error {
-	hysteresis := nodesSetup.GetHysteresis()
-
-	forcedWaitingListNodesPerShard := getHysteresisNodes(nodesSetup.MinNumberOfShardNodes(), hysteresis)
-	if numToShufflePerShard > forcedWaitingListNodesPerShard {
-		return fmt.Errorf("%w per shard for numToShufflePerShard: %d, forcedWaitingListNodesPerShard: %d",
-			errInvalidNodesToShuffleWithHysteresis, numToShufflePerShard, forcedWaitingListNodesPerShard)
-	}
-
-	forcedWaitingListNodesInMeta := getHysteresisNodes(nodesSetup.MinNumberOfMetaNodes(), hysteresis)
-	if numToShufflePerShard > forcedWaitingListNodesInMeta {
-		return fmt.Errorf("%w in metachain for numToShufflePerShard: %d, forcedWaitingListNodesInMeta: %d",
-			errInvalidNodesToShuffleWithHysteresis, numToShufflePerShard, forcedWaitingListNodesInMeta)
-	}
-
-	return nil
-}
-
-func getHysteresisNodes(minNumNodes uint32, hysteresis float32) uint32 {
-	return uint32(float32(minNumNodes) * hysteresis)
 }

--- a/config/configChecker.go
+++ b/config/configChecker.go
@@ -2,7 +2,11 @@ package config
 
 import (
 	"fmt"
+
+	logger "github.com/multiversx/mx-chain-logger-go"
 )
+
+var log = logger.GetOrCreate("config-checker")
 
 // SanityCheckNodesConfig checks if the nodes limit setup is set correctly
 func SanityCheckNodesConfig(
@@ -66,8 +70,9 @@ func checkStakingV4MaxNodesChangeCfg(enableEpochsCfg EnableEpochs, numOfShards u
 			maxNodesConfigAdaptedForStakingV4 = true
 
 			if idx == 0 {
-				return fmt.Errorf("found config change in MaxNodesChangeEnableEpoch for StakingV4Step3EnableEpoch = %d, but %w ",
-					enableEpochsCfg.StakingV4Step3EnableEpoch, errNoMaxNodesConfigBeforeStakingV4)
+				log.Warn(fmt.Errorf("found config change in MaxNodesChangeEnableEpoch for StakingV4Step3EnableEpoch = %d, but %w ",
+					enableEpochsCfg.StakingV4Step3EnableEpoch, errNoMaxNodesConfigBeforeStakingV4).Error())
+				break
 			}
 
 			prevMaxNodesChange := maxNodesChangeCfg[idx-1]

--- a/config/configChecker_test.go
+++ b/config/configChecker_test.go
@@ -86,7 +86,7 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 		require.Equal(t, errStakingV4StepsNotInOrder, err)
 	})
 
-	t.Run("no previous config for max nodes change, should return error", func(t *testing.T) {
+	t.Run("no previous config for max nodes change with one entry, should not return error", func(t *testing.T) {
 		t.Parallel()
 
 		cfg := generateCorrectConfig()
@@ -99,7 +99,7 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 		}
 
 		err := sanityCheckEnableEpochsStakingV4(cfg, numOfShards)
-		require.Equal(t, errNotEnoughMaxNodesChanges, err)
+		require.Nil(t, err)
 	})
 
 	t.Run("no max nodes config change for StakingV4Step3EnableEpoch, should return error", func(t *testing.T) {
@@ -278,13 +278,18 @@ func TestSanityCheckNodesConfig(t *testing.T) {
 		require.Nil(t, err)
 	})
 
-	t.Run("zero nodes to shuffle per shard, should return error", func(t *testing.T) {
+	t.Run("zero nodes to shuffle per shard, should not return error", func(t *testing.T) {
 		t.Parallel()
 
 		cfg := generateCorrectConfig()
 		cfg.MaxNodesChangeEnableEpoch = []MaxNodesChangeConfig{
 			{
 				EpochEnable:            4,
+				MaxNumNodes:            3200,
+				NodesToShufflePerShard: 0,
+			},
+			{
+				EpochEnable:            6,
 				MaxNumNodes:            3200,
 				NodesToShufflePerShard: 0,
 			},
@@ -296,9 +301,7 @@ func TestSanityCheckNodesConfig(t *testing.T) {
 			MinNumberOfShardNodesField: 400,
 		}
 		err := SanityCheckNodesConfig(nodesSetup, cfg)
-		require.NotNil(t, err)
-		require.True(t, strings.Contains(err.Error(), errZeroNodesToShufflePerShard.Error()))
-		require.True(t, strings.Contains(err.Error(), "at EpochEnable = 4"))
+		require.Nil(t, err)
 	})
 
 	t.Run("maxNumNodes < minNumNodesWithHysteresis, should return error ", func(t *testing.T) {

--- a/config/configChecker_test.go
+++ b/config/configChecker_test.go
@@ -125,7 +125,7 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 		require.True(t, strings.Contains(err.Error(), "6"))
 	})
 
-	t.Run("max nodes config change for StakingV4Step3EnableEpoch has no previous config change, should return error", func(t *testing.T) {
+	t.Run("max nodes config change for StakingV4Step3EnableEpoch has no previous config change, should not error", func(t *testing.T) {
 		t.Parallel()
 
 		cfg := generateCorrectConfig()
@@ -143,8 +143,7 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 		}
 
 		err := sanityCheckEnableEpochsStakingV4(cfg, numOfShards)
-		require.NotNil(t, err)
-		require.ErrorIs(t, err, errNoMaxNodesConfigBeforeStakingV4)
+		require.Nil(t, err)
 	})
 
 	t.Run("stakingV4 config for max nodes changed with different nodes to shuffle, should return error", func(t *testing.T) {

--- a/config/configChecker_test.go
+++ b/config/configChecker_test.go
@@ -227,6 +227,58 @@ func TestSanityCheckNodesConfig(t *testing.T) {
 		}
 		err = SanityCheckNodesConfig(nodesSetup, cfg)
 		require.Nil(t, err)
+
+		cfg = []MaxNodesChangeConfig{
+			{
+				EpochEnable:            0,
+				MaxNumNodes:            36,
+				NodesToShufflePerShard: 4,
+			},
+			{
+				EpochEnable:            1,
+				MaxNumNodes:            56,
+				NodesToShufflePerShard: 2,
+			},
+			{
+				EpochEnable:            6,
+				MaxNumNodes:            48,
+				NodesToShufflePerShard: 2,
+			},
+		}
+		nodesSetup = &nodesSetupMock.NodesSetupMock{
+			NumberOfShardsField:        numShards,
+			HysteresisField:            0,
+			MinNumberOfMetaNodesField:  3,
+			MinNumberOfShardNodesField: 3,
+		}
+		err = SanityCheckNodesConfig(nodesSetup, cfg)
+		require.Nil(t, err)
+
+		cfg = []MaxNodesChangeConfig{
+			{
+				EpochEnable:            0,
+				MaxNumNodes:            36,
+				NodesToShufflePerShard: 4,
+			},
+			{
+				EpochEnable:            1,
+				MaxNumNodes:            56,
+				NodesToShufflePerShard: 2,
+			},
+			{
+				EpochEnable:            6,
+				MaxNumNodes:            48,
+				NodesToShufflePerShard: 2,
+			},
+		}
+		nodesSetup = &nodesSetupMock.NodesSetupMock{
+			NumberOfShardsField:        numShards,
+			HysteresisField:            0.2,
+			MinNumberOfMetaNodesField:  7,
+			MinNumberOfShardNodesField: 7,
+		}
+		err = SanityCheckNodesConfig(nodesSetup, cfg)
+		require.Nil(t, err)
 	})
 
 	t.Run("zero nodes to shuffle per shard, should return error", func(t *testing.T) {
@@ -272,76 +324,5 @@ func TestSanityCheckNodesConfig(t *testing.T) {
 		require.True(t, strings.Contains(err.Error(), errInvalidMaxMinNodes.Error()))
 		require.True(t, strings.Contains(err.Error(), "maxNumNodes: 1900"))
 		require.True(t, strings.Contains(err.Error(), "minNumNodesWithHysteresis: 1920"))
-	})
-
-	t.Run("invalid nodes to shuffle per shard, should return error ", func(t *testing.T) {
-		t.Parallel()
-
-		cfg := []MaxNodesChangeConfig{
-			{
-				EpochEnable:            3,
-				MaxNumNodes:            2240,
-				NodesToShufflePerShard: 81,
-			},
-		}
-		nodesSetup := &nodesSetupMock.NodesSetupMock{
-			NumberOfShardsField:        numShards,
-			HysteresisField:            0.2,
-			MinNumberOfMetaNodesField:  400,
-			MinNumberOfShardNodesField: 400,
-		}
-		err := SanityCheckNodesConfig(nodesSetup, cfg)
-		require.NotNil(t, err)
-		require.True(t, strings.Contains(err.Error(), errInvalidNodesToShuffle.Error()))
-		require.True(t, strings.Contains(err.Error(), "nodesToShufflePerShard: 81"))
-		require.True(t, strings.Contains(err.Error(), "waitingListPerShard: 80"))
-	})
-
-	t.Run("invalid nodes to shuffle per shard with hysteresis, should return error ", func(t *testing.T) {
-		t.Parallel()
-
-		cfg := []MaxNodesChangeConfig{
-			{
-				EpochEnable:            1,
-				MaxNumNodes:            1600,
-				NodesToShufflePerShard: 80,
-			},
-		}
-		nodesSetup := &nodesSetupMock.NodesSetupMock{
-			NumberOfShardsField:        1,
-			HysteresisField:            0.2,
-			MinNumberOfMetaNodesField:  500,
-			MinNumberOfShardNodesField: 300,
-		}
-		err := SanityCheckNodesConfig(nodesSetup, cfg)
-		require.NotNil(t, err)
-		require.True(t, strings.Contains(err.Error(), errInvalidNodesToShuffleWithHysteresis.Error()))
-		require.True(t, strings.Contains(err.Error(), "per shard"))
-		require.True(t, strings.Contains(err.Error(), "numToShufflePerShard: 80"))
-		require.True(t, strings.Contains(err.Error(), "forcedWaitingListNodesPerShard: 60"))
-	})
-
-	t.Run("invalid nodes to shuffle in metachain with hysteresis, should return error ", func(t *testing.T) {
-		t.Parallel()
-
-		cfg := []MaxNodesChangeConfig{
-			{
-				EpochEnable:            1,
-				MaxNumNodes:            1600,
-				NodesToShufflePerShard: 80,
-			},
-		}
-		nodesSetup := &nodesSetupMock.NodesSetupMock{
-			NumberOfShardsField:        1,
-			HysteresisField:            0.2,
-			MinNumberOfMetaNodesField:  300,
-			MinNumberOfShardNodesField: 500,
-		}
-		err := SanityCheckNodesConfig(nodesSetup, cfg)
-		require.NotNil(t, err)
-		require.True(t, strings.Contains(err.Error(), errInvalidNodesToShuffleWithHysteresis.Error()))
-		require.True(t, strings.Contains(err.Error(), "in metachain"))
-		require.True(t, strings.Contains(err.Error(), "numToShufflePerShard: 80"))
-		require.True(t, strings.Contains(err.Error(), "forcedWaitingListNodesInMeta: 60"))
 	})
 }

--- a/config/configChecker_test.go
+++ b/config/configChecker_test.go
@@ -8,35 +8,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func generateCorrectConfig() *Configs {
-	return &Configs{
-		EpochConfig: &EpochConfig{
-			EnableEpochs: EnableEpochs{
-				StakingV4Step1EnableEpoch: 4,
-				StakingV4Step2EnableEpoch: 5,
-				StakingV4Step3EnableEpoch: 6,
-				MaxNodesChangeEnableEpoch: []MaxNodesChangeConfig{
-					{
-						EpochEnable:            0,
-						MaxNumNodes:            36,
-						NodesToShufflePerShard: 4,
-					},
-					{
-						EpochEnable:            1,
-						MaxNumNodes:            56,
-						NodesToShufflePerShard: 2,
-					},
-					{
-						EpochEnable:            6,
-						MaxNumNodes:            48,
-						NodesToShufflePerShard: 2,
-					},
-				},
+const numOfShards = 3
+
+func generateCorrectConfig() EnableEpochs {
+	return EnableEpochs{
+		StakingV4Step1EnableEpoch: 4,
+		StakingV4Step2EnableEpoch: 5,
+		StakingV4Step3EnableEpoch: 6,
+		MaxNodesChangeEnableEpoch: []MaxNodesChangeConfig{
+			{
+				EpochEnable:            0,
+				MaxNumNodes:            36,
+				NodesToShufflePerShard: 4,
 			},
-		},
-		GeneralConfig: &Config{
-			GeneralSettings: GeneralSettingsConfig{
-				GenesisMaxNumberOfShards: 3,
+			{
+				EpochEnable:            1,
+				MaxNumNodes:            56,
+				NodesToShufflePerShard: 2,
+			},
+			{
+				EpochEnable:            6,
+				MaxNumNodes:            48,
+				NodesToShufflePerShard: 2,
 			},
 		},
 	}
@@ -49,7 +42,7 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 		t.Parallel()
 
 		cfg := generateCorrectConfig()
-		err := SanityCheckEnableEpochsStakingV4(cfg)
+		err := sanityCheckEnableEpochsStakingV4(cfg, numOfShards)
 		require.Nil(t, err)
 	})
 
@@ -57,15 +50,15 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 		t.Parallel()
 
 		cfg := generateCorrectConfig()
-		cfg.EpochConfig.EnableEpochs.StakingV4Step1EnableEpoch = 5
-		cfg.EpochConfig.EnableEpochs.StakingV4Step2EnableEpoch = 5
-		err := SanityCheckEnableEpochsStakingV4(cfg)
+		cfg.StakingV4Step1EnableEpoch = 5
+		cfg.StakingV4Step2EnableEpoch = 5
+		err := sanityCheckEnableEpochsStakingV4(cfg, numOfShards)
 		require.Equal(t, errStakingV4StepsNotInOrder, err)
 
 		cfg = generateCorrectConfig()
-		cfg.EpochConfig.EnableEpochs.StakingV4Step2EnableEpoch = 5
-		cfg.EpochConfig.EnableEpochs.StakingV4Step3EnableEpoch = 4
-		err = SanityCheckEnableEpochsStakingV4(cfg)
+		cfg.StakingV4Step2EnableEpoch = 5
+		cfg.StakingV4Step3EnableEpoch = 4
+		err = sanityCheckEnableEpochsStakingV4(cfg, numOfShards)
 		require.Equal(t, errStakingV4StepsNotInOrder, err)
 	})
 
@@ -74,22 +67,22 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 
 		cfg := generateCorrectConfig()
 
-		cfg.EpochConfig.EnableEpochs.StakingV4Step1EnableEpoch = 1
-		cfg.EpochConfig.EnableEpochs.StakingV4Step2EnableEpoch = 3
-		cfg.EpochConfig.EnableEpochs.StakingV4Step3EnableEpoch = 6
-		err := SanityCheckEnableEpochsStakingV4(cfg)
+		cfg.StakingV4Step1EnableEpoch = 1
+		cfg.StakingV4Step2EnableEpoch = 3
+		cfg.StakingV4Step3EnableEpoch = 6
+		err := sanityCheckEnableEpochsStakingV4(cfg, numOfShards)
 		require.Equal(t, errStakingV4StepsNotInOrder, err)
 
-		cfg.EpochConfig.EnableEpochs.StakingV4Step1EnableEpoch = 1
-		cfg.EpochConfig.EnableEpochs.StakingV4Step2EnableEpoch = 2
-		cfg.EpochConfig.EnableEpochs.StakingV4Step3EnableEpoch = 6
-		err = SanityCheckEnableEpochsStakingV4(cfg)
+		cfg.StakingV4Step1EnableEpoch = 1
+		cfg.StakingV4Step2EnableEpoch = 2
+		cfg.StakingV4Step3EnableEpoch = 6
+		err = sanityCheckEnableEpochsStakingV4(cfg, numOfShards)
 		require.Equal(t, errStakingV4StepsNotInOrder, err)
 
-		cfg.EpochConfig.EnableEpochs.StakingV4Step1EnableEpoch = 1
-		cfg.EpochConfig.EnableEpochs.StakingV4Step2EnableEpoch = 5
-		cfg.EpochConfig.EnableEpochs.StakingV4Step3EnableEpoch = 6
-		err = SanityCheckEnableEpochsStakingV4(cfg)
+		cfg.StakingV4Step1EnableEpoch = 1
+		cfg.StakingV4Step2EnableEpoch = 5
+		cfg.StakingV4Step3EnableEpoch = 6
+		err = sanityCheckEnableEpochsStakingV4(cfg, numOfShards)
 		require.Equal(t, errStakingV4StepsNotInOrder, err)
 	})
 
@@ -97,7 +90,7 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 		t.Parallel()
 
 		cfg := generateCorrectConfig()
-		cfg.EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch = []MaxNodesChangeConfig{
+		cfg.MaxNodesChangeEnableEpoch = []MaxNodesChangeConfig{
 			{
 				EpochEnable:            6,
 				MaxNumNodes:            48,
@@ -105,7 +98,7 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 			},
 		}
 
-		err := SanityCheckEnableEpochsStakingV4(cfg)
+		err := sanityCheckEnableEpochsStakingV4(cfg, numOfShards)
 		require.Equal(t, errNotEnoughMaxNodesChanges, err)
 	})
 
@@ -113,7 +106,7 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 		t.Parallel()
 
 		cfg := generateCorrectConfig()
-		cfg.EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch = []MaxNodesChangeConfig{
+		cfg.MaxNodesChangeEnableEpoch = []MaxNodesChangeConfig{
 			{
 				EpochEnable:            1,
 				MaxNumNodes:            56,
@@ -126,7 +119,7 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 			},
 		}
 
-		err := SanityCheckEnableEpochsStakingV4(cfg)
+		err := sanityCheckEnableEpochsStakingV4(cfg, numOfShards)
 		require.NotNil(t, err)
 		require.True(t, strings.Contains(err.Error(), errNoMaxNodesConfigChangeForStakingV4.Error()))
 		require.True(t, strings.Contains(err.Error(), "6"))
@@ -136,9 +129,9 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 		t.Parallel()
 
 		cfg := generateCorrectConfig()
-		cfg.EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch = []MaxNodesChangeConfig{
+		cfg.MaxNodesChangeEnableEpoch = []MaxNodesChangeConfig{
 			{
-				EpochEnable:            cfg.EpochConfig.EnableEpochs.StakingV4Step3EnableEpoch,
+				EpochEnable:            cfg.StakingV4Step3EnableEpoch,
 				MaxNumNodes:            48,
 				NodesToShufflePerShard: 2,
 			},
@@ -149,7 +142,7 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 			},
 		}
 
-		err := SanityCheckEnableEpochsStakingV4(cfg)
+		err := sanityCheckEnableEpochsStakingV4(cfg, numOfShards)
 		require.NotNil(t, err)
 		require.ErrorIs(t, err, errNoMaxNodesConfigBeforeStakingV4)
 	})
@@ -158,10 +151,10 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 		t.Parallel()
 
 		cfg := generateCorrectConfig()
-		cfg.EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch[1].NodesToShufflePerShard = 2
-		cfg.EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch[2].NodesToShufflePerShard = 4
+		cfg.MaxNodesChangeEnableEpoch[1].NodesToShufflePerShard = 2
+		cfg.MaxNodesChangeEnableEpoch[2].NodesToShufflePerShard = 4
 
-		err := SanityCheckEnableEpochsStakingV4(cfg)
+		err := sanityCheckEnableEpochsStakingV4(cfg, numOfShards)
 		require.ErrorIs(t, err, errMismatchNodesToShuffle)
 	})
 
@@ -169,9 +162,9 @@ func TestSanityCheckEnableEpochsStakingV4(t *testing.T) {
 		t.Parallel()
 
 		cfg := generateCorrectConfig()
-		cfg.EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch[2].MaxNumNodes = 56
+		cfg.MaxNodesChangeEnableEpoch[2].MaxNumNodes = 56
 
-		err := SanityCheckEnableEpochsStakingV4(cfg)
+		err := sanityCheckEnableEpochsStakingV4(cfg, numOfShards)
 		require.NotNil(t, err)
 		require.True(t, strings.Contains(err.Error(), "expected"))
 		require.True(t, strings.Contains(err.Error(), "48"))
@@ -187,7 +180,7 @@ func TestSanityCheckNodesConfig(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		cfg := generateCorrectConfig().EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch
+		cfg := generateCorrectConfig()
 		nodesSetup := &nodesSetupMock.NodesSetupMock{
 			NumberOfShardsField:        numShards,
 			HysteresisField:            0,
@@ -197,7 +190,7 @@ func TestSanityCheckNodesConfig(t *testing.T) {
 		err := SanityCheckNodesConfig(nodesSetup, cfg)
 		require.Nil(t, err)
 
-		cfg = []MaxNodesChangeConfig{
+		cfg.MaxNodesChangeEnableEpoch = []MaxNodesChangeConfig{
 			{
 				EpochEnable:            1,
 				MaxNumNodes:            3200,
@@ -218,6 +211,11 @@ func TestSanityCheckNodesConfig(t *testing.T) {
 				MaxNumNodes:            2240,
 				NodesToShufflePerShard: 40,
 			},
+			{
+				EpochEnable:            6,
+				MaxNumNodes:            2080,
+				NodesToShufflePerShard: 40,
+			},
 		}
 		nodesSetup = &nodesSetupMock.NodesSetupMock{
 			NumberOfShardsField:        numShards,
@@ -228,7 +226,7 @@ func TestSanityCheckNodesConfig(t *testing.T) {
 		err = SanityCheckNodesConfig(nodesSetup, cfg)
 		require.Nil(t, err)
 
-		cfg = []MaxNodesChangeConfig{
+		cfg.MaxNodesChangeEnableEpoch = []MaxNodesChangeConfig{
 			{
 				EpochEnable:            0,
 				MaxNumNodes:            36,
@@ -254,7 +252,7 @@ func TestSanityCheckNodesConfig(t *testing.T) {
 		err = SanityCheckNodesConfig(nodesSetup, cfg)
 		require.Nil(t, err)
 
-		cfg = []MaxNodesChangeConfig{
+		cfg.MaxNodesChangeEnableEpoch = []MaxNodesChangeConfig{
 			{
 				EpochEnable:            0,
 				MaxNumNodes:            36,
@@ -284,7 +282,8 @@ func TestSanityCheckNodesConfig(t *testing.T) {
 	t.Run("zero nodes to shuffle per shard, should return error", func(t *testing.T) {
 		t.Parallel()
 
-		cfg := []MaxNodesChangeConfig{
+		cfg := generateCorrectConfig()
+		cfg.MaxNodesChangeEnableEpoch = []MaxNodesChangeConfig{
 			{
 				EpochEnable:            4,
 				MaxNumNodes:            3200,
@@ -306,7 +305,8 @@ func TestSanityCheckNodesConfig(t *testing.T) {
 	t.Run("maxNumNodes < minNumNodesWithHysteresis, should return error ", func(t *testing.T) {
 		t.Parallel()
 
-		cfg := []MaxNodesChangeConfig{
+		cfg := generateCorrectConfig()
+		cfg.MaxNodesChangeEnableEpoch = []MaxNodesChangeConfig{
 			{
 				EpochEnable:            4,
 				MaxNumNodes:            1900,

--- a/config/errors.go
+++ b/config/errors.go
@@ -15,7 +15,3 @@ var errNoMaxNodesConfigChangeForStakingV4 = errors.New("no MaxNodesChangeEnableE
 var errZeroNodesToShufflePerShard = errors.New("zero nodes to shuffle per shard found in config")
 
 var errInvalidMaxMinNodes = errors.New("number of min nodes with hysteresis > number of max nodes")
-
-var errInvalidNodesToShuffle = errors.New("number of nodes to shuffle per shard > waiting list size per shard")
-
-var errInvalidNodesToShuffleWithHysteresis = errors.New("number of nodes to shuffle per shard > forced waiting list size per shard with hysteresis")

--- a/config/errors.go
+++ b/config/errors.go
@@ -4,14 +4,10 @@ import "errors"
 
 var errStakingV4StepsNotInOrder = errors.New("staking v4 enable epoch steps should be in cardinal order(e.g.: StakingV4Step1EnableEpoch = 2, StakingV4Step2EnableEpoch = 3, StakingV4Step3EnableEpoch = 4)")
 
-var errNotEnoughMaxNodesChanges = errors.New("not enough entries in MaxNodesChangeEnableEpoch config; expected one entry before stakingV4 and another one starting StakingV4Step3EnableEpoch")
-
 var errNoMaxNodesConfigBeforeStakingV4 = errors.New("no previous config change entry in MaxNodesChangeEnableEpoch before entry with EpochEnable = StakingV4Step3EnableEpoch")
 
 var errMismatchNodesToShuffle = errors.New("previous MaxNodesChangeEnableEpoch.NodesToShufflePerShard != MaxNodesChangeEnableEpoch.NodesToShufflePerShard with EnableEpoch = StakingV4Step3EnableEpoch")
 
 var errNoMaxNodesConfigChangeForStakingV4 = errors.New("no MaxNodesChangeEnableEpoch config found for EpochEnable = StakingV4Step3EnableEpoch")
-
-var errZeroNodesToShufflePerShard = errors.New("zero nodes to shuffle per shard found in config")
 
 var errInvalidMaxMinNodes = errors.New("number of min nodes with hysteresis > number of max nodes")

--- a/config/interface.go
+++ b/config/interface.go
@@ -3,9 +3,5 @@ package config
 // NodesSetupHandler provides nodes setup information
 type NodesSetupHandler interface {
 	MinNumberOfNodesWithHysteresis() uint32
-	MinNumberOfNodes() uint32
-	MinNumberOfShardNodes() uint32
-	MinNumberOfMetaNodes() uint32
-	GetHysteresis() float32
 	NumberOfShards() uint32
 }

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -287,10 +287,7 @@ func (nr *nodeRunner) executeOneComponentCreationCycle(
 		return true, err
 	}
 
-	err = config.SanityCheckNodesConfig(
-		managedCoreComponents.GenesisNodesSetup(),
-		configs.EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch,
-	)
+	err = config.SanityCheckNodesConfig(managedCoreComponents.GenesisNodesSetup(), configs.EpochConfig.EnableEpochs)
 	if err != nil {
 		return true, err
 	}

--- a/scripts/testnet/include/config.sh
+++ b/scripts/testnet/include/config.sh
@@ -131,8 +131,47 @@ updateNodeConfig() {
      sed -i '/\[Antiflood\]/,/\[Logger\]/ s/true/false/' config_observer.toml
   fi
 
+  updateConfigsForStakingV4
+
   echo "Updated configuration for Nodes."
   popd
+}
+
+updateConfigsForStakingV4() {
+  config=$(cat enableEpochs.toml)
+
+  echo "Updating staking v4 configs"
+
+  # Get the StakingV4Step3EnableEpoch value
+  staking_enable_epoch=$(echo "$config" | awk -F '=' '/  StakingV4Step3EnableEpoch/{gsub(/^[ \t]+|[ \t]+$/,"", $2); print $2; exit}')
+  # Count the number of entries in MaxNodesChangeEnableEpoch
+  entry_count=$(echo "$config" | awk '/MaxNodesChangeEnableEpoch/,/\]/{if ($0 ~ /\{/) {count++}} END {print count}')
+
+  # Check if entry_count is less than 2
+  if [ "$entry_count" -lt 2 ]; then
+    echo "Not enough entries found to update"
+  else
+    # Find all entries in MaxNodesChangeEnableEpoch
+    all_entries=$(awk '/MaxNodesChangeEnableEpoch/,/\]/{if ($0 ~ /^[[:space:]]*\{/) {p=1}; if (p) print; if ($0 ~ /\]/) p=0}' enableEpochs.toml | grep -vE '^\s*#' | sed '/^\s*$/d')
+
+    # Get the index of the entry with EpochEnable equal to StakingV4Step3EnableEpoch
+    index=$(echo "$all_entries" | grep -n "EpochEnable = $staking_enable_epoch" | cut -d: -f1)
+
+    prev_entry=$(echo "$all_entries" | sed -n "$((index-1))p")
+    curr_entry=$(echo "$all_entries" | sed -n "$((index))p")
+
+    # Extract the value of MaxNumNodes & NodesToShufflePerShard from prev_entry
+    max_nodes_from_prev_epoch=$(echo "$prev_entry" | awk -F 'MaxNumNodes = ' '{print $2}' | cut -d ',' -f1)
+    nodes_to_shuffle_per_shard=$(echo "$prev_entry" | awk -F 'NodesToShufflePerShard = ' '{gsub(/[^0-9]+/, "", $2); print $2}')
+
+    # Calculate the new MaxNumNodes value based on the formula
+    new_max_nodes=$((max_nodes_from_prev_epoch - (SHARDCOUNT + 1) * nodes_to_shuffle_per_shard))
+    curr_entry_updated=$(echo "$curr_entry" | awk -v new_max_nodes="$new_max_nodes" '{gsub(/MaxNumNodes = [0-9]+,/, "MaxNumNodes = " new_max_nodes ",")}1')
+
+    echo "Updating entry in MaxNodesChangeEnableEpoch from $curr_entry to $curr_entry_updated"
+
+    sed -i "/$staking_enable_epoch/,/$staking_enable_epoch/ s|.*$curr_entry.*|$curr_entry_updated|" enableEpochs.toml
+  fi
 }
 
 copyProxyConfig() {

--- a/scripts/testnet/include/config.sh
+++ b/scripts/testnet/include/config.sh
@@ -157,20 +157,24 @@ updateConfigsForStakingV4() {
     # Get the index of the entry with EpochEnable equal to StakingV4Step3EnableEpoch
     index=$(echo "$all_entries" | grep -n "EpochEnable = $staking_enable_epoch" | cut -d: -f1)
 
-    prev_entry=$(echo "$all_entries" | sed -n "$((index-1))p")
-    curr_entry=$(echo "$all_entries" | sed -n "$((index))p")
+    if [[ -z "${index// }" ]]; then
+      echo -e "\033[1;33mWarning: MaxNodesChangeEnableEpoch does not contain an entry enable epoch for StakingV4Step3EnableEpoch, nodes might fail to start...\033[0m"
+    else
+      prev_entry=$(echo "$all_entries" | sed -n "$((index-1))p")
+      curr_entry=$(echo "$all_entries" | sed -n "$((index))p")
 
-    # Extract the value of MaxNumNodes & NodesToShufflePerShard from prev_entry
-    max_nodes_from_prev_epoch=$(echo "$prev_entry" | awk -F 'MaxNumNodes = ' '{print $2}' | cut -d ',' -f1)
-    nodes_to_shuffle_per_shard=$(echo "$prev_entry" | awk -F 'NodesToShufflePerShard = ' '{gsub(/[^0-9]+/, "", $2); print $2}')
+      # Extract the value of MaxNumNodes & NodesToShufflePerShard from prev_entry
+      max_nodes_from_prev_epoch=$(echo "$prev_entry" | awk -F 'MaxNumNodes = ' '{print $2}' | cut -d ',' -f1)
+      nodes_to_shuffle_per_shard=$(echo "$prev_entry" | awk -F 'NodesToShufflePerShard = ' '{gsub(/[^0-9]+/, "", $2); print $2}')
 
-    # Calculate the new MaxNumNodes value based on the formula
-    new_max_nodes=$((max_nodes_from_prev_epoch - (SHARDCOUNT + 1) * nodes_to_shuffle_per_shard))
-    curr_entry_updated=$(echo "$curr_entry" | awk -v new_max_nodes="$new_max_nodes" '{gsub(/MaxNumNodes = [0-9]+,/, "MaxNumNodes = " new_max_nodes ",")}1')
+      # Calculate the new MaxNumNodes value based on the formula
+      new_max_nodes=$((max_nodes_from_prev_epoch - (SHARDCOUNT + 1) * nodes_to_shuffle_per_shard))
+      curr_entry_updated=$(echo "$curr_entry" | awk -v new_max_nodes="$new_max_nodes" '{gsub(/MaxNumNodes = [0-9]+,/, "MaxNumNodes = " new_max_nodes ",")}1')
 
-    echo "Updating entry in MaxNodesChangeEnableEpoch from $curr_entry to $curr_entry_updated"
+      echo "Updating entry in MaxNodesChangeEnableEpoch from $curr_entry to $curr_entry_updated"
 
-    sed -i "/$staking_enable_epoch/,/$staking_enable_epoch/ s|.*$curr_entry.*|$curr_entry_updated|" enableEpochs.toml
+      sed -i "/$staking_enable_epoch/,/$staking_enable_epoch/ s|.*$curr_entry.*|$curr_entry_updated|" enableEpochs.toml
+    fi
   fi
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request
- Remove enforced config protections
## Proposed changes
- Moved `SanityCheckEnableEpochsStakingV4` (now `sanityCheckEnableEpochsStakingV4`) inside `SanityCheckNodesConfig`
- Minor extra cleanings

## Testing procedure
- Local testnet
## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
