### PR TITLE
Add auction list displayer component and disable it on api

### DIFF
--- a/epochStart/metachain/auctionListDisplayer_test.go
+++ b/epochStart/metachain/auctionListDisplayer_test.go
@@ -8,29 +8,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func createDisplayerArgs() ArgsAuctionListDisplayer {
+	return ArgsAuctionListDisplayer{
+		TableDisplayHandler: NewTableDisplayer(),
+		AuctionConfig:       createSoftAuctionConfig(),
+		Denomination:        0,
+	}
+}
+
 func TestNewAuctionListDisplayer(t *testing.T) {
 	t.Parallel()
 
-	t.Run("invalid config", func(t *testing.T) {
-		cfg := createSoftAuctionConfig()
-		cfg.MaxNumberOfIterations = 0
-		ald, err := NewAuctionListDisplayer(cfg, 0)
+	t.Run("invalid auction config", func(t *testing.T) {
+		cfg := createDisplayerArgs()
+		cfg.AuctionConfig.MaxNumberOfIterations = 0
+		ald, err := NewAuctionListDisplayer(cfg)
 		require.Nil(t, ald)
 		requireInvalidValueError(t, err, "for max number of iterations")
 	})
 
 	t.Run("should work", func(t *testing.T) {
-		cfg := createSoftAuctionConfig()
-		ald, err := NewAuctionListDisplayer(cfg, 0)
+		cfg := createDisplayerArgs()
+		ald, err := NewAuctionListDisplayer(cfg)
 		require.Nil(t, err)
 		require.False(t, ald.IsInterfaceNil())
-
-		require.NotPanics(t, func() {
-			ald.DisplayOwnersData(nil)
-			ald.DisplayOwnersSelectedNodes(nil)
-			ald.DisplayAuctionList(nil, nil, 0)
-
-		})
 	})
 }
 

--- a/epochStart/metachain/auctionListDisplayer_test.go
+++ b/epochStart/metachain/auctionListDisplayer_test.go
@@ -8,7 +8,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewAuctionListDisplayer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid config", func(t *testing.T) {
+		cfg := createSoftAuctionConfig()
+		cfg.MaxNumberOfIterations = 0
+		ald, err := NewAuctionListDisplayer(cfg, 0)
+		require.Nil(t, ald)
+		requireInvalidValueError(t, err, "for max number of iterations")
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		cfg := createSoftAuctionConfig()
+		ald, err := NewAuctionListDisplayer(cfg, 0)
+		require.Nil(t, err)
+		require.False(t, ald.IsInterfaceNil())
+
+		require.NotPanics(t, func() {
+			ald.DisplayOwnersData(nil)
+			ald.DisplayOwnersSelectedNodes(nil)
+			ald.DisplayAuctionList(nil, nil, 0)
+
+		})
+	})
+}
+
 func TestGetPrettyValue(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, "1234.0", getPrettyValue(big.NewInt(1234), big.NewInt(1)))
 	require.Equal(t, "123.4", getPrettyValue(big.NewInt(1234), big.NewInt(10)))
 	require.Equal(t, "12.34", getPrettyValue(big.NewInt(1234), big.NewInt(100)))

--- a/epochStart/metachain/auctionListDisplayer_test.go
+++ b/epochStart/metachain/auctionListDisplayer_test.go
@@ -5,14 +5,17 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/stretchr/testify/require"
 )
 
 func createDisplayerArgs() ArgsAuctionListDisplayer {
 	return ArgsAuctionListDisplayer{
-		TableDisplayHandler: NewTableDisplayer(),
-		AuctionConfig:       createSoftAuctionConfig(),
-		Denomination:        0,
+		TableDisplayHandler:      NewTableDisplayer(),
+		ValidatorPubKeyConverter: &testscommon.PubkeyConverterMock{},
+		AddressPubKeyConverter:   &testscommon.PubkeyConverterMock{},
+		AuctionConfig:            createSoftAuctionConfig(),
+		Denomination:             0,
 	}
 }
 

--- a/epochStart/metachain/auctionListSelector.go
+++ b/epochStart/metachain/auctionListSelector.go
@@ -15,6 +15,7 @@ import (
 	"github.com/multiversx/mx-chain-go/state"
 )
 
+// OwnerAuctionData holds necessary auction data for an owner
 type OwnerAuctionData struct {
 	numStakedNodes           int64
 	numActiveNodes           int64

--- a/epochStart/metachain/auctionListSelector.go
+++ b/epochStart/metachain/auctionListSelector.go
@@ -318,7 +318,10 @@ func (als *auctionListSelector) calcSoftAuctionNodesConfig(
 		maxNumberOfIterationsReached = iterationNumber >= als.softAuctionConfig.maxNumberOfIterations
 	}
 
-	als.auctionListDisplayer.DisplayMinRequiredTopUp(topUp, minTopUp)
+	log.Debug("auctionListSelector: found min required",
+		"topUp", getPrettyValue(topUp, als.softAuctionConfig.denominator),
+		"after num of iterations", iterationNumber,
+	)
 	return previousConfig
 }
 

--- a/epochStart/metachain/auctionListSelector.go
+++ b/epochStart/metachain/auctionListSelector.go
@@ -15,7 +15,7 @@ import (
 	"github.com/multiversx/mx-chain-go/state"
 )
 
-type ownerAuctionData struct {
+type OwnerAuctionData struct {
 	numStakedNodes           int64
 	numActiveNodes           int64
 	numAuctionNodes          int64
@@ -35,10 +35,11 @@ type auctionConfig struct {
 }
 
 type auctionListSelector struct {
-	shardCoordinator    sharding.Coordinator
-	stakingDataProvider epochStart.StakingDataProvider
-	nodesConfigProvider epochStart.MaxNodesChangeConfigProvider
-	softAuctionConfig   *auctionConfig
+	shardCoordinator     sharding.Coordinator
+	stakingDataProvider  epochStart.StakingDataProvider
+	nodesConfigProvider  epochStart.MaxNodesChangeConfigProvider
+	auctionListDisplayer AuctionListDisplayHandler
+	softAuctionConfig    *auctionConfig
 }
 
 // AuctionListSelectorArgs is a struct placeholder for all arguments required to create an auctionListSelector
@@ -46,6 +47,7 @@ type AuctionListSelectorArgs struct {
 	ShardCoordinator             sharding.Coordinator
 	StakingDataProvider          epochStart.StakingDataProvider
 	MaxNodesChangeConfigProvider epochStart.MaxNodesChangeConfigProvider
+	AuctionListDisplayHandler    AuctionListDisplayHandler
 	SoftAuctionConfig            config.SoftAuctionConfig
 	Denomination                 int
 }
@@ -71,10 +73,11 @@ func NewAuctionListSelector(args AuctionListSelectorArgs) (*auctionListSelector,
 	)
 
 	return &auctionListSelector{
-		shardCoordinator:    args.ShardCoordinator,
-		stakingDataProvider: args.StakingDataProvider,
-		nodesConfigProvider: args.MaxNodesChangeConfigProvider,
-		softAuctionConfig:   softAuctionConfig,
+		shardCoordinator:     args.ShardCoordinator,
+		stakingDataProvider:  args.StakingDataProvider,
+		nodesConfigProvider:  args.MaxNodesChangeConfigProvider,
+		auctionListDisplayer: args.AuctionListDisplayHandler,
+		softAuctionConfig:    softAuctionConfig,
 	}, nil
 }
 
@@ -168,6 +171,9 @@ func checkNilArgs(args AuctionListSelectorArgs) error {
 	if check.IfNil(args.MaxNodesChangeConfigProvider) {
 		return epochStart.ErrNilMaxNodesChangeConfigProvider
 	}
+	if check.IfNil(args.AuctionListDisplayHandler) {
+		return errNilAuctionListDisplayHandler
+	}
 
 	return nil
 }
@@ -222,7 +228,7 @@ func (als *auctionListSelector) SelectNodesFromAuctionList(
 		fmt.Sprintf("available slots (%v - %v)", maxNumNodes, numOfValidatorsAfterShuffling), availableSlots,
 	)
 
-	als.displayOwnersData(ownersData)
+	als.auctionListDisplayer.DisplayOwnersData(ownersData)
 	numOfAvailableNodeSlots := core.MinUint32(auctionListSize, availableSlots)
 
 	sw := core.NewStopWatch()
@@ -235,15 +241,15 @@ func (als *auctionListSelector) SelectNodesFromAuctionList(
 	return als.sortAuctionList(ownersData, numOfAvailableNodeSlots, validatorsInfoMap, randomness)
 }
 
-func (als *auctionListSelector) getAuctionData() (map[string]*ownerAuctionData, uint32) {
-	ownersData := make(map[string]*ownerAuctionData)
+func (als *auctionListSelector) getAuctionData() (map[string]*OwnerAuctionData, uint32) {
+	ownersData := make(map[string]*OwnerAuctionData)
 	numOfNodesInAuction := uint32(0)
 
 	for owner, ownerData := range als.stakingDataProvider.GetOwnersData() {
 		if ownerData.Qualified && len(ownerData.AuctionList) > 0 {
 			numAuctionNodes := len(ownerData.AuctionList)
 
-			ownersData[owner] = &ownerAuctionData{
+			ownersData[owner] = &OwnerAuctionData{
 				numActiveNodes:           ownerData.NumActiveNodes,
 				numAuctionNodes:          int64(numAuctionNodes),
 				numQualifiedAuctionNodes: int64(numAuctionNodes),
@@ -274,7 +280,7 @@ func safeSub(a, b uint32) (uint32, error) {
 }
 
 func (als *auctionListSelector) sortAuctionList(
-	ownersData map[string]*ownerAuctionData,
+	ownersData map[string]*OwnerAuctionData,
 	numOfAvailableNodeSlots uint32,
 	validatorsInfoMap state.ShardValidatorsInfoMapHandler,
 	randomness []byte,
@@ -285,9 +291,9 @@ func (als *auctionListSelector) sortAuctionList(
 }
 
 func (als *auctionListSelector) calcSoftAuctionNodesConfig(
-	data map[string]*ownerAuctionData,
+	data map[string]*OwnerAuctionData,
 	numAvailableSlots uint32,
-) map[string]*ownerAuctionData {
+) map[string]*OwnerAuctionData {
 	ownersData := copyOwnersData(data)
 	minTopUp, maxTopUp := als.getMinMaxPossibleTopUp(ownersData)
 	log.Debug("auctionListSelector: calc min and max possible top up",
@@ -312,11 +318,11 @@ func (als *auctionListSelector) calcSoftAuctionNodesConfig(
 		maxNumberOfIterationsReached = iterationNumber >= als.softAuctionConfig.maxNumberOfIterations
 	}
 
-	als.displayMinRequiredTopUp(topUp, minTopUp)
+	als.auctionListDisplayer.DisplayMinRequiredTopUp(topUp, minTopUp)
 	return previousConfig
 }
 
-func (als *auctionListSelector) getMinMaxPossibleTopUp(ownersData map[string]*ownerAuctionData) (*big.Int, *big.Int) {
+func (als *auctionListSelector) getMinMaxPossibleTopUp(ownersData map[string]*OwnerAuctionData) (*big.Int, *big.Int) {
 	min := big.NewInt(0).SetBytes(als.softAuctionConfig.maxTopUp.Bytes())
 	max := big.NewInt(0).SetBytes(als.softAuctionConfig.minTopUp.Bytes())
 
@@ -339,10 +345,10 @@ func (als *auctionListSelector) getMinMaxPossibleTopUp(ownersData map[string]*ow
 	return min, max
 }
 
-func copyOwnersData(ownersData map[string]*ownerAuctionData) map[string]*ownerAuctionData {
-	ret := make(map[string]*ownerAuctionData)
+func copyOwnersData(ownersData map[string]*OwnerAuctionData) map[string]*OwnerAuctionData {
+	ret := make(map[string]*OwnerAuctionData)
 	for owner, data := range ownersData {
-		ret[owner] = &ownerAuctionData{
+		ret[owner] = &OwnerAuctionData{
 			numActiveNodes:           data.numActiveNodes,
 			numAuctionNodes:          data.numAuctionNodes,
 			numQualifiedAuctionNodes: data.numQualifiedAuctionNodes,
@@ -358,7 +364,7 @@ func copyOwnersData(ownersData map[string]*ownerAuctionData) map[string]*ownerAu
 	return ret
 }
 
-func calcNodesConfig(ownersData map[string]*ownerAuctionData, topUp *big.Int) int64 {
+func calcNodesConfig(ownersData map[string]*OwnerAuctionData, topUp *big.Int) int64 {
 	numNodesQualifyingForTopUp := int64(0)
 
 	for ownerPubKey, owner := range ownersData {

--- a/epochStart/metachain/auctionListSelector_test.go
+++ b/epochStart/metachain/auctionListSelector_test.go
@@ -34,13 +34,16 @@ func createAuctionListSelectorArgs(maxNodesChangeConfig []config.MaxNodesChangeC
 
 	argsStakingDataProvider := createStakingDataProviderArgs()
 	stakingSCProvider, _ := NewStakingDataProvider(argsStakingDataProvider)
-
 	shardCoordinator, _ := sharding.NewMultiShardCoordinator(3, core.MetachainShardId)
+
+	softAuctionCfg := createSoftAuctionConfig()
+	auctionDisplayer, _ := NewAuctionListDisplayer(softAuctionCfg, 0)
 	return AuctionListSelectorArgs{
 		ShardCoordinator:             shardCoordinator,
 		StakingDataProvider:          stakingSCProvider,
 		MaxNodesChangeConfigProvider: nodesConfigProvider,
-		SoftAuctionConfig:            createSoftAuctionConfig(),
+		AuctionListDisplayHandler:    auctionDisplayer,
+		SoftAuctionConfig:            softAuctionCfg,
 	}
 }
 
@@ -53,11 +56,15 @@ func createFullAuctionListSelectorArgs(maxNodesChangeConfig []config.MaxNodesCha
 		EpochField: stakingV4Step2EnableEpoch,
 	})
 	argsSystemSC.MaxNodesChangeConfigProvider = nodesConfigProvider
+
+	softAuctionCfg := createSoftAuctionConfig()
+	auctionDisplayer, _ := NewAuctionListDisplayer(softAuctionCfg, 0)
 	return AuctionListSelectorArgs{
 		ShardCoordinator:             argsSystemSC.ShardCoordinator,
 		StakingDataProvider:          argsSystemSC.StakingDataProvider,
 		MaxNodesChangeConfigProvider: nodesConfigProvider,
-		SoftAuctionConfig:            createSoftAuctionConfig(),
+		AuctionListDisplayHandler:    auctionDisplayer,
+		SoftAuctionConfig:            softAuctionCfg,
 	}, argsSystemSC
 }
 
@@ -430,7 +437,7 @@ func TestAuctionListSelector_calcSoftAuctionNodesConfigEdgeCases(t *testing.T) {
 
 		owner1 := "owner1"
 		owner2 := "owner2"
-		ownersData := map[string]*ownerAuctionData{
+		ownersData := map[string]*OwnerAuctionData{
 			owner1: {
 				numActiveNodes:           0,
 				numAuctionNodes:          1,
@@ -478,7 +485,7 @@ func TestAuctionListSelector_calcSoftAuctionNodesConfigEdgeCases(t *testing.T) {
 		owner1 := "owner1"
 		owner2 := "owner2"
 		owner3 := "owner3"
-		ownersData := map[string]*ownerAuctionData{
+		ownersData := map[string]*OwnerAuctionData{
 			owner1: {
 				numActiveNodes:           0,
 				numAuctionNodes:          1,
@@ -540,7 +547,7 @@ func TestAuctionListSelector_calcSoftAuctionNodesConfigEdgeCases(t *testing.T) {
 
 		owner1 := "owner1"
 		owner2 := "owner2"
-		ownersData := map[string]*ownerAuctionData{
+		ownersData := map[string]*OwnerAuctionData{
 			owner1: {
 				numActiveNodes:           0,
 				numAuctionNodes:          1,
@@ -584,7 +591,7 @@ func TestAuctionListSelector_calcSoftAuctionNodesConfigEdgeCases(t *testing.T) {
 
 		owner1 := "owner1"
 		owner2 := "owner2"
-		ownersData := map[string]*ownerAuctionData{
+		ownersData := map[string]*OwnerAuctionData{
 			owner1: {
 				numActiveNodes:           0,
 				numAuctionNodes:          1,
@@ -629,7 +636,7 @@ func TestAuctionListSelector_calcSoftAuctionNodesConfigEdgeCases(t *testing.T) {
 
 		owner1 := "owner1"
 		owner2 := "owner2"
-		ownersData := map[string]*ownerAuctionData{
+		ownersData := map[string]*OwnerAuctionData{
 			owner1: {
 				numActiveNodes:           0,
 				numAuctionNodes:          1,
@@ -695,7 +702,7 @@ func TestAuctionListSelector_calcSoftAuctionNodesConfigEdgeCases(t *testing.T) {
 		owner1TopUp, _ := big.NewInt(0).SetString("32000000000000000000000000", 10) // 31 mil eGLD
 		owner1 := "owner1"
 		owner2 := "owner2"
-		ownersData := map[string]*ownerAuctionData{
+		ownersData := map[string]*OwnerAuctionData{
 			owner1: {
 				numActiveNodes:           0,
 				numAuctionNodes:          1,
@@ -760,7 +767,7 @@ func TestAuctionListSelector_calcSoftAuctionNodesConfig(t *testing.T) {
 	owner2 := "owner2"
 	owner3 := "owner3"
 	owner4 := "owner4"
-	ownersData := map[string]*ownerAuctionData{
+	ownersData := map[string]*OwnerAuctionData{
 		owner1: {
 			numActiveNodes:           2,
 			numAuctionNodes:          2,

--- a/epochStart/metachain/auctionListSelector_test.go
+++ b/epochStart/metachain/auctionListSelector_test.go
@@ -37,7 +37,10 @@ func createAuctionListSelectorArgs(maxNodesChangeConfig []config.MaxNodesChangeC
 	shardCoordinator, _ := sharding.NewMultiShardCoordinator(3, core.MetachainShardId)
 
 	softAuctionCfg := createSoftAuctionConfig()
-	auctionDisplayer, _ := NewAuctionListDisplayer(softAuctionCfg, 0)
+	auctionDisplayer, _ := NewAuctionListDisplayer(ArgsAuctionListDisplayer{
+		TableDisplayHandler: NewTableDisplayer(),
+		AuctionConfig:       softAuctionCfg,
+	})
 	return AuctionListSelectorArgs{
 		ShardCoordinator:             shardCoordinator,
 		StakingDataProvider:          stakingSCProvider,
@@ -58,7 +61,10 @@ func createFullAuctionListSelectorArgs(maxNodesChangeConfig []config.MaxNodesCha
 	argsSystemSC.MaxNodesChangeConfigProvider = nodesConfigProvider
 
 	softAuctionCfg := createSoftAuctionConfig()
-	auctionDisplayer, _ := NewAuctionListDisplayer(softAuctionCfg, 0)
+	auctionDisplayer, _ := NewAuctionListDisplayer(ArgsAuctionListDisplayer{
+		TableDisplayHandler: NewTableDisplayer(),
+		AuctionConfig:       softAuctionCfg,
+	})
 	return AuctionListSelectorArgs{
 		ShardCoordinator:             argsSystemSC.ShardCoordinator,
 		StakingDataProvider:          argsSystemSC.StakingDataProvider,

--- a/epochStart/metachain/auctionListSelector_test.go
+++ b/epochStart/metachain/auctionListSelector_test.go
@@ -105,6 +105,15 @@ func TestNewAuctionListSelector(t *testing.T) {
 		require.Equal(t, epochStart.ErrNilMaxNodesChangeConfigProvider, err)
 	})
 
+	t.Run("nil auction list displayer", func(t *testing.T) {
+		t.Parallel()
+		args := createAuctionListSelectorArgs(nil)
+		args.AuctionListDisplayHandler = nil
+		als, err := NewAuctionListSelector(args)
+		require.Nil(t, als)
+		require.Equal(t, errNilAuctionListDisplayHandler, err)
+	})
+
 	t.Run("invalid soft auction config", func(t *testing.T) {
 		t.Parallel()
 		args := createAuctionListSelectorArgs(nil)

--- a/epochStart/metachain/auctionListSelector_test.go
+++ b/epochStart/metachain/auctionListSelector_test.go
@@ -38,8 +38,10 @@ func createAuctionListSelectorArgs(maxNodesChangeConfig []config.MaxNodesChangeC
 
 	softAuctionCfg := createSoftAuctionConfig()
 	auctionDisplayer, _ := NewAuctionListDisplayer(ArgsAuctionListDisplayer{
-		TableDisplayHandler: NewTableDisplayer(),
-		AuctionConfig:       softAuctionCfg,
+		TableDisplayHandler:      NewTableDisplayer(),
+		ValidatorPubKeyConverter: &testscommon.PubkeyConverterMock{},
+		AddressPubKeyConverter:   &testscommon.PubkeyConverterMock{},
+		AuctionConfig:            softAuctionCfg,
 	})
 	return AuctionListSelectorArgs{
 		ShardCoordinator:             shardCoordinator,
@@ -62,8 +64,10 @@ func createFullAuctionListSelectorArgs(maxNodesChangeConfig []config.MaxNodesCha
 
 	softAuctionCfg := createSoftAuctionConfig()
 	auctionDisplayer, _ := NewAuctionListDisplayer(ArgsAuctionListDisplayer{
-		TableDisplayHandler: NewTableDisplayer(),
-		AuctionConfig:       softAuctionCfg,
+		TableDisplayHandler:      NewTableDisplayer(),
+		ValidatorPubKeyConverter: &testscommon.PubkeyConverterMock{},
+		AddressPubKeyConverter:   &testscommon.PubkeyConverterMock{},
+		AuctionConfig:            softAuctionCfg,
 	})
 	return AuctionListSelectorArgs{
 		ShardCoordinator:             argsSystemSC.ShardCoordinator,

--- a/epochStart/metachain/auctionListSorting.go
+++ b/epochStart/metachain/auctionListSorting.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (als *auctionListSelector) selectNodes(
-	ownersData map[string]*ownerAuctionData,
+	ownersData map[string]*OwnerAuctionData,
 	numAvailableSlots uint32,
 	randomness []byte,
 ) []state.ValidatorInfoHandler {
@@ -25,14 +25,14 @@ func (als *auctionListSelector) selectNodes(
 		selectedFromAuction = append(selectedFromAuction, owner.auctionList[:owner.numQualifiedAuctionNodes]...)
 	}
 
-	als.displayOwnersSelectedNodes(ownersData)
+	als.auctionListDisplayer.DisplayOwnersSelectedNodes(ownersData)
 	sortValidators(selectedFromAuction, validatorTopUpMap, normRand)
-	als.displayAuctionList(selectedFromAuction, ownersData, numAvailableSlots)
+	als.auctionListDisplayer.DisplayAuctionList(selectedFromAuction, ownersData, numAvailableSlots)
 
 	return selectedFromAuction[:numAvailableSlots]
 }
 
-func getPubKeyLen(ownersData map[string]*ownerAuctionData) int {
+func getPubKeyLen(ownersData map[string]*OwnerAuctionData) int {
 	for _, owner := range ownersData {
 		return len(owner.auctionList[0].GetPublicKey())
 	}
@@ -62,7 +62,7 @@ func sortListByPubKey(list []state.ValidatorInfoHandler) {
 	})
 }
 
-func addQualifiedValidatorsTopUpInMap(owner *ownerAuctionData, validatorTopUpMap map[string]*big.Int) {
+func addQualifiedValidatorsTopUpInMap(owner *OwnerAuctionData, validatorTopUpMap map[string]*big.Int) {
 	for i := int64(0); i < owner.numQualifiedAuctionNodes; i++ {
 		validatorPubKey := string(owner.auctionList[i].GetPublicKey())
 		validatorTopUpMap[validatorPubKey] = big.NewInt(0).SetBytes(owner.qualifiedTopUpPerNode.Bytes())

--- a/epochStart/metachain/errors.go
+++ b/epochStart/metachain/errors.go
@@ -7,3 +7,5 @@ var errNilValidatorsInfoMap = errors.New("received nil shard validators info map
 var errCannotComputeDenominator = errors.New("cannot compute denominator value")
 
 var errNilAuctionListDisplayHandler = errors.New("nil auction list display handler provided")
+
+var errNilTableDisplayHandler = errors.New("nil table display handler provided")

--- a/epochStart/metachain/errors.go
+++ b/epochStart/metachain/errors.go
@@ -5,3 +5,5 @@ import "errors"
 var errNilValidatorsInfoMap = errors.New("received nil shard validators info map")
 
 var errCannotComputeDenominator = errors.New("cannot compute denominator value")
+
+var errNilAuctionListDisplayHandler = errors.New("nil auction list display handler provided")

--- a/epochStart/metachain/interface.go
+++ b/epochStart/metachain/interface.go
@@ -1,13 +1,11 @@
 package metachain
 
 import (
-	"math/big"
-
 	"github.com/multiversx/mx-chain-go/state"
 )
 
+// AuctionListDisplayHandler should be able to display auction list data during selection process
 type AuctionListDisplayHandler interface {
-	DisplayMinRequiredTopUp(topUp *big.Int, startTopUp *big.Int)
 	DisplayOwnersData(ownersData map[string]*OwnerAuctionData)
 	DisplayOwnersSelectedNodes(ownersData map[string]*OwnerAuctionData)
 	DisplayAuctionList(

--- a/epochStart/metachain/interface.go
+++ b/epochStart/metachain/interface.go
@@ -1,0 +1,19 @@
+package metachain
+
+import (
+	"math/big"
+
+	"github.com/multiversx/mx-chain-go/state"
+)
+
+type AuctionListDisplayHandler interface {
+	DisplayMinRequiredTopUp(topUp *big.Int, startTopUp *big.Int)
+	DisplayOwnersData(ownersData map[string]*OwnerAuctionData)
+	DisplayOwnersSelectedNodes(ownersData map[string]*OwnerAuctionData)
+	DisplayAuctionList(
+		auctionList []state.ValidatorInfoHandler,
+		ownersData map[string]*OwnerAuctionData,
+		numOfSelectedNodes uint32,
+	)
+	IsInterfaceNil() bool
+}

--- a/epochStart/metachain/interface.go
+++ b/epochStart/metachain/interface.go
@@ -1,6 +1,7 @@
 package metachain
 
 import (
+	"github.com/multiversx/mx-chain-core-go/display"
 	"github.com/multiversx/mx-chain-go/state"
 )
 
@@ -13,5 +14,11 @@ type AuctionListDisplayHandler interface {
 		ownersData map[string]*OwnerAuctionData,
 		numOfSelectedNodes uint32,
 	)
+	IsInterfaceNil() bool
+}
+
+// TableDisplayHandler should be able to display tables in log
+type TableDisplayHandler interface {
+	DisplayTable(tableHeader []string, lines []*display.LineData, message string)
 	IsInterfaceNil() bool
 }

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -908,8 +908,11 @@ func createFullArgumentsForSystemSCProcessing(enableEpochsConfig config.EnableEp
 		MaxNumberOfIterations: 100000,
 	}
 	ald, _ := NewAuctionListDisplayer(ArgsAuctionListDisplayer{
-		TableDisplayHandler: NewTableDisplayer(),
-		AuctionConfig:       auctionCfg,
+		TableDisplayHandler:      NewTableDisplayer(),
+		ValidatorPubKeyConverter: &testscommon.PubkeyConverterMock{},
+		AddressPubKeyConverter:   &testscommon.PubkeyConverterMock{},
+		AuctionConfig:            auctionCfg,
+		Denomination:             0,
 	})
 	argsAuctionListSelector := AuctionListSelectorArgs{
 		ShardCoordinator:             shardCoordinator,
@@ -1924,8 +1927,11 @@ func TestSystemSCProcessor_ProcessSystemSmartContractStakingV4Enabled(t *testing
 		MaxNumberOfIterations: 100000,
 	}
 	ald, _ := NewAuctionListDisplayer(ArgsAuctionListDisplayer{
-		TableDisplayHandler: NewTableDisplayer(),
-		AuctionConfig:       auctionCfg,
+		TableDisplayHandler:      NewTableDisplayer(),
+		ValidatorPubKeyConverter: &testscommon.PubkeyConverterMock{},
+		AddressPubKeyConverter:   &testscommon.PubkeyConverterMock{},
+		AuctionConfig:            auctionCfg,
+		Denomination:             0,
 	})
 
 	argsAuctionListSelector := AuctionListSelectorArgs{

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -907,7 +907,10 @@ func createFullArgumentsForSystemSCProcessing(enableEpochsConfig config.EnableEp
 		MaxTopUp:              "32000000",
 		MaxNumberOfIterations: 100000,
 	}
-	ald, _ := NewAuctionListDisplayer(auctionCfg, 0)
+	ald, _ := NewAuctionListDisplayer(ArgsAuctionListDisplayer{
+		TableDisplayHandler: NewTableDisplayer(),
+		AuctionConfig:       auctionCfg,
+	})
 	argsAuctionListSelector := AuctionListSelectorArgs{
 		ShardCoordinator:             shardCoordinator,
 		StakingDataProvider:          stakingSCProvider,
@@ -1920,7 +1923,10 @@ func TestSystemSCProcessor_ProcessSystemSmartContractStakingV4Enabled(t *testing
 		MaxTopUp:              "32000000",
 		MaxNumberOfIterations: 100000,
 	}
-	ald, _ := NewAuctionListDisplayer(auctionCfg, 0)
+	ald, _ := NewAuctionListDisplayer(ArgsAuctionListDisplayer{
+		TableDisplayHandler: NewTableDisplayer(),
+		AuctionConfig:       auctionCfg,
+	})
 
 	argsAuctionListSelector := AuctionListSelectorArgs{
 		ShardCoordinator:             args.ShardCoordinator,

--- a/epochStart/metachain/systemSCs_test.go
+++ b/epochStart/metachain/systemSCs_test.go
@@ -901,16 +901,19 @@ func createFullArgumentsForSystemSCProcessing(enableEpochsConfig config.EnableEp
 	shardCoordinator, _ := sharding.NewMultiShardCoordinator(3, core.MetachainShardId)
 
 	nodesConfigProvider, _ := notifier.NewNodesConfigProvider(en, nil)
+	auctionCfg := config.SoftAuctionConfig{
+		TopUpStep:             "10",
+		MinTopUp:              "1",
+		MaxTopUp:              "32000000",
+		MaxNumberOfIterations: 100000,
+	}
+	ald, _ := NewAuctionListDisplayer(auctionCfg, 0)
 	argsAuctionListSelector := AuctionListSelectorArgs{
 		ShardCoordinator:             shardCoordinator,
 		StakingDataProvider:          stakingSCProvider,
 		MaxNodesChangeConfigProvider: nodesConfigProvider,
-		SoftAuctionConfig: config.SoftAuctionConfig{
-			TopUpStep:             "10",
-			MinTopUp:              "1",
-			MaxTopUp:              "32000000",
-			MaxNumberOfIterations: 100000,
-		},
+		AuctionListDisplayHandler:    ald,
+		SoftAuctionConfig:            auctionCfg,
 	}
 	als, _ := NewAuctionListSelector(argsAuctionListSelector)
 
@@ -1910,16 +1913,21 @@ func TestSystemSCProcessor_ProcessSystemSmartContractStakingV4Enabled(t *testing
 
 	args, _ := createFullArgumentsForSystemSCProcessing(config.EnableEpochs{}, testscommon.CreateMemUnit())
 	nodesConfigProvider, _ := notifier.NewNodesConfigProvider(args.EpochNotifier, []config.MaxNodesChangeConfig{{MaxNumNodes: 8}})
+
+	auctionCfg := config.SoftAuctionConfig{
+		TopUpStep:             "10",
+		MinTopUp:              "1",
+		MaxTopUp:              "32000000",
+		MaxNumberOfIterations: 100000,
+	}
+	ald, _ := NewAuctionListDisplayer(auctionCfg, 0)
+
 	argsAuctionListSelector := AuctionListSelectorArgs{
 		ShardCoordinator:             args.ShardCoordinator,
 		StakingDataProvider:          args.StakingDataProvider,
 		MaxNodesChangeConfigProvider: nodesConfigProvider,
-		SoftAuctionConfig: config.SoftAuctionConfig{
-			TopUpStep:             "10",
-			MinTopUp:              "1",
-			MaxTopUp:              "32000000",
-			MaxNumberOfIterations: 100000,
-		},
+		SoftAuctionConfig:            auctionCfg,
+		AuctionListDisplayHandler:    ald,
 	}
 	als, _ := NewAuctionListSelector(argsAuctionListSelector)
 	args.AuctionListSelector = als

--- a/epochStart/metachain/tableDisplayer.go
+++ b/epochStart/metachain/tableDisplayer.go
@@ -1,0 +1,32 @@
+package metachain
+
+import (
+	"fmt"
+
+	"github.com/multiversx/mx-chain-core-go/display"
+)
+
+type tableDisplayer struct {
+}
+
+// NewTableDisplayer will create a component able to display tables in logger
+func NewTableDisplayer() *tableDisplayer {
+	return &tableDisplayer{}
+}
+
+// DisplayTable will display a table in the log
+func (tb *tableDisplayer) DisplayTable(tableHeader []string, lines []*display.LineData, message string) {
+	table, err := display.CreateTableString(tableHeader, lines)
+	if err != nil {
+		log.Error("could not create table", "tableHeader", tableHeader, "error", err)
+		return
+	}
+
+	msg := fmt.Sprintf("%s\n%s", message, table)
+	log.Debug(msg)
+}
+
+// IsInterfaceNil checks if the underlying pointer is nil
+func (tb *tableDisplayer) IsInterfaceNil() bool {
+	return tb == nil
+}

--- a/factory/disabled/auctionListDisplayer.go
+++ b/factory/disabled/auctionListDisplayer.go
@@ -1,8 +1,6 @@
 package disabled
 
 import (
-	"math/big"
-
 	"github.com/multiversx/mx-chain-go/epochStart/metachain"
 	"github.com/multiversx/mx-chain-go/state"
 )
@@ -10,22 +8,20 @@ import (
 type auctionListDisplayer struct {
 }
 
+// NewDisabledAuctionListDisplayer creates a disabled auction list displayer
 func NewDisabledAuctionListDisplayer() *auctionListDisplayer {
 	return &auctionListDisplayer{}
 }
 
-func (ald *auctionListDisplayer) DisplayMinRequiredTopUp(_ *big.Int, _ *big.Int) {
-
-}
-
+// DisplayOwnersData does nothing
 func (ald *auctionListDisplayer) DisplayOwnersData(_ map[string]*metachain.OwnerAuctionData) {
-
 }
 
+// DisplayOwnersSelectedNodes does nothing
 func (ald *auctionListDisplayer) DisplayOwnersSelectedNodes(_ map[string]*metachain.OwnerAuctionData) {
-
 }
 
+// DisplayAuctionList does nothing
 func (ald *auctionListDisplayer) DisplayAuctionList(
 	_ []state.ValidatorInfoHandler,
 	_ map[string]*metachain.OwnerAuctionData,

--- a/factory/disabled/auctionListDisplayer.go
+++ b/factory/disabled/auctionListDisplayer.go
@@ -1,0 +1,39 @@
+package disabled
+
+import (
+	"math/big"
+
+	"github.com/multiversx/mx-chain-go/epochStart/metachain"
+	"github.com/multiversx/mx-chain-go/state"
+)
+
+type auctionListDisplayer struct {
+}
+
+func NewDisabledAuctionListDisplayer() *auctionListDisplayer {
+	return &auctionListDisplayer{}
+}
+
+func (ald *auctionListDisplayer) DisplayMinRequiredTopUp(_ *big.Int, _ *big.Int) {
+
+}
+
+func (ald *auctionListDisplayer) DisplayOwnersData(_ map[string]*metachain.OwnerAuctionData) {
+
+}
+
+func (ald *auctionListDisplayer) DisplayOwnersSelectedNodes(_ map[string]*metachain.OwnerAuctionData) {
+
+}
+
+func (ald *auctionListDisplayer) DisplayAuctionList(
+	_ []state.ValidatorInfoHandler,
+	_ map[string]*metachain.OwnerAuctionData,
+	_ uint32,
+) {
+}
+
+// IsInterfaceNil checks if the underlying pointer is nil
+func (ald *auctionListDisplayer) IsInterfaceNil() bool {
+	return ald == nil
+}

--- a/factory/processing/blockProcessorCreator.go
+++ b/factory/processing/blockProcessorCreator.go
@@ -887,10 +887,12 @@ func (pcf *processComponentsFactory) newMetaBlockProcessor(
 		return nil, err
 	}
 
-	auctionListDisplayer, err := metachainEpochStart.NewAuctionListDisplayer(
-		pcf.systemSCConfig.SoftAuctionConfig,
-		pcf.economicsConfig.GlobalSettings.Denomination,
-	)
+	argsAuctionListDisplayer := metachainEpochStart.ArgsAuctionListDisplayer{
+		TableDisplayHandler: metachainEpochStart.NewTableDisplayer(),
+		AuctionConfig:       pcf.systemSCConfig.SoftAuctionConfig,
+		Denomination:        pcf.economicsConfig.GlobalSettings.Denomination,
+	}
+	auctionListDisplayer, err := metachainEpochStart.NewAuctionListDisplayer(argsAuctionListDisplayer)
 	if err != nil {
 		return nil, err
 	}

--- a/factory/processing/blockProcessorCreator.go
+++ b/factory/processing/blockProcessorCreator.go
@@ -887,10 +887,19 @@ func (pcf *processComponentsFactory) newMetaBlockProcessor(
 		return nil, err
 	}
 
+	auctionListDisplayer, err := metachainEpochStart.NewAuctionListDisplayer(
+		pcf.systemSCConfig.SoftAuctionConfig,
+		pcf.economicsConfig.GlobalSettings.Denomination,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	argsAuctionListSelector := metachainEpochStart.AuctionListSelectorArgs{
 		ShardCoordinator:             pcf.bootstrapComponents.ShardCoordinator(),
 		StakingDataProvider:          stakingDataProvider,
 		MaxNodesChangeConfigProvider: maxNodesChangeConfigProvider,
+		AuctionListDisplayHandler:    auctionListDisplayer,
 		SoftAuctionConfig:            pcf.systemSCConfig.SoftAuctionConfig,
 		Denomination:                 pcf.economicsConfig.GlobalSettings.Denomination,
 	}
@@ -905,6 +914,7 @@ func (pcf *processComponentsFactory) newMetaBlockProcessor(
 		MaxNodesChangeConfigProvider: maxNodesChangeConfigProvider,
 		SoftAuctionConfig:            pcf.systemSCConfig.SoftAuctionConfig,
 		Denomination:                 pcf.economicsConfig.GlobalSettings.Denomination,
+		AuctionListDisplayHandler:    factoryDisabled.NewDisabledAuctionListDisplayer(),
 	}
 	auctionListSelectorAPI, err := metachainEpochStart.NewAuctionListSelector(argsAuctionListSelectorAPI)
 	if err != nil {

--- a/factory/processing/blockProcessorCreator.go
+++ b/factory/processing/blockProcessorCreator.go
@@ -888,9 +888,11 @@ func (pcf *processComponentsFactory) newMetaBlockProcessor(
 	}
 
 	argsAuctionListDisplayer := metachainEpochStart.ArgsAuctionListDisplayer{
-		TableDisplayHandler: metachainEpochStart.NewTableDisplayer(),
-		AuctionConfig:       pcf.systemSCConfig.SoftAuctionConfig,
-		Denomination:        pcf.economicsConfig.GlobalSettings.Denomination,
+		TableDisplayHandler:      metachainEpochStart.NewTableDisplayer(),
+		ValidatorPubKeyConverter: pcf.coreData.ValidatorPubKeyConverter(),
+		AddressPubKeyConverter:   pcf.coreData.AddressPubKeyConverter(),
+		AuctionConfig:            pcf.systemSCConfig.SoftAuctionConfig,
+		Denomination:             pcf.economicsConfig.GlobalSettings.Denomination,
 	}
 	auctionListDisplayer, err := metachainEpochStart.NewAuctionListDisplayer(argsAuctionListDisplayer)
 	if err != nil {

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -2335,16 +2335,20 @@ func (tpn *TestProcessorNode) initBlockProcessor() {
 			tpn.EpochNotifier,
 			nil,
 		)
+		auctionCfg := config.SoftAuctionConfig{
+			TopUpStep:             "10",
+			MinTopUp:              "1",
+			MaxTopUp:              "32000000",
+			MaxNumberOfIterations: 100000,
+		}
+		ald, _ := metachain.NewAuctionListDisplayer(auctionCfg, 0)
+
 		argsAuctionListSelector := metachain.AuctionListSelectorArgs{
 			ShardCoordinator:             tpn.ShardCoordinator,
 			StakingDataProvider:          stakingDataProvider,
 			MaxNodesChangeConfigProvider: maxNodesChangeConfigProvider,
-			SoftAuctionConfig: config.SoftAuctionConfig{
-				TopUpStep:             "10",
-				MinTopUp:              "1",
-				MaxTopUp:              "32000000",
-				MaxNumberOfIterations: 100000,
-			},
+			AuctionListDisplayHandler:    ald,
+			SoftAuctionConfig:            auctionCfg,
 		}
 		auctionListSelector, _ := metachain.NewAuctionListSelector(argsAuctionListSelector)
 

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -2341,7 +2341,10 @@ func (tpn *TestProcessorNode) initBlockProcessor() {
 			MaxTopUp:              "32000000",
 			MaxNumberOfIterations: 100000,
 		}
-		ald, _ := metachain.NewAuctionListDisplayer(auctionCfg, 0)
+		ald, _ := metachain.NewAuctionListDisplayer(metachain.ArgsAuctionListDisplayer{
+			TableDisplayHandler: metachain.NewTableDisplayer(),
+			AuctionConfig:       auctionCfg,
+		})
 
 		argsAuctionListSelector := metachain.AuctionListSelectorArgs{
 			ShardCoordinator:             tpn.ShardCoordinator,

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -2342,8 +2342,10 @@ func (tpn *TestProcessorNode) initBlockProcessor() {
 			MaxNumberOfIterations: 100000,
 		}
 		ald, _ := metachain.NewAuctionListDisplayer(metachain.ArgsAuctionListDisplayer{
-			TableDisplayHandler: metachain.NewTableDisplayer(),
-			AuctionConfig:       auctionCfg,
+			TableDisplayHandler:      metachain.NewTableDisplayer(),
+			ValidatorPubKeyConverter: &testscommon.PubkeyConverterMock{},
+			AddressPubKeyConverter:   &testscommon.PubkeyConverterMock{},
+			AuctionConfig:            auctionCfg,
 		})
 
 		argsAuctionListSelector := metachain.AuctionListSelectorArgs{

--- a/integrationTests/vm/staking/systemSCCreator.go
+++ b/integrationTests/vm/staking/systemSCCreator.go
@@ -45,16 +45,21 @@ func createSystemSCProcessor(
 		coreComponents.EpochNotifier(),
 		maxNodesConfig,
 	)
+
+	auctionCfg := config.SoftAuctionConfig{
+		TopUpStep:             "10",
+		MinTopUp:              "1",
+		MaxTopUp:              "32000000",
+		MaxNumberOfIterations: 100000,
+	}
+	ald, _ := metachain.NewAuctionListDisplayer(auctionCfg, 0)
+
 	argsAuctionListSelector := metachain.AuctionListSelectorArgs{
 		ShardCoordinator:             shardCoordinator,
 		StakingDataProvider:          stakingDataProvider,
 		MaxNodesChangeConfigProvider: maxNodesChangeConfigProvider,
-		SoftAuctionConfig: config.SoftAuctionConfig{
-			TopUpStep:             "10",
-			MinTopUp:              "1",
-			MaxTopUp:              "32000000",
-			MaxNumberOfIterations: 100000,
-		},
+		AuctionListDisplayHandler:    ald,
+		SoftAuctionConfig:            auctionCfg,
 	}
 	auctionListSelector, _ := metachain.NewAuctionListSelector(argsAuctionListSelector)
 

--- a/integrationTests/vm/staking/systemSCCreator.go
+++ b/integrationTests/vm/staking/systemSCCreator.go
@@ -52,7 +52,10 @@ func createSystemSCProcessor(
 		MaxTopUp:              "32000000",
 		MaxNumberOfIterations: 100000,
 	}
-	ald, _ := metachain.NewAuctionListDisplayer(auctionCfg, 0)
+	ald, _ := metachain.NewAuctionListDisplayer(metachain.ArgsAuctionListDisplayer{
+		TableDisplayHandler: metachain.NewTableDisplayer(),
+		AuctionConfig:       auctionCfg,
+	})
 
 	argsAuctionListSelector := metachain.AuctionListSelectorArgs{
 		ShardCoordinator:             shardCoordinator,

--- a/integrationTests/vm/staking/systemSCCreator.go
+++ b/integrationTests/vm/staking/systemSCCreator.go
@@ -53,8 +53,10 @@ func createSystemSCProcessor(
 		MaxNumberOfIterations: 100000,
 	}
 	ald, _ := metachain.NewAuctionListDisplayer(metachain.ArgsAuctionListDisplayer{
-		TableDisplayHandler: metachain.NewTableDisplayer(),
-		AuctionConfig:       auctionCfg,
+		TableDisplayHandler:      metachain.NewTableDisplayer(),
+		ValidatorPubKeyConverter: &testscommon.PubkeyConverterMock{},
+		AddressPubKeyConverter:   &testscommon.PubkeyConverterMock{},
+		AuctionConfig:            auctionCfg,
 	})
 
 	argsAuctionListSelector := metachain.AuctionListSelectorArgs{

--- a/testscommon/tableDisplayerMock.go
+++ b/testscommon/tableDisplayerMock.go
@@ -1,0 +1,19 @@
+package testscommon
+
+import "github.com/multiversx/mx-chain-core-go/display"
+
+// TableDisplayerMock -
+type TableDisplayerMock struct {
+	DisplayTableCalled func(tableHeader []string, lines []*display.LineData, message string)
+}
+
+// DisplayTable -
+func (mock *TableDisplayerMock) DisplayTable(tableHeader []string, lines []*display.LineData, message string) {
+	if mock.DisplayTableCalled != nil {
+		mock.DisplayTableCalled(tableHeader, lines, message)
+	}
+}
+
+func (mock *TableDisplayerMock) IsInterfaceNil() bool {
+	return mock == nil
+}


### PR DESCRIPTION
## Reasoning behind the pull request
- We use the same component `AuctionListSelector` for both computation at the end of the epoch and api calls simulation
- Since this component used to print a lot of data to the log, therefore causing increased storage needs, we needed to disable it for api calls
  
## Proposed changes
- Moved all storage expensive table displayers into a new component: `auctionListDisplayer`.
- This above mentioned displayer is used only for epoch start computation. For api component, we use a disabled one

## Testing procedure
- Run a system test with debug level, multiKey and enough nodes in network to always have the auction list filled
- After epoch 6 (when whole stakingV4 chain is enabled), we should periodically call `validator/auction` route and make sure that no table is printed
- Meanwhile, starting epoch 6, at each epoch change, we should always see the tables (  **3 tables**) ,    similar to this:

1.
```
DEBUG[2024-02-01 18:49:36.194] [..hStart/metachain] [metachain/1269/18448096/(BLOCK)] Initial nodes config in auction list
+------------------------------------------------------------------+------------------+------------------+-------------------+---------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Owner                                                            | Num staked nodes | Num active nodes | Num auction nodes | Total top up  | Top up per node | Auction list nodes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+------------------------------------------------------------------+------------------+------------------+-------------------+---------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 0000000000000000000100000000000000000000000000000000000053ffffff | 2                | 1                | 1                 | 817.01201     | 408.50600       | 2b8e414f0d...195434e787                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
| f4b8d1aed9c04baa08b750203edadcee1bc3d963d66ce7000f5863a3fcd9f290 | 1                | 0                | 1                 | 0.00000       | 0.00000         | 752f4d283f...20371be80f                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
| 000000000000000000010000000000000000000000000000000000007fffffff | 10               | 9                | 1                 | 31075.81928   | 3107.58192      | 22bd559821...d733faff89                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |

```

2.

```
DEBUG[2024-02-01 18:49:36.196] [..hStart/metachain] [metachain/1269/18448096/(BLOCK)] Selected nodes config from auction list
+------------------------------------------------------------------+------------------+----------------+---------------+-------------------+-----------------------------+------------------+---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Owner                                                            | Num staked nodes | TopUp per node | Total top up  | Num auction nodes | Num qualified auction nodes | Num active nodes | Qualified top up per node | Selected auction list nodes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+------------------------------------------------------------------+------------------+----------------+---------------+-------------------+-----------------------------+------------------+---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 0000000000000000000100000000000000000000000000000000000006ffffff | 50               | 2799.00877     | 139950.43854  | 4                 | 4                           | 46               | 2799.00877                | bb367a3240...20b40e528b, b345934c17...4d6511b20b, 91401271d3...b3c4275114, 59c0081328...c04d597c06                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
| 000000000000000000010000000000000000000000000000000000000bffffff | 53               | 1438.83780     | 76258.40364   | 5                 | 5                           | 48               | 1438.83780                | f56d9c29a0...ba7908a112, e6a1f584b4...6c2b450f80, d55bde4cbd...ca6e5a4f8b, a811cfb07c...3bc4d96b17, 32ed3dcd02...9a4bcb9d05                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
| 0000000000000000000100000000000000000000000000000000000020ffffff | 36               | 4015.53315     | 144559.19363  | 4                 | 4                           | 32               | 4015.53315                | c60c12298c...cc41aea519, b89df7002f...1f7f073105, 6f8038d51b...ee34147b92, 31ff7db5d5...65199f1d14                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |

```

3.

```
DEBUG[2024-02-01 18:49:36.198] [..hStart/metachain] [metachain/1269/18448096/(BLOCK)] Final selected nodes from auction list
+------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------+
| Owner                                                            | Registered key                                                                                                                                                                                   | Qualified TopUp per node |
+------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------+
| 0000000000000000000100000000000000000000000000000000000061ffffff | 90e951e3342ec776a0a73272c88b75bda92dc7dca5eb38528b1c6acb81c7ba0f66430b5cbc3cdeacbfc378a4f0584c10ba8d96b9d789c21a0aad7d15263e2b52a2e5ed597268d414735a50c07cde3ec1952b9fdb3ac3dcd95bfa2649f006a605 | 29553.89004              |
| 0000000000000000000100000000000000000000000000000000000061ffffff | b3a052a7bb2cc302f6f5189e31d59e6603e151eaa6a1785258615b259156cf37907e95e8077f4d3ae2aaffb76510d810dc81c318542ffaec543c52bd70950b285140ac908b162f9be92a96f8bf38d21212db5c07e6cf11f23dac6ee71007ee93 | 29553.89004              |
| 0000000000000000000100000000000000000000000000000000000061ffffff | d7f14109f8276376e77e714f4aef1cb68bd0ad3ef3a07a9b925627a386e4b4e134d74eebfcba11a359571dddd223db0849ebbc7687a1d497029da99fec36a89c75dc65dd5b851d1e8424fe4dd6cfbf90954b27973e7d0529952ccda649faaf0d | 29553.89004              |

```


## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
