### PR TITLE
FIX: Add back subscribed events for outgoing operations

### DIFF
--- a/cmd/sovereignnode/config/sovereignConfig.toml
+++ b/cmd/sovereignnode/config/sovereignConfig.toml
@@ -33,6 +33,10 @@
     # Time to wait in seconds for outgoing operations that need to be bridged from sovereign chain to main chain.
     # If no confirmation of bridged data is received after this time, next leader should retry sending data.
     TimeToWaitForUnconfirmedOutGoingOperationInSeconds = 30
+    
+    SubscribedEvents = [
+        { Identifier = "deposit", Addresses = ["erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"] }
+    ]
 
 [OutGoingBridge]
     GRPCHost = "localhost"

--- a/config/sovereignConfig.go
+++ b/config/sovereignConfig.go
@@ -13,7 +13,8 @@ type SovereignConfig struct {
 
 // OutgoingSubscribedEvents holds config for outgoing subscribed events
 type OutgoingSubscribedEvents struct {
-	TimeToWaitForUnconfirmedOutGoingOperationInSeconds uint32 `toml:"TimeToWaitForUnconfirmedOutGoingOperationInSeconds"`
+	TimeToWaitForUnconfirmedOutGoingOperationInSeconds uint32            `toml:"TimeToWaitForUnconfirmedOutGoingOperationInSeconds"`
+	SubscribedEvents                                   []SubscribedEvent `toml:"SubscribedEvents"`
 }
 
 // MainChainNotarization defines necessary data to start main chain notarization on a sovereign shard

--- a/factory/processing/blockProcessorCreator.go
+++ b/factory/processing/blockProcessorCreator.go
@@ -539,7 +539,7 @@ func (pcf *processComponentsFactory) createBlockProcessor(
 		// TODO: Radu Chis: move this in the factory of the sovereign block processor once the refactor is completed
 
 		outgoingOpFormatter, errOpFormatter := sovereign.CreateOutgoingOperationsFormatter(
-			pcf.config.SovereignConfig.NotifierConfig.SubscribedEvents,
+			pcf.config.SovereignConfig.OutgoingSubscribedEvents.SubscribedEvents,
 			pcf.coreData.AddressPubKeyConverter(),
 			pcf.coreData.RoundHandler(),
 		)

--- a/testscommon/components/configs.go
+++ b/testscommon/components/configs.go
@@ -199,6 +199,14 @@ func GetGeneralConfig() config.Config {
 					},
 				},
 			},
+			OutgoingSubscribedEvents: config.OutgoingSubscribedEvents{
+				SubscribedEvents: []config.SubscribedEvent{
+					{
+						Identifier: "bridgeOps",
+						Addresses:  []string{"erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"},
+					},
+				},
+			},
 		},
 	}
 }

--- a/testscommon/generalConfig.go
+++ b/testscommon/generalConfig.go
@@ -424,6 +424,14 @@ func GetGeneralConfig() config.Config {
 					},
 				},
 			},
+			OutgoingSubscribedEvents: config.OutgoingSubscribedEvents{
+				SubscribedEvents: []config.SubscribedEvent{
+					{
+						Identifier: "bridgeOps",
+						Addresses:  []string{"erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"},
+					},
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
## Reasoning behind the pull request
-  Add back subscribed events for outgoing operations

## Testing procedure
- Local testnet

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
