### PR TITLE
Bug-fix: Fix /transaction/cost api route

### DIFF
--- a/facade/interface.go
+++ b/facade/interface.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/multiversx/mx-chain-core-go/core"
+	coreData "github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/alteredAccount"
 	"github.com/multiversx/mx-chain-core-go/data/api"
 	"github.com/multiversx/mx-chain-core-go/data/esdt"
@@ -106,7 +107,7 @@ type NodeHandler interface {
 
 // TransactionSimulatorProcessor defines the actions which a transaction simulator processor has to implement
 type TransactionSimulatorProcessor interface {
-	ProcessTx(tx *transaction.Transaction) (*txSimData.SimulationResultsWithVMOutput, error)
+	ProcessTx(tx *transaction.Transaction, currentHeader coreData.HeaderHandler) (*txSimData.SimulationResultsWithVMOutput, error)
 	IsInterfaceNil() bool
 }
 

--- a/factory/processing/txSimulatorProcessComponents.go
+++ b/factory/processing/txSimulatorProcessComponents.go
@@ -79,6 +79,7 @@ func (pcf *processComponentsFactory) createAPITransactionEvaluator() (factory.Tr
 		Accounts:            simulationAccountsDB,
 		ShardCoordinator:    pcf.bootstrapComponents.ShardCoordinator(),
 		EnableEpochsHandler: pcf.coreData.EnableEpochsHandler(),
+		BlockChain:          pcf.data.Blockchain(),
 	})
 
 	return apiTransactionEvaluator, vmContainerFactory, err
@@ -140,6 +141,8 @@ func (pcf *processComponentsFactory) createArgsTxSimulatorProcessorForMeta(
 	if err != nil {
 		return args, nil, nil, err
 	}
+
+	args.BlockChainHook = vmContainerFactory.BlockChainHookImpl()
 
 	vmContainer, err := vmContainerFactory.Create()
 	if err != nil {
@@ -300,6 +303,8 @@ func (pcf *processComponentsFactory) createArgsTxSimulatorProcessorShard(
 	if err != nil {
 		return args, nil, nil, err
 	}
+
+	args.BlockChainHook = vmContainerFactory.BlockChainHookImpl()
 
 	err = builtInFuncFactory.SetPayableHandler(vmContainerFactory.BlockChainHookImpl())
 	if err != nil {

--- a/integrationTests/testProcessorNodeWithTestWebServer.go
+++ b/integrationTests/testProcessorNodeWithTestWebServer.go
@@ -179,6 +179,7 @@ func createFacadeComponents(tpn *TestProcessorNode) nodeFacade.ApiResolver {
 		Hasher:                    TestHasher,
 		VMOutputCacher:            &testscommon.CacherMock{},
 		DataFieldParser:           dataFieldParser,
+		BlockChainHook:            tpn.BlockchainHook,
 	}
 
 	txSimulator, err := transactionEvaluator.NewTransactionSimulator(argSimulator)
@@ -194,6 +195,7 @@ func createFacadeComponents(tpn *TestProcessorNode) nodeFacade.ApiResolver {
 		Accounts:            wrappedAccounts,
 		ShardCoordinator:    tpn.ShardCoordinator,
 		EnableEpochsHandler: tpn.EnableEpochsHandler,
+		BlockChain:          tpn.BlockChain,
 	}
 	apiTransactionEvaluator, err := transactionEvaluator.NewAPITransactionEvaluator(argsTransactionEvaluator)
 	log.LogIfError(err)

--- a/integrationTests/vm/testInitializer.go
+++ b/integrationTests/vm/testInitializer.go
@@ -818,6 +818,7 @@ func CreateTxProcessorWithOneSCExecutorWithVMs(
 	epochNotifierInstance process.EpochNotifier,
 	guardianChecker process.GuardianChecker,
 	roundNotifierInstance process.RoundNotifier,
+	chainHandler data.ChainHandler,
 ) (*ResultsCreateTxProcessor, error) {
 	if check.IfNil(poolsHolder) {
 		poolsHolder = dataRetrieverMock.NewPoolsHolderMock()
@@ -980,6 +981,7 @@ func CreateTxProcessorWithOneSCExecutorWithVMs(
 		Marshalizer:            integrationtests.TestMarshalizer,
 		Hasher:                 integrationtests.TestHasher,
 		DataFieldParser:        dataFieldParser,
+		BlockChainHook:         blockChainHook,
 	}
 
 	argsNewSCProcessor.VMOutputCacher = txSimulatorProcessorArgs.VMOutputCacher
@@ -1006,6 +1008,7 @@ func CreateTxProcessorWithOneSCExecutorWithVMs(
 		Accounts:            simulationAccountsDB,
 		ShardCoordinator:    shardCoordinator,
 		EnableEpochsHandler: argsNewSCProcessor.EnableEpochsHandler,
+		BlockChain:          chainHandler,
 	}
 	apiTransactionEvaluator, err := transactionEvaluator.NewAPITransactionEvaluator(argsTransactionEvaluator)
 	if err != nil {
@@ -1128,6 +1131,7 @@ func CreatePreparedTxProcessorAndAccountsWithVMsWithRoundsConfig(
 		epochNotifierInstance,
 		guardedAccountHandler,
 		roundNotifierInstance,
+		chainHandler,
 	)
 	if err != nil {
 		return nil, err
@@ -1279,6 +1283,7 @@ func CreatePreparedTxProcessorWithVMConfigWithShardCoordinatorDBAndGasAndRoundCo
 		epochNotifierInstance,
 		guardedAccountHandler,
 		roundNotifierInstance,
+		chainHandler,
 	)
 	if err != nil {
 		return nil, err
@@ -1374,6 +1379,7 @@ func CreateTxProcessorArwenVMWithGasScheduleAndRoundConfig(
 		epochNotifierInstance,
 		guardedAccountHandler,
 		roundNotifierInstance,
+		chainHandler,
 	)
 	if err != nil {
 		return nil, err
@@ -1455,6 +1461,7 @@ func CreateTxProcessorArwenWithVMConfigAndRoundConfig(
 		epochNotifierInstance,
 		guardedAccountHandler,
 		roundNotifierInstance,
+		chainHandler,
 	)
 	if err != nil {
 		return nil, err
@@ -1885,6 +1892,7 @@ func CreatePreparedTxProcessorWithVMsMultiShardRoundVMConfig(
 		epochNotifierInstance,
 		guardedAccountHandler,
 		roundNotifierInstance,
+		chainHandler,
 	)
 	if err != nil {
 		return nil, err

--- a/process/mock/transactionSimulatorStub.go
+++ b/process/mock/transactionSimulatorStub.go
@@ -1,19 +1,20 @@
 package mock
 
 import (
+	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	txSimData "github.com/multiversx/mx-chain-go/process/transactionEvaluator/data"
 )
 
 // TransactionSimulatorStub -
 type TransactionSimulatorStub struct {
-	ProcessTxCalled func(tx *transaction.Transaction) (*txSimData.SimulationResultsWithVMOutput, error)
+	ProcessTxCalled func(tx *transaction.Transaction, currentHeader data.HeaderHandler) (*txSimData.SimulationResultsWithVMOutput, error)
 }
 
 // ProcessTx -
-func (tss *TransactionSimulatorStub) ProcessTx(tx *transaction.Transaction) (*txSimData.SimulationResultsWithVMOutput, error) {
+func (tss *TransactionSimulatorStub) ProcessTx(tx *transaction.Transaction, currentHeader data.HeaderHandler) (*txSimData.SimulationResultsWithVMOutput, error) {
 	if tss.ProcessTxCalled != nil {
-		return tss.ProcessTxCalled(tx)
+		return tss.ProcessTxCalled(tx, currentHeader)
 	}
 
 	return nil, nil

--- a/process/transactionEvaluator/transactionSimulator_test.go
+++ b/process/transactionEvaluator/transactionSimulator_test.go
@@ -125,7 +125,7 @@ func TestTransactionSimulator_ProcessTxProcessingErrShouldSignal(t *testing.T) {
 	}
 	ts, _ := NewTransactionSimulator(args)
 
-	results, err := ts.ProcessTx(&transaction.Transaction{Nonce: 37})
+	results, err := ts.ProcessTx(&transaction.Transaction{Nonce: 37}, &block.Header{})
 	require.NoError(t, err)
 	require.Equal(t, expErr.Error(), results.FailReason)
 }
@@ -207,7 +207,7 @@ func TestTransactionSimulator_ProcessTxShouldIncludeScrsAndReceipts(t *testing.T
 	txHash, _ := core.CalculateHash(args.Marshalizer, args.Hasher, tx)
 	args.VMOutputCacher.Put(txHash, &vmcommon.VMOutput{}, 0)
 
-	results, err := ts.ProcessTx(tx)
+	results, err := ts.ProcessTx(tx, &block.Header{})
 	require.NoError(t, err)
 	require.Equal(
 		t,
@@ -236,6 +236,7 @@ func getTxSimulatorArgs() ArgsTxSimulator {
 		Marshalizer:               &mock.MarshalizerMock{},
 		Hasher:                    &hashingMocks.HasherMock{},
 		DataFieldParser:           dataFieldParser,
+		BlockChainHook:            &testscommon.BlockChainHookStub{},
 	}
 }
 
@@ -261,7 +262,7 @@ func TestTransactionSimulator_ProcessTxConcurrentCalls(t *testing.T) {
 	for i := 0; i < numCalls; i++ {
 		go func(idx int) {
 			time.Sleep(time.Millisecond * 10)
-			_, _ = txSimulator.ProcessTx(tx)
+			_, _ = txSimulator.ProcessTx(tx, &block.Header{})
 			wg.Done()
 		}(i)
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- Fixed the bug related to this issue: https://github.com/multiversx/mx-chain-proxy-go/issues/418
- There was a problem with the `BlockChainHook` used inside the components that calculate the transaction cost: BlockChainHook didn't have a `CurrentHeader` set.
  
## Proposed changes
- Set CurrentHeader in the `BlockChainHook` used for transaction cost computation.

## Testing procedure
- Run a node on `devnet` on shard 1 with this branch and ensure the cost is computed correctly for the example from the `mx-chain-proxy-go` GitHub issue 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
