### PR TITLE
FIX: Duplicated pub key in stakingV4

### DIFF
--- a/epochStart/metachain/legacySystemSCs.go
+++ b/epochStart/metachain/legacySystemSCs.go
@@ -1231,6 +1231,16 @@ func (s *legacySystemSCProcessor) addNewlyStakedNodesToValidatorTrie(
 			RewardAddress:   rewardAddress,
 			AccumulatedFees: big.NewInt(0),
 		}
+
+		existingValidator := validatorsInfoMap.GetValidator(validatorInfo.GetPublicKey())
+		// This fix might not be backwards incompatible
+		if !check.IfNil(existingValidator) && s.enableEpochsHandler.IsFlagEnabled(common.StakingV4StartedFlag) {
+			err = validatorsInfoMap.Delete(existingValidator)
+			if err != nil {
+				return err
+			}
+		}
+
 		err = validatorsInfoMap.Add(validatorInfo)
 		if err != nil {
 			return err

--- a/epochStart/metachain/legacySystemSCs.go
+++ b/epochStart/metachain/legacySystemSCs.go
@@ -1233,7 +1233,7 @@ func (s *legacySystemSCProcessor) addNewlyStakedNodesToValidatorTrie(
 		}
 
 		existingValidator := validatorsInfoMap.GetValidator(validatorInfo.GetPublicKey())
-		// This fix might not be backwards incompatible
+		// This fix is not be backwards incompatible
 		if !check.IfNil(existingValidator) && s.enableEpochsHandler.IsFlagEnabled(common.StakingV4StartedFlag) {
 			err = validatorsInfoMap.Delete(existingValidator)
 			if err != nil {

--- a/epochStart/metachain/validators.go
+++ b/epochStart/metachain/validators.go
@@ -178,7 +178,8 @@ func (vic *validatorInfoCreator) deterministicSortValidators(validators []state.
 		bValidatorString := validators[b].GoString()
 		// possible issues as we have 2 entries with the same public key. Print & assure deterministic sorting
 		log.Warn("found 2 entries in validatorInfoCreator.deterministicSortValidators with the same public key",
-			"validator a", aValidatorString, "validator b", bValidatorString)
+			"validator a", aValidatorString, "validator b", bValidatorString,
+			"validator a pub key", validators[a].GetPublicKey(), "validator b pub key", validators[b].GetPublicKey())
 
 		// since the GoString will include all fields, we do not need to marshal the struct again. Strings comparison will
 		// suffice in this case.


### PR DESCRIPTION
## Reasoning behind the pull request
- When staking new nodes from queue to auction list in `StakingV4Step1`, in some edge cases with queued inactive jailed validators, when sending them to auction (after they are unjailed), they would appear as duplicates when trying to sort them. This, however, would be fixed in nodes coordinator, therefore would not have any impact of the code. This is something that happens on existing code(before stakingV4) anyway
  
## Proposed changes
- However, starting stakingV4, we will delete such existing nodes(if found) and replace them with the new ones

## Testing procedure
- Initially found in this test `TestChainSimulator_FromQueueToAuctionList` as a `WARN`, from this pr: https://github.com/multiversx/mx-chain-go/pull/5937. Tested the fix with that integration test and it works

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
