### PR TITLE
Fix scripts for local testnet in multikey mode

### DIFF
--- a/scripts/testnet/include/config.sh
+++ b/scripts/testnet/include/config.sh
@@ -3,6 +3,7 @@ generateConfig() {
 
   TMP_SHARD_OBSERVERCOUNT=$SHARD_OBSERVERCOUNT
   TMP_META_OBSERVERCOUNT=$META_OBSERVERCOUNT
+  # set num of observers to 0, they will start with generated keys
   if [[ $MULTI_KEY_NODES -eq 1 ]]; then
     TMP_SHARD_OBSERVERCOUNT=0
     TMP_META_OBSERVERCOUNT=0

--- a/scripts/testnet/include/observers.sh
+++ b/scripts/testnet/include/observers.sh
@@ -82,10 +82,18 @@ assembleCommand_startObserverNode() {
   let "KEY_INDEX=$TOTAL_NODECOUNT - $OBSERVER_INDEX - 1"
   WORKING_DIR=$TESTNETDIR/node_working_dirs/observer$OBSERVER_INDEX
 
+  KEYS_FLAGS="-validator-key-pem-file ./config/validatorKey.pem -sk-index $KEY_INDEX"
+  # if node is running in multi key mode, in order to avoid loading the common allValidatorKeys.pem file
+  # and force generating a new key for observers, simply provide an invalid path
+  if [[ $MULTI_KEY_NODES -eq 1 ]]; then
+        TMP_MISSING_PEM="missing-file.pem"
+        KEYS_FLAGS="-all-validator-keys-pem-file $TMP_MISSING_PEM -validator-key-pem-file $TMP_MISSING_PEM"
+  fi
+
   local nodeCommand="./node \
         -port $PORT --profile-mode -log-save -log-level $LOGLEVEL --log-logger-name --log-correlation --use-health-service -rest-api-interface localhost:$RESTAPIPORT \
         -destination-shard-as-observer $SHARD \
-        -sk-index $KEY_INDEX \
+        $KEYS_FLAGS \
         -working-directory $WORKING_DIR -config ./config/config_observer.toml $EXTRA_OBSERVERS_FLAGS"
 
   if [ -n "$NODE_NICENESS" ]

--- a/scripts/testnet/variables.sh
+++ b/scripts/testnet/variables.sh
@@ -170,10 +170,6 @@ export TOTAL_OBSERVERCOUNT=$total_observer_count
 # to enable the full archive feature on the observers, please use the --full-archive flag
 export EXTRA_OBSERVERS_FLAGS="-operation-mode db-lookup-extension"
 
-if [[ $MULTI_KEY_NODES -eq 1 ]]; then
-  EXTRA_OBSERVERS_FLAGS="--no-key"
-fi
-
 # Leave unchanged.
 let "total_node_count = $SHARD_VALIDATORCOUNT * $SHARDCOUNT + $META_VALIDATORCOUNT + $TOTAL_OBSERVERCOUNT"
 export TOTAL_NODECOUNT=$total_node_count


### PR DESCRIPTION
## Reasoning behind the pull request
- with the deprecation of -no-key flag, the local testnets scripts would start the observers as multi key nodes
  
## Proposed changes
- fix scripts

## Testing procedure
- only scripts changes

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
