### PR TITLE
Protocol ID check in seeder

### DIFF
--- a/cmd/seednode/main.go
+++ b/cmd/seednode/main.go
@@ -309,12 +309,21 @@ func displayMessengerInfo(messenger p2p.Messenger) {
 		return strings.Compare(mesConnectedAddrs[i], mesConnectedAddrs[j]) < 0
 	})
 
-	log.Info("known peers", "num peers", len(messenger.Peers()))
-	headerConnectedAddresses := []string{fmt.Sprintf("Seednode is connected to %d peers:", len(mesConnectedAddrs))}
+	protocolIDString := "Valid protocol ID?"
+	log.Info("peers info", "num known peers", len(messenger.Peers()), "num connected peers", len(mesConnectedAddrs))
+	headerConnectedAddresses := []string{"Connected peers", protocolIDString}
 	connAddresses := make([]*display.LineData, len(mesConnectedAddrs))
 
+	yesMarker := "yes"
+	yesMarker = strings.Repeat(" ", (len(protocolIDString)-len(yesMarker))/2) + yesMarker // add padding
+	noMarker := "!!! no !!!"
+	noMarker = strings.Repeat(" ", (len(protocolIDString)-len(noMarker))/2) + noMarker // add padding
 	for idx, address := range mesConnectedAddrs {
-		connAddresses[idx] = display.NewLineData(false, []string{address})
+		marker := noMarker
+		if messenger.HasCompatibleProtocolID(address) {
+			marker = yesMarker
+		}
+		connAddresses[idx] = display.NewLineData(false, []string{address, marker})
 	}
 
 	tbl2, _ := display.CreateTableString(headerConnectedAddresses, connAddresses)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/gops v0.3.18
 	github.com/gorilla/websocket v1.5.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/multiversx/mx-chain-communication-go v1.0.13-0.20231129114230-d280af707381
+	github.com/multiversx/mx-chain-communication-go v1.0.13-0.20240123161141-8b8b0259c602
 	github.com/multiversx/mx-chain-core-go v1.2.19-0.20231214115026-a1e7279b14f1
 	github.com/multiversx/mx-chain-crypto-go v1.2.10-0.20231129101537-ef355850e34b
 	github.com/multiversx/mx-chain-es-indexer-go v1.4.18-0.20231228064619-e3b0caf29058

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,8 @@ github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/n
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
 github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUYwbO0993uPI=
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
-github.com/multiversx/mx-chain-communication-go v1.0.13-0.20231129114230-d280af707381 h1:M4JNeubA+zq7NaH2LP5YsWUVeKn9hNL+HgSw2kqwWUc=
-github.com/multiversx/mx-chain-communication-go v1.0.13-0.20231129114230-d280af707381/go.mod h1:n4E8BWIV0g3AcNGe1gf+vcjUC8A2QCJ4ARQSbiUDGrI=
+github.com/multiversx/mx-chain-communication-go v1.0.13-0.20240123161141-8b8b0259c602 h1:R010kiv1Gp0ULko3TJxAGJmQQz24frgN05y9crLTp/Q=
+github.com/multiversx/mx-chain-communication-go v1.0.13-0.20240123161141-8b8b0259c602/go.mod h1:n4E8BWIV0g3AcNGe1gf+vcjUC8A2QCJ4ARQSbiUDGrI=
 github.com/multiversx/mx-chain-core-go v1.2.19-0.20231214115026-a1e7279b14f1 h1:8rz1ZpRAsWVxSEBy7PJIUStQMKiHs3I4mvpRmHUpsbI=
 github.com/multiversx/mx-chain-core-go v1.2.19-0.20231214115026-a1e7279b14f1/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
 github.com/multiversx/mx-chain-crypto-go v1.2.10-0.20231129101537-ef355850e34b h1:TIE6it719ZIW0E1bFgPAgE+U3zPSkPfAloFYEIeOL3U=

--- a/p2p/disabled/networkMessenger.go
+++ b/p2p/disabled/networkMessenger.go
@@ -190,6 +190,11 @@ func (netMes *networkMessenger) SetDebugger(_ p2p.Debugger) error {
 	return nil
 }
 
+// HasCompatibleProtocolID returns false as it is disabled
+func (netMes *networkMessenger) HasCompatibleProtocolID(_ string) bool {
+	return false
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (netMes *networkMessenger) IsInterfaceNil() bool {
 	return netMes == nil

--- a/testscommon/p2pmocks/messengerStub.go
+++ b/testscommon/p2pmocks/messengerStub.go
@@ -46,6 +46,7 @@ type MessengerStub struct {
 	SignUsingPrivateKeyCalled               func(skBytes []byte, payload []byte) ([]byte, error)
 	ProcessReceivedMessageCalled            func(message p2p.MessageP2P, fromConnectedPeer core.PeerID, source p2p.MessageHandler) error
 	SetDebuggerCalled                       func(debugger p2p.Debugger) error
+	HasCompatibleProtocolIDCalled           func(address string) bool
 }
 
 // ID -
@@ -367,6 +368,15 @@ func (ms *MessengerStub) SetDebugger(debugger p2p.Debugger) error {
 		return ms.SetDebuggerCalled(debugger)
 	}
 	return nil
+}
+
+// HasCompatibleProtocolID -
+func (ms *MessengerStub) HasCompatibleProtocolID(address string) bool {
+	if ms.HasCompatibleProtocolIDCalled != nil {
+		return ms.HasCompatibleProtocolIDCalled(address)
+	}
+
+	return false
 }
 
 // IsInterfaceNil returns true if there is no value under the interface


### PR DESCRIPTION
## Reasoning behind the pull request
- added protocol ID check in seeder for better debugging experience
- related PR: https://github.com/multiversx/mx-chain-communication-go/pull/47
  
## Proposed changes
- the seeder now displays a table like this:
```
INFO [2024-01-23 20:39:05.436]   peers info                               num known peers = 3 num connected peers = 2 
INFO [2024-01-23 20:39:05.436]   
+------------------------------------------------------------------------------------+--------------------+
| Connected peers                                                                    | Valid protocol ID? |
+------------------------------------------------------------------------------------+--------------------+
| /ip4/127.0.0.1/tcp/40938/p2p/16Uiu2HAm8YvJcudqcMHrSJkGds9KJN2fXr57Fohws1fSZ35kE8pi |     !!! no !!!     |
| /ip4/127.0.0.1/tcp/54098/p2p/16Uiu2HAkwSencHzCkH9G7bHNSt1pM1VLC8fAkRjXSqwgyK9RupmA |        yes         |
+------------------------------------------------------------------------------------+--------------------+
```

## Testing procedure
- standard system test
- try to connect to this seeder with nodes or other seeders by having similar p2p.toml configs and then change the `ProtocolID` from the p2p.toml file to something different. In this case the seednode/node with the wrong ProtocolID will be signaled in the table just like in the model above.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
