### PR TITLE
Process proxy fix

### DIFF
--- a/process/smartContract/processProxy/processProxy.go
+++ b/process/smartContract/processProxy/processProxy.go
@@ -169,11 +169,11 @@ func (proxy *scProcessorProxy) IsInterfaceNil() bool {
 }
 
 // EpochConfirmed is called whenever a new epoch is confirmed
-func (proxy *scProcessorProxy) EpochConfirmed(_ uint32, _ uint64) {
+func (proxy *scProcessorProxy) EpochConfirmed(epoch uint32, _ uint64) {
 	proxy.mutRc.Lock()
 	defer proxy.mutRc.Unlock()
 
-	if proxy.args.EnableEpochsHandler.IsFlagEnabled(common.SCProcessorV2Flag) {
+	if proxy.args.EnableEpochsHandler.IsFlagEnabledInEpoch(common.SCProcessorV2Flag, epoch) {
 		proxy.setActiveProcessorV2()
 		return
 	}

--- a/process/smartContract/processProxy/processProxy_test.go
+++ b/process/smartContract/processProxy/processProxy_test.go
@@ -129,7 +129,11 @@ func TestNewSmartContractProcessorProxy(t *testing.T) {
 		t.Parallel()
 
 		args := createMockSmartContractProcessorArguments()
-		args.EnableEpochsHandler = enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.SCProcessorV2Flag)
+		args.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+				return flag == common.SCProcessorV2Flag
+			},
+		}
 
 		proxy, err := NewSmartContractProcessorProxy(args, &epochNotifierMock.EpochNotifierStub{})
 		assert.False(t, check.IfNil(proxy))

--- a/process/smartContract/processProxy/testProcessProxy.go
+++ b/process/smartContract/processProxy/testProcessProxy.go
@@ -145,11 +145,11 @@ func (proxy *scProcessorTestProxy) IsInterfaceNil() bool {
 }
 
 // EpochConfirmed is called whenever a new epoch is confirmed
-func (proxy *scProcessorTestProxy) EpochConfirmed(_ uint32, _ uint64) {
+func (proxy *scProcessorTestProxy) EpochConfirmed(epoch uint32, _ uint64) {
 	proxy.mutRc.Lock()
 	defer proxy.mutRc.Unlock()
 
-	if proxy.args.EnableEpochsHandler.IsFlagEnabled(common.SCProcessorV2Flag) {
+	if proxy.args.EnableEpochsHandler.IsFlagEnabledInEpoch(common.SCProcessorV2Flag, epoch) {
 		proxy.setActiveProcessorV2()
 		return
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- using IsFlagEnabled could lead to an edge case where EpochConfirmed from enableEpochsHandler is called after processProxy's one
  
## Proposed changes
- replaced with IsFlagEnabledInEpoch

## Testing procedure
- standard system test + import-db, will be run on feat branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
