### PR TITLE
miniblocks transactions fixes and unit tests

### DIFF
--- a/process/block/preprocess/sovereignChainTransactions_test.go
+++ b/process/block/preprocess/sovereignChainTransactions_test.go
@@ -406,9 +406,10 @@ func TestTxsPreprocessor_IsTransactionEligibleForExecutionShouldWork(t *testing.
 		tp, _ := NewTransactionPreprocessor(args)
 		sctp, _ := NewSovereignChainTransactionPreprocessor(tp)
 
-		value := sctp.isTransactionEligibleForExecution(nil, errors.New("error"))
+		err, value := sctp.isTransactionEligibleForExecution(nil, errors.New("error"))
 
-		assert.False(t, value)
+		require.Equal(t, "error", err.Error())
+		require.False(t, value)
 	})
 
 	t.Run("isTransactionEligibleForExecution should return false when sender account is nil", func(t *testing.T) {
@@ -419,9 +420,10 @@ func TestTxsPreprocessor_IsTransactionEligibleForExecutionShouldWork(t *testing.
 		tp, _ := NewTransactionPreprocessor(args)
 		sctp, _ := NewSovereignChainTransactionPreprocessor(tp)
 
-		value := sctp.isTransactionEligibleForExecution(nil, nil)
+		err, value := sctp.isTransactionEligibleForExecution(nil, nil)
 
-		assert.False(t, value)
+		require.Nil(t, err)
+		require.False(t, value)
 	})
 
 	t.Run("isTransactionEligibleForExecution should return false when transaction has a higher nonce", func(t *testing.T) {
@@ -445,9 +447,10 @@ func TestTxsPreprocessor_IsTransactionEligibleForExecutionShouldWork(t *testing.
 			SndAddr: []byte("X"),
 			Nonce:   1,
 		}
-		value := sctp.isTransactionEligibleForExecution(tx, nil)
+		err, value := sctp.isTransactionEligibleForExecution(tx, nil)
 
-		assert.False(t, value)
+		require.ErrorIs(t, err, process.ErrHigherNonceInTransaction)
+		require.False(t, value)
 	})
 
 	t.Run("isTransactionEligibleForExecution should return false when account has insufficient balance for fees", func(t *testing.T) {
@@ -476,9 +479,10 @@ func TestTxsPreprocessor_IsTransactionEligibleForExecutionShouldWork(t *testing.
 			SndAddr: []byte("X"),
 			Nonce:   1,
 		}
-		value := sctp.isTransactionEligibleForExecution(tx, nil)
+		err, value := sctp.isTransactionEligibleForExecution(tx, nil)
 
-		assert.False(t, value)
+		require.ErrorIs(t, err, process.ErrInsufficientFee)
+		require.False(t, value)
 	})
 
 	t.Run("isTransactionEligibleForExecution should return false when account has insufficient funds", func(t *testing.T) {
@@ -508,9 +512,10 @@ func TestTxsPreprocessor_IsTransactionEligibleForExecutionShouldWork(t *testing.
 			Nonce:   1,
 			Value:   big.NewInt(2),
 		}
-		value := sctp.isTransactionEligibleForExecution(tx, nil)
+		err, value := sctp.isTransactionEligibleForExecution(tx, nil)
 
-		assert.False(t, value)
+		require.Nil(t, err)
+		require.True(t, value)
 	})
 
 	t.Run("isTransactionEligibleForExecution should return true", func(t *testing.T) {
@@ -540,8 +545,9 @@ func TestTxsPreprocessor_IsTransactionEligibleForExecutionShouldWork(t *testing.
 			Nonce:   1,
 			Value:   big.NewInt(2),
 		}
-		value := sctp.isTransactionEligibleForExecution(tx, nil)
+		err, value := sctp.isTransactionEligibleForExecution(tx, nil)
 
+		require.Nil(t, err)
 		assert.True(t, value)
 
 		accntInfo, found := sctp.accntsTracker.getAccountInfo(tx.GetSndAddr())
@@ -558,8 +564,9 @@ func TestTxsPreprocessor_IsTransactionEligibleForExecutionShouldWork(t *testing.
 			Nonce:   2,
 			Value:   big.NewInt(5),
 		}
-		value = sctp.isTransactionEligibleForExecution(tx2, nil)
+		err, value = sctp.isTransactionEligibleForExecution(tx2, nil)
 
+		require.Nil(t, err)
 		assert.True(t, value)
 
 		accntInfo, found = sctp.accntsTracker.getAccountInfo(tx2.GetSndAddr())

--- a/process/block/preprocess/sovereignChainTransactions_test.go
+++ b/process/block/preprocess/sovereignChainTransactions_test.go
@@ -406,9 +406,10 @@ func TestTxsPreprocessor_IsTransactionEligibleForExecutionShouldWork(t *testing.
 		tp, _ := NewTransactionPreprocessor(args)
 		sctp, _ := NewSovereignChainTransactionPreprocessor(tp)
 
-		err, value := sctp.isTransactionEligibleForExecution(nil, errors.New("error"))
+		expectedError := errors.New("error")
+		err, value := sctp.isTransactionEligibleForExecution(nil, expectedError)
 
-		require.Equal(t, "error", err.Error())
+		require.Equal(t, expectedError, err)
 		require.False(t, value)
 	})
 
@@ -512,7 +513,7 @@ func TestTxsPreprocessor_IsTransactionEligibleForExecutionShouldWork(t *testing.
 		require.False(t, value)
 	})
 
-	t.Run("isTransactionEligibleForExecution should return false when account has insufficient funds", func(t *testing.T) {
+	t.Run("isTransactionEligibleForExecution should return true if account has sufficient funds for fee but not sufficient for transfer.", func(t *testing.T) {
 		t.Parallel()
 
 		args := createDefaultTransactionsProcessorArgs()

--- a/process/block/preprocess/transactions.go
+++ b/process/block/preprocess/transactions.go
@@ -70,7 +70,7 @@ type transactions struct {
 
 	scheduledTXContinueFunc               func(isShardStuck func(uint32) bool, wrappedTx *txcache.WrappedTransaction, mapSCTxs map[string]struct{}, mbInfo *createScheduledMiniBlocksInfo) (*transaction.Transaction, *block.MiniBlock, bool)
 	shouldSkipMiniBlockFunc               func(miniBlock *block.MiniBlock) bool
-	isTransactionEligibleForExecutionFunc func(tx *transaction.Transaction, err error) bool
+	isTransactionEligibleForExecutionFunc func(tx *transaction.Transaction, err error) (error, bool)
 }
 
 // ArgsTransactionPreProcessor holds the arguments to create a txs pre processor

--- a/process/block/preprocess/transactionsV2.go
+++ b/process/block/preprocess/transactionsV2.go
@@ -385,7 +385,7 @@ func (txs *transactions) verifyTransaction(
 
 	executionErr, canExecute := txs.isTransactionEligibleForExecutionFunc(tx, err)
 	if !canExecute {
-		isTxTargetedForDeletion := errors.Is(executionErr, process.ErrLowerNonceInTransaction) || errors.Is(executionErr, process.ErrHigherNonceInTransaction) || errors.Is(executionErr, process.ErrInsufficientFee) || errors.Is(executionErr, process.ErrTransactionNotExecutable)
+		isTxTargetedForDeletion := errors.Is(executionErr, process.ErrLowerNonceInTransaction) || errors.Is(executionErr, process.ErrInsufficientFee) || errors.Is(executionErr, process.ErrTransactionNotExecutable)
 		log.Trace("bad tx", "error", executionErr, "hash", txHash)
 
 		if isTxTargetedForDeletion {

--- a/process/block/preprocess/transactionsV2.go
+++ b/process/block/preprocess/transactionsV2.go
@@ -386,20 +386,19 @@ func (txs *transactions) verifyTransaction(
 	executionErr, canExecute := txs.isTransactionEligibleForExecutionFunc(tx, err)
 	if !canExecute {
 		isTxTargetedForDeletion := errors.Is(executionErr, process.ErrLowerNonceInTransaction) || errors.Is(executionErr, process.ErrInsufficientFee) || errors.Is(executionErr, process.ErrTransactionNotExecutable)
-		log.Trace("bad tx", "error", executionErr, "hash", txHash)
-
 		if isTxTargetedForDeletion {
 			strCache := process.ShardCacherIdentifier(senderShardID, receiverShardID)
 			txs.txPool.RemoveData(txHash, strCache)
-
-			mbInfo.schedulingInfo.numScheduledBadTxs++
-
-			txs.gasHandler.RemoveGasProvidedAsScheduled([][]byte{txHash})
-
-			mbInfo.gasInfo.gasConsumedByMiniBlocksInSenderShard = oldGasConsumedByMiniBlocksInSenderShard
-			mbInfo.mapGasConsumedByMiniBlockInReceiverShard[receiverShardID] = oldGasConsumedByMiniBlockInReceiverShard
-			mbInfo.gasInfo.totalGasConsumedInSelfShard = oldTotalGasConsumedInSelfShard
 		}
+
+		mbInfo.schedulingInfo.numScheduledBadTxs++
+		log.Trace("bad tx", "error", executionErr, "hash", txHash)
+
+		txs.gasHandler.RemoveGasProvidedAsScheduled([][]byte{txHash})
+
+		mbInfo.gasInfo.gasConsumedByMiniBlocksInSenderShard = oldGasConsumedByMiniBlocksInSenderShard
+		mbInfo.mapGasConsumedByMiniBlockInReceiverShard[receiverShardID] = oldGasConsumedByMiniBlockInReceiverShard
+		mbInfo.gasInfo.totalGasConsumedInSelfShard = oldTotalGasConsumedInSelfShard
 
 		return executionErr
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- Correction for transactions that should be added in the scheduled mini block
- 
- 
  
## Proposed changes
- `isTransactionEligibleForExecution` function should return the error
error => is not added in the miniblock and for some cases removed from txpool (e.g. InsufficientFee, LowerNonce)
no error => is added in the miniblock (including txs with InsufficientFunds)

## Testing procedure
- running sovereign node and sending bad transactions
- a full testing plan with transaction should be defined later
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
