### PR TITLE
Change ticker to tokenId for some errors

### DIFF
--- a/vm/errors.go
+++ b/vm/errors.go
@@ -199,6 +199,9 @@ var ErrNilAddressPubKeyConverter = errors.New("nil address public key converter"
 // ErrNoTickerWithGivenName signals that ticker does not exist with given name
 var ErrNoTickerWithGivenName = errors.New("no ticker with given name")
 
+// ErrNoTokenIdWithGivenName signals that tokenId does not exist with given name
+var ErrNoTokenIdWithGivenName = errors.New("no token ID with given name")
+
 // ErrInvalidAddress signals that invalid address has been provided
 var ErrInvalidAddress = errors.New("invalid address")
 

--- a/vm/systemSmartContracts/esdt_test.go
+++ b/vm/systemSmartContracts/esdt_test.go
@@ -492,7 +492,7 @@ func TestEsdt_ExecuteBurnOnNonExistentTokenShouldFail(t *testing.T) {
 
 	output := e.Execute(vmInput)
 	assert.Equal(t, vmcommon.UserError, output)
-	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTickerWithGivenName.Error()))
+	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTokenIdWithGivenName.Error()))
 }
 
 func TestEsdt_ExecuteBurnAndMintDisabled(t *testing.T) {
@@ -647,7 +647,7 @@ func TestEsdt_ExecuteMintOnNonExistentTokenShouldFail(t *testing.T) {
 
 	output := e.Execute(vmInput)
 	assert.Equal(t, vmcommon.UserError, output)
-	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTickerWithGivenName.Error()))
+	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTokenIdWithGivenName.Error()))
 }
 
 func TestEsdt_ExecuteMintNotByOwnerShouldFail(t *testing.T) {
@@ -1000,13 +1000,13 @@ func TestEsdt_ExecuteToggleFreezeOnNonExistentTokenShouldFail(t *testing.T) {
 
 	output := e.Execute(vmInput)
 	assert.Equal(t, vmcommon.UserError, output)
-	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTickerWithGivenName.Error()))
+	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTokenIdWithGivenName.Error()))
 
 	vmInput.Function = "freezeSingleNFT"
 	vmInput.Arguments = append(vmInput.Arguments, []byte("owner"))
 	output = e.Execute(vmInput)
 	assert.Equal(t, vmcommon.UserError, output)
-	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTickerWithGivenName.Error()))
+	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTokenIdWithGivenName.Error()))
 }
 
 func TestEsdt_ExecuteToggleFreezeNotByOwnerShouldFail(t *testing.T) {
@@ -1455,13 +1455,13 @@ func TestEsdt_ExecuteWipeOnNonExistentTokenShouldFail(t *testing.T) {
 
 	output := e.Execute(vmInput)
 	assert.Equal(t, vmcommon.UserError, output)
-	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTickerWithGivenName.Error()))
+	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTokenIdWithGivenName.Error()))
 
 	vmInput.Function = "wipeSingleNFT"
 	vmInput.Arguments = append(vmInput.Arguments, []byte("one"))
 	output = e.Execute(vmInput)
 	assert.Equal(t, vmcommon.UserError, output)
-	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTickerWithGivenName.Error()))
+	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTokenIdWithGivenName.Error()))
 }
 
 func TestEsdt_ExecuteWipeNotByOwnerShouldFail(t *testing.T) {
@@ -1754,7 +1754,7 @@ func TestEsdt_ExecutePauseOnNonExistentTokenShouldFail(t *testing.T) {
 
 	output := e.Execute(vmInput)
 	assert.Equal(t, vmcommon.UserError, output)
-	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTickerWithGivenName.Error()))
+	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTokenIdWithGivenName.Error()))
 }
 
 func TestEsdt_ExecutePauseNotByOwnerShouldFail(t *testing.T) {
@@ -2071,7 +2071,7 @@ func TestEsdt_ExecuteTransferOwnershipOnNonExistentTokenShouldFail(t *testing.T)
 
 	output := e.Execute(vmInput)
 	assert.Equal(t, vmcommon.UserError, output)
-	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTickerWithGivenName.Error()))
+	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTokenIdWithGivenName.Error()))
 }
 
 func TestEsdt_ExecuteTransferOwnershipNotByOwnerShouldFail(t *testing.T) {
@@ -2238,7 +2238,7 @@ func TestEsdt_ExecuteEsdtControlChangesOnNonExistentTokenShouldFail(t *testing.T
 
 	output := e.Execute(vmInput)
 	assert.Equal(t, vmcommon.UserError, output)
-	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTickerWithGivenName.Error()))
+	assert.True(t, strings.Contains(eei.returnMessage, vm.ErrNoTokenIdWithGivenName.Error()))
 }
 
 func TestEsdt_ExecuteEsdtControlChangesNotByOwnerShouldFail(t *testing.T) {


### PR DESCRIPTION
Change ErrNoTickerWithGivenName to ErrNoTokenIdWithGivenName for better error feedback.

## Reasoning behind the pull request
The actual error is that tokenID is wrong, not the ticker. For beginners, could be confusing.
  
## Proposed changes
Change ErrNoTickerWithGivenName to ErrNoTokenIdWithGivenName for better error feedback.
 
## Testing procedure
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
