### PR TITLE
Fix multikey backup step in

### DIFF
--- a/consensus/spos/bls/subroundEndRound.go
+++ b/consensus/spos/bls/subroundEndRound.go
@@ -15,6 +15,7 @@ import (
 	"github.com/multiversx/mx-chain-go/consensus"
 	"github.com/multiversx/mx-chain-go/consensus/spos"
 	"github.com/multiversx/mx-chain-go/p2p"
+	"github.com/multiversx/mx-chain-go/process/headerCheck"
 )
 
 type subroundEndRound struct {
@@ -861,33 +862,9 @@ func (sr *subroundEndRound) doEndRoundConsensusCheck() bool {
 	return false
 }
 
-// computeSignersPublicKeys will extract from the provided consensus group slice only the strings that matched with the bitmap
-func computeSignersPublicKeys(consensusGroup []string, bitmap []byte) []string {
-	nbBitsBitmap := len(bitmap) * 8
-	consensusGroupSize := len(consensusGroup)
-	size := consensusGroupSize
-	if consensusGroupSize > nbBitsBitmap {
-		size = nbBitsBitmap
-	}
-
-	result := make([]string, 0, len(consensusGroup))
-
-	for i := 0; i < size; i++ {
-		indexRequired := (bitmap[i/8] & (1 << uint16(i%8))) > 0
-		if !indexRequired {
-			continue
-		}
-
-		pubKey := consensusGroup[i]
-		result = append(result, pubKey)
-	}
-
-	return result
-}
-
 func (sr *subroundEndRound) checkSignaturesValidity(bitmap []byte) error {
 	consensusGroup := sr.ConsensusGroup()
-	signers := computeSignersPublicKeys(consensusGroup, bitmap)
+	signers := headerCheck.ComputeSignersPublicKeys(consensusGroup, bitmap)
 	for _, pubKey := range signers {
 		isSigJobDone, err := sr.JobDone(pubKey, SrSignature)
 		if err != nil {

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -2122,8 +2122,15 @@ func (bp *baseProcessor) checkSentSignaturesAtCommitTime(header data.HeaderHandl
 		return err
 	}
 
+	consensusGroup := make([]string, 0, len(validatorsGroup))
 	for _, validator := range validatorsGroup {
-		bp.sentSignaturesTracker.ResetCountersForManagedBlockSigner(validator.PubKey())
+		consensusGroup = append(consensusGroup, string(validator.PubKey()))
+	}
+
+	signers := headerCheck.ComputeSignersPublicKeys(consensusGroup, header.GetPubKeysBitmap())
+
+	for _, signer := range signers {
+		bp.sentSignaturesTracker.ResetCountersForManagedBlockSigner([]byte(signer))
 	}
 
 	return nil

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -3153,7 +3153,7 @@ func TestBaseProcessor_CheckSentSignaturesAtCommitTime(t *testing.T) {
 		err := bp.CheckSentSignaturesAtCommitTime(&block.Header{})
 		assert.Equal(t, expectedErr, err)
 	})
-	t.Run("should work", func(t *testing.T) {
+	t.Run("should work with bitmap", func(t *testing.T) {
 		validator0, _ := nodesCoordinator.NewValidator([]byte("pk0"), 0, 0)
 		validator1, _ := nodesCoordinator.NewValidator([]byte("pk1"), 1, 1)
 		validator2, _ := nodesCoordinator.NewValidator([]byte("pk2"), 2, 2)
@@ -3173,9 +3173,11 @@ func TestBaseProcessor_CheckSentSignaturesAtCommitTime(t *testing.T) {
 		arguments.NodesCoordinator = nodesCoordinatorInstance
 		bp, _ := blproc.NewShardProcessor(arguments)
 
-		err := bp.CheckSentSignaturesAtCommitTime(&block.Header{})
+		err := bp.CheckSentSignaturesAtCommitTime(&block.Header{
+			PubKeysBitmap: []byte{0b00000101},
+		})
 		assert.Nil(t, err)
 
-		assert.Equal(t, [][]byte{validator0.PubKey(), validator1.PubKey(), validator2.PubKey()}, resetCountersCalled)
+		assert.Equal(t, [][]byte{validator0.PubKey(), validator2.PubKey()}, resetCountersCalled)
 	})
 }

--- a/process/block/metablock_test.go
+++ b/process/block/metablock_test.go
@@ -991,6 +991,7 @@ func TestMetaProcessor_CommitBlockOkValsShouldWork(t *testing.T) {
 	mdp := initDataPool([]byte("tx_hash"))
 	rootHash := []byte("rootHash")
 	hdr := createMetaBlockHeader()
+	hdr.PubKeysBitmap = []byte{0b11111111}
 	body := &block.Body{}
 	accounts := &stateMock.AccountsStub{
 		CommitCalled: func() (i []byte, e error) {

--- a/process/block/shardblock_test.go
+++ b/process/block/shardblock_test.go
@@ -2048,7 +2048,7 @@ func TestShardProcessor_CommitBlockOkValsShouldWork(t *testing.T) {
 	hdr := &block.Header{
 		Nonce:           1,
 		Round:           1,
-		PubKeysBitmap:   rootHash,
+		PubKeysBitmap:   []byte{0b11111111},
 		PrevHash:        hdrHash,
 		Signature:       rootHash,
 		RootHash:        rootHash,

--- a/process/headerCheck/common.go
+++ b/process/headerCheck/common.go
@@ -26,3 +26,27 @@ func ComputeConsensusGroup(header data.HeaderHandler, nodesCoordinator nodesCoor
 
 	return nodesCoordinator.ComputeConsensusGroup(prevRandSeed, header.GetRound(), header.GetShardID(), epoch)
 }
+
+// ComputeSignersPublicKeys will extract from the provided consensus group slice only the strings that matched with the bitmap
+func ComputeSignersPublicKeys(consensusGroup []string, bitmap []byte) []string {
+	nbBitsBitmap := len(bitmap) * 8
+	consensusGroupSize := len(consensusGroup)
+	size := consensusGroupSize
+	if consensusGroupSize > nbBitsBitmap {
+		size = nbBitsBitmap
+	}
+
+	result := make([]string, 0, len(consensusGroup))
+
+	for i := 0; i < size; i++ {
+		indexRequired := (bitmap[i/8] & (1 << uint16(i%8))) > 0
+		if !indexRequired {
+			continue
+		}
+
+		pubKey := consensusGroup[i]
+		result = append(result, pubKey)
+	}
+
+	return result
+}


### PR DESCRIPTION
## Reasoning behind the pull request
- fixed multikey backup step-in by filtering the consensus group that created the block by applying the bitmap. Without this, the backup node can not step in as it continuously resets the counters for the monitored keys 
  
## Proposed changes
- apply the bitmap filtering extracted in a common function for reusability reasons

## Testing procedure
- standard system-test
- multikey & singlekey backup scenarios

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
