### PR TITLE
Deep VM queries: deep-history observer vs. regular observer

### DIFF
--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -632,7 +632,8 @@ func applyCompatibleConfigs(log logger.Logger, configs *config.Configs) error {
 
 	isInHistoricalBalancesMode := operationmodes.SliceContainsElement(operationModes, operationmodes.OperationModeHistoricalBalances)
 	if isInHistoricalBalancesMode {
-		processHistoricalBalancesMode(log, configs)
+		// TODO move all operation modes settings in the common/operationmodes package and add tests
+		operationmodes.ProcessHistoricalBalancesMode(log, configs)
 	}
 
 	isInDbLookupExtensionMode := operationmodes.SliceContainsElement(operationModes, operationmodes.OperationModeDbLookupExtension)
@@ -646,28 +647,6 @@ func applyCompatibleConfigs(log logger.Logger, configs *config.Configs) error {
 	}
 
 	return nil
-}
-
-func processHistoricalBalancesMode(log logger.Logger, configs *config.Configs) {
-	configs.GeneralConfig.StoragePruning.Enabled = true
-	configs.GeneralConfig.StoragePruning.ValidatorCleanOldEpochsData = false
-	configs.GeneralConfig.StoragePruning.ObserverCleanOldEpochsData = false
-	configs.GeneralConfig.GeneralSettings.StartInEpochEnabled = false
-	configs.GeneralConfig.StoragePruning.AccountsTrieCleanOldEpochsData = false
-	configs.GeneralConfig.StateTriesConfig.AccountsStatePruningEnabled = false
-	configs.GeneralConfig.DbLookupExtensions.Enabled = true
-	configs.PreferencesConfig.Preferences.FullArchive = true
-
-	log.Warn("the node is in historical balances mode! Will auto-set some config values",
-		"StoragePruning.Enabled", configs.GeneralConfig.StoragePruning.Enabled,
-		"StoragePruning.ValidatorCleanOldEpochsData", configs.GeneralConfig.StoragePruning.ValidatorCleanOldEpochsData,
-		"StoragePruning.ObserverCleanOldEpochsData", configs.GeneralConfig.StoragePruning.ObserverCleanOldEpochsData,
-		"StoragePruning.AccountsTrieCleanOldEpochsData", configs.GeneralConfig.StoragePruning.AccountsTrieCleanOldEpochsData,
-		"GeneralSettings.StartInEpochEnabled", configs.GeneralConfig.GeneralSettings.StartInEpochEnabled,
-		"StateTriesConfig.AccountsStatePruningEnabled", configs.GeneralConfig.StateTriesConfig.AccountsStatePruningEnabled,
-		"DbLookupExtensions.Enabled", configs.GeneralConfig.DbLookupExtensions.Enabled,
-		"Preferences.FullArchive", configs.PreferencesConfig.Preferences.FullArchive,
-	)
 }
 
 func processDbLookupExtensionMode(log logger.Logger, configs *config.Configs) {

--- a/common/operationmodes/historicalBalances.go
+++ b/common/operationmodes/historicalBalances.go
@@ -1,0 +1,41 @@
+package operationmodes
+
+import (
+	"github.com/multiversx/mx-chain-go/config"
+	logger "github.com/multiversx/mx-chain-logger-go"
+)
+
+// ProcessHistoricalBalancesMode will process the provided flags for the historical balances
+func ProcessHistoricalBalancesMode(log logger.Logger, configs *config.Configs) {
+	configs.GeneralConfig.StoragePruning.Enabled = true
+	configs.GeneralConfig.StoragePruning.ValidatorCleanOldEpochsData = false
+	configs.GeneralConfig.StoragePruning.ObserverCleanOldEpochsData = false
+	configs.GeneralConfig.GeneralSettings.StartInEpochEnabled = false
+	configs.GeneralConfig.StoragePruning.AccountsTrieCleanOldEpochsData = false
+	configs.GeneralConfig.StateTriesConfig.AccountsStatePruningEnabled = false
+	configs.GeneralConfig.DbLookupExtensions.Enabled = true
+	configs.PreferencesConfig.Preferences.FullArchive = true
+
+	log.Warn("the node is in historical balances mode! Will auto-set some config values",
+		"StoragePruning.Enabled", configs.GeneralConfig.StoragePruning.Enabled,
+		"StoragePruning.ValidatorCleanOldEpochsData", configs.GeneralConfig.StoragePruning.ValidatorCleanOldEpochsData,
+		"StoragePruning.ObserverCleanOldEpochsData", configs.GeneralConfig.StoragePruning.ObserverCleanOldEpochsData,
+		"StoragePruning.AccountsTrieCleanOldEpochsData", configs.GeneralConfig.StoragePruning.AccountsTrieCleanOldEpochsData,
+		"GeneralSettings.StartInEpochEnabled", configs.GeneralConfig.GeneralSettings.StartInEpochEnabled,
+		"StateTriesConfig.AccountsStatePruningEnabled", configs.GeneralConfig.StateTriesConfig.AccountsStatePruningEnabled,
+		"DbLookupExtensions.Enabled", configs.GeneralConfig.DbLookupExtensions.Enabled,
+		"Preferences.FullArchive", configs.PreferencesConfig.Preferences.FullArchive,
+	)
+}
+
+// IsInHistoricalBalancesMode returns true if the configuration provided denotes a historical balances mode
+func IsInHistoricalBalancesMode(configs *config.Configs) bool {
+	return configs.GeneralConfig.StoragePruning.Enabled &&
+		!configs.GeneralConfig.StoragePruning.ValidatorCleanOldEpochsData &&
+		!configs.GeneralConfig.StoragePruning.ObserverCleanOldEpochsData &&
+		!configs.GeneralConfig.GeneralSettings.StartInEpochEnabled &&
+		!configs.GeneralConfig.StoragePruning.AccountsTrieCleanOldEpochsData &&
+		!configs.GeneralConfig.StateTriesConfig.AccountsStatePruningEnabled &&
+		configs.GeneralConfig.DbLookupExtensions.Enabled &&
+		configs.PreferencesConfig.Preferences.FullArchive
+}

--- a/common/operationmodes/historicalBalances_test.go
+++ b/common/operationmodes/historicalBalances_test.go
@@ -1,0 +1,141 @@
+package operationmodes
+
+import (
+	"testing"
+
+	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessHistoricalBalancesMode(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Configs{
+		GeneralConfig:     &config.Config{},
+		PreferencesConfig: &config.Preferences{},
+	}
+	ProcessHistoricalBalancesMode(&testscommon.LoggerStub{}, cfg)
+
+	assert.True(t, cfg.GeneralConfig.StoragePruning.Enabled)
+	assert.False(t, cfg.GeneralConfig.StoragePruning.ValidatorCleanOldEpochsData)
+	assert.False(t, cfg.GeneralConfig.StoragePruning.ObserverCleanOldEpochsData)
+	assert.False(t, cfg.GeneralConfig.GeneralSettings.StartInEpochEnabled)
+	assert.False(t, cfg.GeneralConfig.StoragePruning.AccountsTrieCleanOldEpochsData)
+	assert.False(t, cfg.GeneralConfig.StateTriesConfig.AccountsStatePruningEnabled)
+	assert.True(t, cfg.GeneralConfig.DbLookupExtensions.Enabled)
+	assert.True(t, cfg.PreferencesConfig.Preferences.FullArchive)
+}
+
+func TestIsInHistoricalBalancesMode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty configs should return false", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Configs{
+			GeneralConfig:     &config.Config{},
+			PreferencesConfig: &config.Preferences{},
+		}
+		assert.False(t, IsInHistoricalBalancesMode(cfg))
+	})
+	t.Run("storage pruning disabled should return false", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Configs{
+			GeneralConfig:     &config.Config{},
+			PreferencesConfig: &config.Preferences{},
+		}
+		ProcessHistoricalBalancesMode(&testscommon.LoggerStub{}, cfg)
+		cfg.GeneralConfig.StoragePruning.Enabled = false
+		assert.False(t, IsInHistoricalBalancesMode(cfg))
+	})
+	t.Run("validator clean old epoch data enabled should return false", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Configs{
+			GeneralConfig:     &config.Config{},
+			PreferencesConfig: &config.Preferences{},
+		}
+		ProcessHistoricalBalancesMode(&testscommon.LoggerStub{}, cfg)
+		cfg.GeneralConfig.StoragePruning.ValidatorCleanOldEpochsData = true
+		assert.False(t, IsInHistoricalBalancesMode(cfg))
+	})
+	t.Run("observer clean old epoch data enabled should return false", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Configs{
+			GeneralConfig:     &config.Config{},
+			PreferencesConfig: &config.Preferences{},
+		}
+		ProcessHistoricalBalancesMode(&testscommon.LoggerStub{}, cfg)
+		cfg.GeneralConfig.StoragePruning.ObserverCleanOldEpochsData = true
+		assert.False(t, IsInHistoricalBalancesMode(cfg))
+	})
+	t.Run("start in epoch enabled should return false", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Configs{
+			GeneralConfig:     &config.Config{},
+			PreferencesConfig: &config.Preferences{},
+		}
+		ProcessHistoricalBalancesMode(&testscommon.LoggerStub{}, cfg)
+		cfg.GeneralConfig.GeneralSettings.StartInEpochEnabled = true
+		assert.False(t, IsInHistoricalBalancesMode(cfg))
+	})
+	t.Run("accounts trie clean old epoch data enabled should return false", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Configs{
+			GeneralConfig:     &config.Config{},
+			PreferencesConfig: &config.Preferences{},
+		}
+		ProcessHistoricalBalancesMode(&testscommon.LoggerStub{}, cfg)
+		cfg.GeneralConfig.StoragePruning.AccountsTrieCleanOldEpochsData = true
+		assert.False(t, IsInHistoricalBalancesMode(cfg))
+	})
+	t.Run("accounts state pruning enabled should return false", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Configs{
+			GeneralConfig:     &config.Config{},
+			PreferencesConfig: &config.Preferences{},
+		}
+		ProcessHistoricalBalancesMode(&testscommon.LoggerStub{}, cfg)
+		cfg.GeneralConfig.StateTriesConfig.AccountsStatePruningEnabled = true
+		assert.False(t, IsInHistoricalBalancesMode(cfg))
+	})
+	t.Run("db lookup extension disabled should return false", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Configs{
+			GeneralConfig:     &config.Config{},
+			PreferencesConfig: &config.Preferences{},
+		}
+		ProcessHistoricalBalancesMode(&testscommon.LoggerStub{}, cfg)
+		cfg.GeneralConfig.DbLookupExtensions.Enabled = false
+		assert.False(t, IsInHistoricalBalancesMode(cfg))
+	})
+	t.Run("not a full archive node should return false", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Configs{
+			GeneralConfig:     &config.Config{},
+			PreferencesConfig: &config.Preferences{},
+		}
+		ProcessHistoricalBalancesMode(&testscommon.LoggerStub{}, cfg)
+		cfg.PreferencesConfig.Preferences.FullArchive = false
+		assert.False(t, IsInHistoricalBalancesMode(cfg))
+	})
+	t.Run("with historical balances config should return true", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Configs{
+			GeneralConfig:     &config.Config{},
+			PreferencesConfig: &config.Preferences{},
+		}
+		ProcessHistoricalBalancesMode(&testscommon.LoggerStub{}, cfg)
+		assert.True(t, IsInHistoricalBalancesMode(cfg))
+	})
+
+}

--- a/common/operationmodes/operationmodes.go
+++ b/common/operationmodes/operationmodes.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 )
 
+// constants that define the operation mode of the node
 const (
 	OperationModeFullArchive          = "full-archive"
 	OperationModeDbLookupExtension    = "db-lookup-extension"

--- a/factory/api/apiResolverFactory.go
+++ b/factory/api/apiResolverFactory.go
@@ -461,6 +461,7 @@ func createScQueryElement(
 		Marshaller:               args.coreComponents.InternalMarshalizer(),
 		Hasher:                   args.coreComponents.Hasher(),
 		Uint64ByteSliceConverter: args.coreComponents.Uint64ByteSliceConverter(),
+		IsInSnapshottingMode:     args.generalConfig.StateTriesConfig.SnapshotsEnabled,
 	}
 
 	return smartContract.NewSCQueryService(argsNewSCQueryService)

--- a/factory/api/apiResolverFactory.go
+++ b/factory/api/apiResolverFactory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/disabled"
+	"github.com/multiversx/mx-chain-go/common/operationmodes"
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/dataRetriever/blockchain"
@@ -71,40 +72,42 @@ type ApiResolverArgs struct {
 }
 
 type scQueryServiceArgs struct {
-	generalConfig         *config.Config
-	epochConfig           *config.EpochConfig
-	coreComponents        factory.CoreComponentsHolder
-	stateComponents       factory.StateComponentsHolder
-	dataComponents        factory.DataComponentsHolder
-	processComponents     factory.ProcessComponentsHolder
-	statusCoreComponents  factory.StatusCoreComponentsHolder
-	gasScheduleNotifier   core.GasScheduleNotifier
-	messageSigVerifier    vm.MessageSignVerifier
-	systemSCConfig        *config.SystemSmartContractsConfig
-	bootstrapper          process.Bootstrapper
-	guardedAccountHandler process.GuardedAccountHandler
-	allowVMQueriesChan    chan struct{}
-	workingDir            string
-	processingMode        common.NodeProcessingMode
+	generalConfig              *config.Config
+	epochConfig                *config.EpochConfig
+	coreComponents             factory.CoreComponentsHolder
+	stateComponents            factory.StateComponentsHolder
+	dataComponents             factory.DataComponentsHolder
+	processComponents          factory.ProcessComponentsHolder
+	statusCoreComponents       factory.StatusCoreComponentsHolder
+	gasScheduleNotifier        core.GasScheduleNotifier
+	messageSigVerifier         vm.MessageSignVerifier
+	systemSCConfig             *config.SystemSmartContractsConfig
+	bootstrapper               process.Bootstrapper
+	guardedAccountHandler      process.GuardedAccountHandler
+	allowVMQueriesChan         chan struct{}
+	workingDir                 string
+	processingMode             common.NodeProcessingMode
+	isInHistoricalBalancesMode bool
 }
 
 type scQueryElementArgs struct {
-	generalConfig         *config.Config
-	epochConfig           *config.EpochConfig
-	coreComponents        factory.CoreComponentsHolder
-	stateComponents       factory.StateComponentsHolder
-	dataComponents        factory.DataComponentsHolder
-	processComponents     factory.ProcessComponentsHolder
-	statusCoreComponents  factory.StatusCoreComponentsHolder
-	gasScheduleNotifier   core.GasScheduleNotifier
-	messageSigVerifier    vm.MessageSignVerifier
-	systemSCConfig        *config.SystemSmartContractsConfig
-	bootstrapper          process.Bootstrapper
-	guardedAccountHandler process.GuardedAccountHandler
-	allowVMQueriesChan    chan struct{}
-	workingDir            string
-	index                 int
-	processingMode        common.NodeProcessingMode
+	generalConfig              *config.Config
+	epochConfig                *config.EpochConfig
+	coreComponents             factory.CoreComponentsHolder
+	stateComponents            factory.StateComponentsHolder
+	dataComponents             factory.DataComponentsHolder
+	processComponents          factory.ProcessComponentsHolder
+	statusCoreComponents       factory.StatusCoreComponentsHolder
+	gasScheduleNotifier        core.GasScheduleNotifier
+	messageSigVerifier         vm.MessageSignVerifier
+	systemSCConfig             *config.SystemSmartContractsConfig
+	bootstrapper               process.Bootstrapper
+	guardedAccountHandler      process.GuardedAccountHandler
+	allowVMQueriesChan         chan struct{}
+	workingDir                 string
+	index                      int
+	processingMode             common.NodeProcessingMode
+	isInHistoricalBalancesMode bool
 }
 
 // CreateApiResolver is able to create an ApiResolver instance that will solve the REST API requests through the node facade
@@ -112,21 +115,22 @@ type scQueryElementArgs struct {
 func CreateApiResolver(args *ApiResolverArgs) (facade.ApiResolver, error) {
 	apiWorkingDir := filepath.Join(args.Configs.FlagsConfig.WorkingDir, common.TemporaryPath)
 	argsSCQuery := &scQueryServiceArgs{
-		generalConfig:         args.Configs.GeneralConfig,
-		epochConfig:           args.Configs.EpochConfig,
-		coreComponents:        args.CoreComponents,
-		dataComponents:        args.DataComponents,
-		stateComponents:       args.StateComponents,
-		processComponents:     args.ProcessComponents,
-		statusCoreComponents:  args.StatusCoreComponents,
-		gasScheduleNotifier:   args.GasScheduleNotifier,
-		messageSigVerifier:    args.CryptoComponents.MessageSignVerifier(),
-		systemSCConfig:        args.Configs.SystemSCConfig,
-		bootstrapper:          args.Bootstrapper,
-		guardedAccountHandler: args.BootstrapComponents.GuardedAccountHandler(),
-		allowVMQueriesChan:    args.AllowVMQueriesChan,
-		workingDir:            apiWorkingDir,
-		processingMode:        args.ProcessingMode,
+		generalConfig:              args.Configs.GeneralConfig,
+		epochConfig:                args.Configs.EpochConfig,
+		coreComponents:             args.CoreComponents,
+		dataComponents:             args.DataComponents,
+		stateComponents:            args.StateComponents,
+		processComponents:          args.ProcessComponents,
+		statusCoreComponents:       args.StatusCoreComponents,
+		gasScheduleNotifier:        args.GasScheduleNotifier,
+		messageSigVerifier:         args.CryptoComponents.MessageSignVerifier(),
+		systemSCConfig:             args.Configs.SystemSCConfig,
+		bootstrapper:               args.Bootstrapper,
+		guardedAccountHandler:      args.BootstrapComponents.GuardedAccountHandler(),
+		allowVMQueriesChan:         args.AllowVMQueriesChan,
+		workingDir:                 apiWorkingDir,
+		processingMode:             args.ProcessingMode,
+		isInHistoricalBalancesMode: operationmodes.IsInHistoricalBalancesMode(args.Configs),
 	}
 
 	scQueryService, err := createScQueryService(argsSCQuery)
@@ -299,22 +303,23 @@ func createScQueryService(
 	}
 
 	argsQueryElem := &scQueryElementArgs{
-		generalConfig:         args.generalConfig,
-		epochConfig:           args.epochConfig,
-		coreComponents:        args.coreComponents,
-		stateComponents:       args.stateComponents,
-		dataComponents:        args.dataComponents,
-		processComponents:     args.processComponents,
-		statusCoreComponents:  args.statusCoreComponents,
-		gasScheduleNotifier:   args.gasScheduleNotifier,
-		messageSigVerifier:    args.messageSigVerifier,
-		systemSCConfig:        args.systemSCConfig,
-		bootstrapper:          args.bootstrapper,
-		guardedAccountHandler: args.guardedAccountHandler,
-		allowVMQueriesChan:    args.allowVMQueriesChan,
-		workingDir:            args.workingDir,
-		index:                 0,
-		processingMode:        args.processingMode,
+		generalConfig:              args.generalConfig,
+		epochConfig:                args.epochConfig,
+		coreComponents:             args.coreComponents,
+		stateComponents:            args.stateComponents,
+		dataComponents:             args.dataComponents,
+		processComponents:          args.processComponents,
+		statusCoreComponents:       args.statusCoreComponents,
+		gasScheduleNotifier:        args.gasScheduleNotifier,
+		messageSigVerifier:         args.messageSigVerifier,
+		systemSCConfig:             args.systemSCConfig,
+		bootstrapper:               args.bootstrapper,
+		guardedAccountHandler:      args.guardedAccountHandler,
+		allowVMQueriesChan:         args.allowVMQueriesChan,
+		workingDir:                 args.workingDir,
+		index:                      0,
+		processingMode:             args.processingMode,
+		isInHistoricalBalancesMode: args.isInHistoricalBalancesMode,
 	}
 
 	var err error
@@ -446,22 +451,22 @@ func createScQueryElement(
 	}
 
 	argsNewSCQueryService := smartContract.ArgsNewSCQueryService{
-		VmContainer:              vmContainer,
-		EconomicsFee:             args.coreComponents.EconomicsData(),
-		BlockChainHook:           vmFactory.BlockChainHookImpl(),
-		MainBlockChain:           args.dataComponents.Blockchain(),
-		APIBlockChain:            apiBlockchain,
-		WasmVMChangeLocker:       args.coreComponents.WasmVMChangeLocker(),
-		Bootstrapper:             args.bootstrapper,
-		AllowExternalQueriesChan: args.allowVMQueriesChan,
-		MaxGasLimitPerQuery:      maxGasForVmQueries,
-		HistoryRepository:        args.processComponents.HistoryRepository(),
-		ShardCoordinator:         args.processComponents.ShardCoordinator(),
-		StorageService:           args.dataComponents.StorageService(),
-		Marshaller:               args.coreComponents.InternalMarshalizer(),
-		Hasher:                   args.coreComponents.Hasher(),
-		Uint64ByteSliceConverter: args.coreComponents.Uint64ByteSliceConverter(),
-		IsInSnapshottingMode:     args.generalConfig.StateTriesConfig.SnapshotsEnabled,
+		VmContainer:                vmContainer,
+		EconomicsFee:               args.coreComponents.EconomicsData(),
+		BlockChainHook:             vmFactory.BlockChainHookImpl(),
+		MainBlockChain:             args.dataComponents.Blockchain(),
+		APIBlockChain:              apiBlockchain,
+		WasmVMChangeLocker:         args.coreComponents.WasmVMChangeLocker(),
+		Bootstrapper:               args.bootstrapper,
+		AllowExternalQueriesChan:   args.allowVMQueriesChan,
+		MaxGasLimitPerQuery:        maxGasForVmQueries,
+		HistoryRepository:          args.processComponents.HistoryRepository(),
+		ShardCoordinator:           args.processComponents.ShardCoordinator(),
+		StorageService:             args.dataComponents.StorageService(),
+		Marshaller:                 args.coreComponents.InternalMarshalizer(),
+		Hasher:                     args.coreComponents.Hasher(),
+		Uint64ByteSliceConverter:   args.coreComponents.Uint64ByteSliceConverter(),
+		IsInHistoricalBalancesMode: args.isInHistoricalBalancesMode,
 	}
 
 	return smartContract.NewSCQueryService(argsNewSCQueryService)

--- a/process/smartContract/scQueryService.go
+++ b/process/smartContract/scQueryService.go
@@ -266,6 +266,7 @@ func (service *SCQueryService) recreateTrie(blockRootHash []byte, blockHeader da
 		}
 
 		service.rememberQueriedEpoch(blockHeader.GetEpoch())
+		return nil
 	}
 
 	logQueryService.Trace("calling RecreateTrieFromEpoch, for older history", "block", blockHeader.GetNonce(), "rootHash", blockRootHash)
@@ -277,7 +278,7 @@ func (service *SCQueryService) recreateTrie(blockRootHash []byte, blockHeader da
 	}
 
 	service.rememberQueriedEpoch(blockHeader.GetEpoch())
-	return err
+	return nil
 }
 
 func (service *SCQueryService) isLatestQueriedEpoch(epoch uint32) bool {

--- a/process/smartContract/scQueryService.go
+++ b/process/smartContract/scQueryService.go
@@ -53,6 +53,7 @@ type SCQueryService struct {
 	hasher                   hashing.Hasher
 	uint64ByteSliceConverter typeConverters.Uint64ByteSliceConverter
 	latestQueriedEpoch       core.OptionalUint32
+	isInSnapshottingMode     bool
 }
 
 // ArgsNewSCQueryService defines the arguments needed for the sc query service
@@ -72,6 +73,7 @@ type ArgsNewSCQueryService struct {
 	Marshaller               marshal.Marshalizer
 	Hasher                   hashing.Hasher
 	Uint64ByteSliceConverter typeConverters.Uint64ByteSliceConverter
+	IsInSnapshottingMode     bool
 }
 
 // NewSCQueryService returns a new instance of SCQueryService
@@ -104,6 +106,7 @@ func NewSCQueryService(
 		hasher:                   args.Hasher,
 		uint64ByteSliceConverter: args.Uint64ByteSliceConverter,
 		latestQueriedEpoch:       core.OptionalUint32{},
+		isInSnapshottingMode:     args.IsInSnapshottingMode,
 	}, nil
 }
 
@@ -282,15 +285,12 @@ func (service *SCQueryService) recreateTrie(blockRootHash []byte, blockHeader da
 }
 
 func (service *SCQueryService) shouldCallRecreateTrieWithoutEpoch(epochInQuestion uint32) bool {
-	if service.latestQueriedEpoch.HasValue && service.latestQueriedEpoch.Value == epochInQuestion {
+	if !service.isInSnapshottingMode {
+		// for snapshotless operation, we need to force this method to return true so the RecreateTrie will be called instead of RecreateTrieFromEpoch
 		return true
 	}
 
-	if !service.latestQueriedEpoch.HasValue && epochInQuestion == service.getCurrentEpoch() {
-		return true
-	}
-
-	return false
+	return service.latestQueriedEpoch.HasValue && service.latestQueriedEpoch.Value == epochInQuestion
 }
 
 func (service *SCQueryService) rememberQueriedEpoch(epoch uint32) {


### PR DESCRIPTION
## Reasoning behind the pull request
- In some cases, deep VM queries against old epochs caused subsequent VM queries on recent blocks to fail.

```
print("Causing the issue...")
do_contract_query(recent_block - 6 * 14400)
do_contract_query(recent_block - 5 * 14400)
do_contract_query(recent_block - 4 * 14400)
print("This will fail")
do_contract_query(recent_block)

print("Repairing the issue...")
do_contract_query(recent_block - 3 * 14400)

print("Now it will work")
do_contract_query(recent_block)
```
  
## Proposed changes
If observer is started in **deep-history mode**, perform deep VM queries, using `recreateTrieFromEpoch`. Otherwise, rely on `recreateTrie`. Most important work is done by https://github.com/multiversx/mx-chain-go/pull/6008.

## Testing procedure
- Regular testing
- VM queries stressing (default)
- VM queries against both old and new blocks (not only sequential queries, but also random access queries)

Log level: `*:DEBUG,process/smartcontract.queryService:TRACE`.

Inspect logs: `calling RecreateTrie|calling RecreateTrieFromEpoch`.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
