### PR TITLE
FIX: Rename auction list nodes to nodes

### DIFF
--- a/api/groups/validatorGroup_test.go
+++ b/api/groups/validatorGroup_test.go
@@ -40,7 +40,7 @@ type validatorStatisticsResponse struct {
 	Error  string                                    `json:"error"`
 }
 
-type auctionListReponse struct {
+type auctionListResponse struct {
 	Data struct {
 		Result []*common.AuctionListValidatorAPIResponse `json:"auctionList"`
 	} `json:"data"`
@@ -216,7 +216,7 @@ func TestAuctionList_ErrorWhenFacadeFails(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	response := auctionListReponse{}
+	response := auctionListResponse{}
 	loadResponse(resp.Body, &response)
 
 	assert.Equal(t, http.StatusBadRequest, resp.Code)
@@ -249,7 +249,7 @@ func TestAuctionList_ReturnsSuccessfully(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 
-	response := auctionListReponse{}
+	response := auctionListResponse{}
 	loadResponse(resp.Body, &response)
 
 	assert.Equal(t, http.StatusOK, resp.Code)

--- a/common/dtos.go
+++ b/common/dtos.go
@@ -89,5 +89,5 @@ type AuctionListValidatorAPIResponse struct {
 	TotalTopUp     string         `json:"totalTopUp"`
 	TopUpPerNode   string         `json:"topUpPerNode"`
 	QualifiedTopUp string         `json:"qualifiedTopUp"`
-	AuctionList    []*AuctionNode `json:"auctionList"`
+	Nodes          []*AuctionNode `json:"nodes"`
 }

--- a/integrationTests/chainSimulator/staking/delegation_test.go
+++ b/integrationTests/chainSimulator/staking/delegation_test.go
@@ -346,7 +346,7 @@ func testBLSKeyIsInAuction(
 	}
 
 	require.Equal(t, actionListSize, len(auctionList))
-	require.Equal(t, 1, len(auctionList[0].AuctionList))
+	require.Equal(t, 1, len(auctionList[0].Nodes))
 	require.Equal(t, topUpInAuctionList.String(), auctionList[0].TopUpPerNode)
 
 	// in staking ph 4 we should find the key in the validators statics

--- a/integrationTests/chainSimulator/staking/stakeAndUnStake_test.go
+++ b/integrationTests/chainSimulator/staking/stakeAndUnStake_test.go
@@ -264,7 +264,7 @@ func TestChainSimulator_AddANewValidatorAfterStakingV4(t *testing.T) {
 	results, err := metachainNode.GetFacadeHandler().AuctionListApi()
 	require.Nil(t, err)
 	require.Equal(t, newValidatorOwner, results[0].Owner)
-	require.Equal(t, 20, len(results[0].AuctionList))
+	require.Equal(t, 20, len(results[0].Nodes))
 	checkTotalQualified(t, results, 8)
 
 	err = cs.GenerateBlocks(100)
@@ -278,7 +278,7 @@ func TestChainSimulator_AddANewValidatorAfterStakingV4(t *testing.T) {
 func checkTotalQualified(t *testing.T, auctionList []*common.AuctionListValidatorAPIResponse, expected int) {
 	totalQualified := 0
 	for _, res := range auctionList {
-		for _, node := range res.AuctionList {
+		for _, node := range res.Nodes {
 			if node.Qualified {
 				totalQualified++
 			}

--- a/process/peer/validatorsProviderAuction.go
+++ b/process/peer/validatorsProviderAuction.go
@@ -137,8 +137,8 @@ func compareByNumQualified(owner1Nodes, owner2Nodes *common.AuctionListValidator
 		return owner1Qualified
 	}
 
-	owner1NumQualified := getNumQualified(owner1Nodes.AuctionList)
-	owner2NumQualified := getNumQualified(owner2Nodes.AuctionList)
+	owner1NumQualified := getNumQualified(owner1Nodes.Nodes)
+	owner2NumQualified := getNumQualified(owner2Nodes.Nodes)
 
 	return owner1NumQualified > owner2NumQualified
 }
@@ -170,7 +170,7 @@ func (vp *validatorsProvider) getAuctionListValidatorsAPIResponse(
 				TotalTopUp:     ownerData.TotalTopUp.String(),
 				TopUpPerNode:   ownerData.TopUpPerNode.String(),
 				QualifiedTopUp: ownerData.TopUpPerNode.String(),
-				AuctionList:    make([]*common.AuctionNode, 0, numAuctionNodes),
+				Nodes:          make([]*common.AuctionNode, 0, numAuctionNodes),
 			}
 			vp.fillAuctionQualifiedValidatorAPIData(selectedNodes, ownerData, auctionValidator)
 			auctionListValidators = append(auctionListValidators, auctionValidator)
@@ -187,7 +187,7 @@ func (vp *validatorsProvider) fillAuctionQualifiedValidatorAPIData(
 	ownerData *epochStart.OwnerData,
 	auctionValidatorAPI *common.AuctionListValidatorAPIResponse,
 ) {
-	auctionValidatorAPI.AuctionList = make([]*common.AuctionNode, 0, len(ownerData.AuctionList))
+	auctionValidatorAPI.Nodes = make([]*common.AuctionNode, 0, len(ownerData.AuctionList))
 	numOwnerQualifiedNodes := int64(0)
 	for _, nodeInAuction := range ownerData.AuctionList {
 		auctionNode := &common.AuctionNode{
@@ -199,7 +199,7 @@ func (vp *validatorsProvider) fillAuctionQualifiedValidatorAPIData(
 			numOwnerQualifiedNodes++
 		}
 
-		auctionValidatorAPI.AuctionList = append(auctionValidatorAPI.AuctionList, auctionNode)
+		auctionValidatorAPI.Nodes = append(auctionValidatorAPI.Nodes, auctionNode)
 	}
 
 	if numOwnerQualifiedNodes > 0 {

--- a/process/peer/validatorsProvider_test.go
+++ b/process/peer/validatorsProvider_test.go
@@ -953,7 +953,7 @@ func TestValidatorsProvider_GetAuctionList(t *testing.T) {
 				TotalTopUp:     "4000",
 				TopUpPerNode:   "2000",
 				QualifiedTopUp: "4000",
-				AuctionList: []*common.AuctionNode{
+				Nodes: []*common.AuctionNode{
 					{
 						BlsKey:    args.ValidatorPubKeyConverter.SilentEncode(v5.PublicKey, log),
 						Qualified: true,
@@ -970,7 +970,7 @@ func TestValidatorsProvider_GetAuctionList(t *testing.T) {
 				TotalTopUp:     "7500",
 				TopUpPerNode:   "2500",
 				QualifiedTopUp: "2500",
-				AuctionList: []*common.AuctionNode{
+				Nodes: []*common.AuctionNode{
 					{
 						BlsKey:    args.ValidatorPubKeyConverter.SilentEncode(v1.PublicKey, log),
 						Qualified: true,
@@ -987,7 +987,7 @@ func TestValidatorsProvider_GetAuctionList(t *testing.T) {
 				TotalTopUp:     "3000",
 				TopUpPerNode:   "1000",
 				QualifiedTopUp: "1500",
-				AuctionList: []*common.AuctionNode{
+				Nodes: []*common.AuctionNode{
 					{
 						BlsKey:    args.ValidatorPubKeyConverter.SilentEncode(v3.PublicKey, log),
 						Qualified: true,
@@ -1004,7 +1004,7 @@ func TestValidatorsProvider_GetAuctionList(t *testing.T) {
 				TotalTopUp:     "0",
 				TopUpPerNode:   "0",
 				QualifiedTopUp: "0",
-				AuctionList: []*common.AuctionNode{
+				Nodes: []*common.AuctionNode{
 					{
 						BlsKey:    args.ValidatorPubKeyConverter.SilentEncode(v12.PublicKey, log),
 						Qualified: true,
@@ -1017,7 +1017,7 @@ func TestValidatorsProvider_GetAuctionList(t *testing.T) {
 				TotalTopUp:     "0",
 				TopUpPerNode:   "0",
 				QualifiedTopUp: "0",
-				AuctionList: []*common.AuctionNode{
+				Nodes: []*common.AuctionNode{
 					{
 						BlsKey:    args.ValidatorPubKeyConverter.SilentEncode(v11.PublicKey, log),
 						Qualified: false,
@@ -1030,7 +1030,7 @@ func TestValidatorsProvider_GetAuctionList(t *testing.T) {
 				TotalTopUp:     "0",
 				TopUpPerNode:   "0",
 				QualifiedTopUp: "0",
-				AuctionList: []*common.AuctionNode{
+				Nodes: []*common.AuctionNode{
 					{
 						BlsKey:    args.ValidatorPubKeyConverter.SilentEncode(v7.PublicKey, log),
 						Qualified: false,


### PR DESCRIPTION
## Reasoning behind the pull request
- Renamed auction list api response for auction nodes to nodes in order to avoid redundant naming