### PR TITLE
Added missing fields on the transaction/pool by-sender request

### DIFF
--- a/api/groups/transactionGroup.go
+++ b/api/groups/transactionGroup.go
@@ -745,6 +745,10 @@ func validateQuery(sender, fields string, lastNonce, nonceGaps bool) error {
 		return errors.ErrEmptySenderToGetNonceGaps
 	}
 
+	if fields == "*" {
+		return nil
+	}
+
 	if fields != "" {
 		return validateFields(fields)
 	}

--- a/api/groups/transactionGroup_test.go
+++ b/api/groups/transactionGroup_test.go
@@ -704,6 +704,7 @@ func TestTransactionGroup_getTransactionsPool(t *testing.T) {
 	t.Run("fields + nonce gaps", testTxPoolWithInvalidQuery("?fields=sender,receiver&nonce-gaps=true", apiErrors.ErrFetchingNonceGapsCannotIncludeFields))
 	t.Run("fields has spaces", testTxPoolWithInvalidQuery("?fields=sender ,receiver", apiErrors.ErrInvalidFields))
 	t.Run("fields has numbers", testTxPoolWithInvalidQuery("?fields=sender1", apiErrors.ErrInvalidFields))
+	t.Run("fields + wild card", testTxPoolWithInvalidQuery("?fields=sender,receiver,*", apiErrors.ErrInvalidFields))
 	t.Run("GetTransactionsPool error should error", func(t *testing.T) {
 		t.Parallel()
 
@@ -816,8 +817,7 @@ func TestTransactionGroup_getTransactionsPool(t *testing.T) {
 		t.Parallel()
 
 		expectedSender := "sender"
-		providedFields := "sender,receiver"
-		query := "?by-sender=" + expectedSender + "&fields=" + providedFields
+		query := "?by-sender=" + expectedSender + "&fields=*"
 		expectedResp := &common.TransactionsPoolForSenderApiResponse{
 			Transactions: []common.Transaction{
 				{

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	rewardTxData "github.com/multiversx/mx-chain-core-go/data/rewardTx"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
@@ -319,11 +320,11 @@ func (atp *apiTransactionProcessor) extractRequestedTxInfo(wrappedTx *txcache.Wr
 	}
 
 	if requestedFieldsHandler.HasSender {
-		tx.TxFields[senderField], _ = atp.addressPubKeyConverter.Encode(wrappedTx.Tx.GetSndAddr())
+		tx.TxFields[senderField] = atp.addressPubKeyConverter.SilentEncode(wrappedTx.Tx.GetSndAddr(), log)
 	}
 
 	if requestedFieldsHandler.HasReceiver {
-		tx.TxFields[receiverField], _ = atp.addressPubKeyConverter.Encode(wrappedTx.Tx.GetRcvAddr())
+		tx.TxFields[receiverField] = atp.addressPubKeyConverter.SilentEncode(wrappedTx.Tx.GetRcvAddr(), log)
 	}
 
 	if requestedFieldsHandler.HasGasLimit {
@@ -340,6 +341,12 @@ func (atp *apiTransactionProcessor) extractRequestedTxInfo(wrappedTx *txcache.Wr
 	}
 	if requestedFieldsHandler.HasValue {
 		tx.TxFields[valueField] = getTxValue(wrappedTx)
+	}
+	if requestedFieldsHandler.HasGuardian {
+		guardedTx, isGuardedTx := wrappedTx.Tx.(data.GuardedTransactionHandler)
+		if isGuardedTx {
+			tx.TxFields[guardianField] = atp.addressPubKeyConverter.SilentEncode(guardedTx.GetGuardianAddr(), log)
+		}
 	}
 
 	return tx

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -314,35 +314,35 @@ func (atp *apiTransactionProcessor) extractRequestedTxInfo(wrappedTx *txcache.Wr
 		TxFields: make(map[string]interface{}),
 	}
 
-	for field, getter := range fieldGetters {
+	for field, value := range fieldGetters {
 		if requestedFieldsHandler.IsFieldSet(field) {
-			tx.TxFields[field] = getter()
+			tx.TxFields[field] = value
 		}
 	}
 
 	return tx
 }
 
-func (atp *apiTransactionProcessor) getFieldGettersForTx(wrappedTx *txcache.WrappedTransaction) map[string]func() interface{} {
-	var fieldGetters = map[string]func() interface{}{
-		hashField:        func() interface{} { return hex.EncodeToString(wrappedTx.TxHash) },
-		nonceField:       func() interface{} { return wrappedTx.Tx.GetNonce() },
-		senderField:      func() interface{} { return atp.addressPubKeyConverter.SilentEncode(wrappedTx.Tx.GetSndAddr(), log) },
-		receiverField:    func() interface{} { return atp.addressPubKeyConverter.SilentEncode(wrappedTx.Tx.GetRcvAddr(), log) },
-		gasLimitField:    func() interface{} { return wrappedTx.Tx.GetGasLimit() },
-		gasPriceField:    func() interface{} { return wrappedTx.Tx.GetGasPrice() },
-		rcvUsernameField: func() interface{} { return wrappedTx.Tx.GetRcvUserName() },
-		dataField:        func() interface{} { return wrappedTx.Tx.GetData() },
-		valueField:       func() interface{} { return getTxValue(wrappedTx) },
-		senderShardID:    func() interface{} { return wrappedTx.SenderShardID },
-		receiverShardID:  func() interface{} { return wrappedTx.ReceiverShardID },
+func (atp *apiTransactionProcessor) getFieldGettersForTx(wrappedTx *txcache.WrappedTransaction) map[string]interface{} {
+	var fieldGetters = map[string]interface{}{
+		hashField:        hex.EncodeToString(wrappedTx.TxHash),
+		nonceField:       wrappedTx.Tx.GetNonce(),
+		senderField:      atp.addressPubKeyConverter.SilentEncode(wrappedTx.Tx.GetSndAddr(), log),
+		receiverField:    atp.addressPubKeyConverter.SilentEncode(wrappedTx.Tx.GetRcvAddr(), log),
+		gasLimitField:    wrappedTx.Tx.GetGasLimit(),
+		gasPriceField:    wrappedTx.Tx.GetGasPrice(),
+		rcvUsernameField: wrappedTx.Tx.GetRcvUserName(),
+		dataField:        wrappedTx.Tx.GetData(),
+		valueField:       getTxValue(wrappedTx),
+		senderShardID:    wrappedTx.SenderShardID,
+		receiverShardID:  wrappedTx.ReceiverShardID,
 	}
 
 	guardedTx, isGuardedTx := wrappedTx.Tx.(data.GuardedTransactionHandler)
 	if isGuardedTx {
-		fieldGetters[signatureField] = func() interface{} { return hex.EncodeToString(guardedTx.GetSignature()) }
-		fieldGetters[guardianField] = func() interface{} { return atp.addressPubKeyConverter.SilentEncode(guardedTx.GetGuardianAddr(), log) }
-		fieldGetters[guardianSignatureField] = func() interface{} { return hex.EncodeToString(guardedTx.GetGuardianSignature()) }
+		fieldGetters[signatureField] = hex.EncodeToString(guardedTx.GetSignature())
+		fieldGetters[guardianField] = atp.addressPubKeyConverter.SilentEncode(guardedTx.GetGuardianAddr(), log)
+		fieldGetters[guardianSignatureField] = hex.EncodeToString(guardedTx.GetGuardianSignature())
 	}
 
 	return fieldGetters

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -330,22 +330,49 @@ func (atp *apiTransactionProcessor) extractRequestedTxInfo(wrappedTx *txcache.Wr
 	if requestedFieldsHandler.HasGasLimit {
 		tx.TxFields[gasLimitField] = wrappedTx.Tx.GetGasLimit()
 	}
+
 	if requestedFieldsHandler.HasGasPrice {
 		tx.TxFields[gasPriceField] = wrappedTx.Tx.GetGasPrice()
 	}
+
 	if requestedFieldsHandler.HasRcvUsername {
 		tx.TxFields[rcvUsernameField] = wrappedTx.Tx.GetRcvUserName()
 	}
+
 	if requestedFieldsHandler.HasData {
 		tx.TxFields[dataField] = wrappedTx.Tx.GetData()
 	}
+
 	if requestedFieldsHandler.HasValue {
 		tx.TxFields[valueField] = getTxValue(wrappedTx)
 	}
+
+	if requestedFieldsHandler.HasSenderShardID {
+		tx.TxFields[senderShardID] = wrappedTx.SenderShardID
+	}
+
+	if requestedFieldsHandler.HasReceiverShardID {
+		tx.TxFields[receiverShardID] = wrappedTx.ReceiverShardID
+	}
+
+	if requestedFieldsHandler.HasSignature {
+		castedTx, hasSignature := wrappedTx.Tx.(data.GuardedTransactionHandler)
+		if hasSignature {
+			tx.TxFields[signatureField] = hex.EncodeToString(castedTx.GetSignature())
+		}
+	}
+
 	if requestedFieldsHandler.HasGuardian {
 		guardedTx, isGuardedTx := wrappedTx.Tx.(data.GuardedTransactionHandler)
 		if isGuardedTx {
 			tx.TxFields[guardianField] = atp.addressPubKeyConverter.SilentEncode(guardedTx.GetGuardianAddr(), log)
+		}
+	}
+
+	if requestedFieldsHandler.HasGuardianSignature {
+		guardedTx, isGuardedTx := wrappedTx.Tx.(data.GuardedTransactionHandler)
+		if isGuardedTx {
+			tx.TxFields[guardianSignatureField] = hex.EncodeToString(guardedTx.GetGuardianSignature())
 		}
 	}
 

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -825,7 +825,7 @@ func TestApiTransactionProcessor_GetTransactionsPoolForSender(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, atp)
 
-	res, err := atp.GetTransactionsPoolForSender(sender, "sender,value")
+	res, err := atp.GetTransactionsPoolForSender(sender, "*")
 	require.NoError(t, err)
 	expectedHashes := []string{hex.EncodeToString(txHash0), hex.EncodeToString(txHash1), hex.EncodeToString(txHash2), hex.EncodeToString(txHash3), hex.EncodeToString(txHash4)}
 	expectedValues := []string{"100001", "100002", "100003", "100004", "100005"}

--- a/node/external/transactionAPI/fieldsHandler.go
+++ b/node/external/transactionAPI/fieldsHandler.go
@@ -25,49 +25,32 @@ const (
 )
 
 type fieldsHandler struct {
-	HasNonce             bool
-	HasSender            bool
-	HasReceiver          bool
-	HasGasLimit          bool
-	HasGasPrice          bool
-	HasRcvUsername       bool
-	HasData              bool
-	HasValue             bool
-	HasSignature         bool
-	HasSenderShardID     bool
-	HasReceiverShardID   bool
-	HasGuardian          bool
-	HasGuardianSignature bool
+	fieldsMap map[string]struct{}
 }
 
 func newFieldsHandler(parameters string) fieldsHandler {
-	parameters = strings.ToLower(parameters)
-	parametersMap := sliceToMap(strings.Split(parameters, separator))
-	ph := fieldsHandler{
-		HasNonce:             shouldConsiderField(parametersMap, nonceField),
-		HasSender:            shouldConsiderField(parametersMap, senderField),
-		HasReceiver:          shouldConsiderField(parametersMap, receiverField),
-		HasGasLimit:          shouldConsiderField(parametersMap, gasLimitField),
-		HasGasPrice:          shouldConsiderField(parametersMap, gasPriceField),
-		HasRcvUsername:       shouldConsiderField(parametersMap, rcvUsernameField),
-		HasData:              shouldConsiderField(parametersMap, dataField),
-		HasValue:             shouldConsiderField(parametersMap, valueField),
-		HasSignature:         shouldConsiderField(parametersMap, signatureField),
-		HasSenderShardID:     shouldConsiderField(parametersMap, senderShardID),
-		HasReceiverShardID:   shouldConsiderField(parametersMap, receiverShardID),
-		HasGuardian:          shouldConsiderField(parametersMap, guardianField),
-		HasGuardianSignature: shouldConsiderField(parametersMap, guardianSignatureField),
+	if len(parameters) == 0 {
+		return fieldsHandler{
+			fieldsMap: map[string]struct{}{
+				hashField: {}, // hash should always be returned
+			},
+		}
 	}
-	return ph
+
+	parameters = strings.ToLower(parameters)
+	return fieldsHandler{
+		fieldsMap: sliceToMap(strings.Split(parameters, separator)),
+	}
 }
 
-func shouldConsiderField(parametersMap map[string]struct{}, field string) bool {
-	_, hasWildCard := parametersMap[wildCard]
+// IsFieldSet returns true if the provided field is set
+func (handler *fieldsHandler) IsFieldSet(field string) bool {
+	_, hasWildCard := handler.fieldsMap[wildCard]
 	if hasWildCard {
 		return true
 	}
 
-	_, has := parametersMap[field]
+	_, has := handler.fieldsMap[strings.ToLower(field)]
 	return has
 }
 

--- a/node/external/transactionAPI/fieldsHandler.go
+++ b/node/external/transactionAPI/fieldsHandler.go
@@ -5,42 +5,74 @@ import (
 )
 
 const (
-	hashField        = "hash"
-	nonceField       = "nonce"
-	senderField      = "sender"
-	receiverField    = "receiver"
-	gasLimitField    = "gaslimit"
-	gasPriceField    = "gasprice"
-	rcvUsernameField = "receiverusername"
-	dataField        = "data"
-	valueField       = "value"
-	guardianField    = "guardian"
+	hashField              = "hash"
+	nonceField             = "nonce"
+	senderField            = "sender"
+	receiverField          = "receiver"
+	gasLimitField          = "gaslimit"
+	gasPriceField          = "gasprice"
+	rcvUsernameField       = "receiverusername"
+	dataField              = "data"
+	valueField             = "value"
+	signatureField         = "signature"
+	guardianField          = "guardian"
+	guardianSignatureField = "guardiansignature"
+	senderShardID          = "sendershard"
+	receiverShardID        = "receivershard"
+	wildCard               = "*"
+
+	separator = ","
 )
 
 type fieldsHandler struct {
-	HasNonce       bool
-	HasSender      bool
-	HasReceiver    bool
-	HasGasLimit    bool
-	HasGasPrice    bool
-	HasRcvUsername bool
-	HasData        bool
-	HasValue       bool
-	HasGuardian    bool
+	HasNonce             bool
+	HasSender            bool
+	HasReceiver          bool
+	HasGasLimit          bool
+	HasGasPrice          bool
+	HasRcvUsername       bool
+	HasData              bool
+	HasValue             bool
+	HasSignature         bool
+	HasSenderShardID     bool
+	HasReceiverShardID   bool
+	HasGuardian          bool
+	HasGuardianSignature bool
 }
 
 func newFieldsHandler(parameters string) fieldsHandler {
 	parameters = strings.ToLower(parameters)
+	parametersMap := sliceToMap(strings.Split(parameters, separator))
 	ph := fieldsHandler{
-		HasNonce:       strings.Contains(parameters, nonceField),
-		HasSender:      strings.Contains(parameters, senderField),
-		HasReceiver:    strings.Contains(parameters, receiverField),
-		HasGasLimit:    strings.Contains(parameters, gasLimitField),
-		HasGasPrice:    strings.Contains(parameters, gasPriceField),
-		HasRcvUsername: strings.Contains(parameters, rcvUsernameField),
-		HasData:        strings.Contains(parameters, dataField),
-		HasValue:       strings.Contains(parameters, valueField),
-		HasGuardian:    strings.Contains(parameters, guardianField),
+		HasNonce:             shouldConsiderField(parametersMap, nonceField),
+		HasSender:            shouldConsiderField(parametersMap, senderField),
+		HasReceiver:          shouldConsiderField(parametersMap, receiverField),
+		HasGasLimit:          shouldConsiderField(parametersMap, gasLimitField),
+		HasGasPrice:          shouldConsiderField(parametersMap, gasPriceField),
+		HasRcvUsername:       shouldConsiderField(parametersMap, rcvUsernameField),
+		HasData:              shouldConsiderField(parametersMap, dataField),
+		HasValue:             shouldConsiderField(parametersMap, valueField),
+		HasSignature:         shouldConsiderField(parametersMap, signatureField),
+		HasSenderShardID:     shouldConsiderField(parametersMap, senderShardID),
+		HasReceiverShardID:   shouldConsiderField(parametersMap, receiverShardID),
+		HasGuardian:          shouldConsiderField(parametersMap, guardianField),
+		HasGuardianSignature: shouldConsiderField(parametersMap, guardianSignatureField),
 	}
 	return ph
+}
+
+func shouldConsiderField(parametersMap map[string]struct{}, field string) bool {
+	_, has := parametersMap[field]
+	_, hasWildCard := parametersMap[wildCard]
+
+	return has || hasWildCard
+}
+
+func sliceToMap(providedSlice []string) map[string]struct{} {
+	result := make(map[string]struct{}, len(providedSlice))
+	for _, entry := range providedSlice {
+		result[entry] = struct{}{}
+	}
+
+	return result
 }

--- a/node/external/transactionAPI/fieldsHandler.go
+++ b/node/external/transactionAPI/fieldsHandler.go
@@ -62,10 +62,13 @@ func newFieldsHandler(parameters string) fieldsHandler {
 }
 
 func shouldConsiderField(parametersMap map[string]struct{}, field string) bool {
-	_, has := parametersMap[field]
 	_, hasWildCard := parametersMap[wildCard]
+	if hasWildCard {
+		return true
+	}
 
-	return has || hasWildCard
+	_, has := parametersMap[field]
+	return has
 }
 
 func sliceToMap(providedSlice []string) map[string]struct{} {

--- a/node/external/transactionAPI/fieldsHandler.go
+++ b/node/external/transactionAPI/fieldsHandler.go
@@ -14,6 +14,7 @@ const (
 	rcvUsernameField = "receiverusername"
 	dataField        = "data"
 	valueField       = "value"
+	guardianField    = "guardian"
 )
 
 type fieldsHandler struct {
@@ -25,6 +26,7 @@ type fieldsHandler struct {
 	HasRcvUsername bool
 	HasData        bool
 	HasValue       bool
+	HasGuardian    bool
 }
 
 func newFieldsHandler(parameters string) fieldsHandler {
@@ -38,6 +40,7 @@ func newFieldsHandler(parameters string) fieldsHandler {
 		HasRcvUsername: strings.Contains(parameters, rcvUsernameField),
 		HasData:        strings.Contains(parameters, dataField),
 		HasValue:       strings.Contains(parameters, valueField),
+		HasGuardian:    strings.Contains(parameters, guardianField),
 	}
 	return ph
 }

--- a/node/external/transactionAPI/fieldsHandler_test.go
+++ b/node/external/transactionAPI/fieldsHandler_test.go
@@ -12,7 +12,7 @@ func Test_newFieldsHandler(t *testing.T) {
 	t.Parallel()
 
 	fh := newFieldsHandler("")
-	require.Equal(t, fieldsHandler{make(map[string]struct{})}, fh)
+	require.Equal(t, fieldsHandler{map[string]struct{}{hashField: {}}}, fh)
 
 	providedFields := "nOnCe,sender,receiver,gasLimit,GASprice,receiverusername,data,value,signature,guardian,guardiansignature,sendershard,receivershard"
 	splitFields := strings.Split(providedFields, separator)

--- a/node/external/transactionAPI/fieldsHandler_test.go
+++ b/node/external/transactionAPI/fieldsHandler_test.go
@@ -12,17 +12,24 @@ func Test_newFieldsHandler(t *testing.T) {
 	fh := newFieldsHandler("")
 	require.Equal(t, fieldsHandler{}, fh)
 
-	fh = newFieldsHandler("nOnCe,sender,receiver,gasLimit,GASprice,receiverusername,data,value,guardian")
+	fh = newFieldsHandler("nOnCe,sender,receiver,gasLimit,GASprice,receiverusername,data,value,signature,guardian,guardiansignature,sendershard,receivershard")
 	expectedPH := fieldsHandler{
-		HasNonce:       true,
-		HasSender:      true,
-		HasReceiver:    true,
-		HasGasLimit:    true,
-		HasGasPrice:    true,
-		HasRcvUsername: true,
-		HasData:        true,
-		HasValue:       true,
-		HasGuardian:    true,
+		HasNonce:             true,
+		HasSender:            true,
+		HasReceiver:          true,
+		HasGasLimit:          true,
+		HasGasPrice:          true,
+		HasRcvUsername:       true,
+		HasData:              true,
+		HasValue:             true,
+		HasSignature:         true,
+		HasSenderShardID:     true,
+		HasReceiverShardID:   true,
+		HasGuardian:          true,
+		HasGuardianSignature: true,
 	}
+	require.Equal(t, expectedPH, fh)
+
+	fh = newFieldsHandler("*")
 	require.Equal(t, expectedPH, fh)
 }

--- a/node/external/transactionAPI/fieldsHandler_test.go
+++ b/node/external/transactionAPI/fieldsHandler_test.go
@@ -1,6 +1,8 @@
 package transactionAPI
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,26 +12,17 @@ func Test_newFieldsHandler(t *testing.T) {
 	t.Parallel()
 
 	fh := newFieldsHandler("")
-	require.Equal(t, fieldsHandler{}, fh)
+	require.Equal(t, fieldsHandler{make(map[string]struct{})}, fh)
 
-	fh = newFieldsHandler("nOnCe,sender,receiver,gasLimit,GASprice,receiverusername,data,value,signature,guardian,guardiansignature,sendershard,receivershard")
-	expectedPH := fieldsHandler{
-		HasNonce:             true,
-		HasSender:            true,
-		HasReceiver:          true,
-		HasGasLimit:          true,
-		HasGasPrice:          true,
-		HasRcvUsername:       true,
-		HasData:              true,
-		HasValue:             true,
-		HasSignature:         true,
-		HasSenderShardID:     true,
-		HasReceiverShardID:   true,
-		HasGuardian:          true,
-		HasGuardianSignature: true,
+	providedFields := "nOnCe,sender,receiver,gasLimit,GASprice,receiverusername,data,value,signature,guardian,guardiansignature,sendershard,receivershard"
+	splitFields := strings.Split(providedFields, separator)
+	fh = newFieldsHandler(providedFields)
+	for _, field := range splitFields {
+		require.True(t, fh.IsFieldSet(field), fmt.Sprintf("field %s is not set", field))
 	}
-	require.Equal(t, expectedPH, fh)
 
 	fh = newFieldsHandler("*")
-	require.Equal(t, expectedPH, fh)
+	for _, field := range splitFields {
+		require.True(t, fh.IsFieldSet(field))
+	}
 }

--- a/node/external/transactionAPI/fieldsHandler_test.go
+++ b/node/external/transactionAPI/fieldsHandler_test.go
@@ -12,7 +12,7 @@ func Test_newFieldsHandler(t *testing.T) {
 	fh := newFieldsHandler("")
 	require.Equal(t, fieldsHandler{}, fh)
 
-	fh = newFieldsHandler("nOnCe,sender,receiver,gasLimit,GASprice,receiverusername,data,value")
+	fh = newFieldsHandler("nOnCe,sender,receiver,gasLimit,GASprice,receiverusername,data,value,guardian")
 	expectedPH := fieldsHandler{
 		HasNonce:       true,
 		HasSender:      true,
@@ -22,6 +22,7 @@ func Test_newFieldsHandler(t *testing.T) {
 		HasRcvUsername: true,
 		HasData:        true,
 		HasValue:       true,
+		HasGuardian:    true,
 	}
 	require.Equal(t, expectedPH, fh)
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- missing fields in response of /transaction/pool by sender
  
## Proposed changes
- added new fields which can be requested: `guardian`, `guardiansignature`, `signature`, `sendershard`, `receivershard` and wildcard `*` which will return all fields as in the next picture
![image](https://github.com/multiversx/mx-chain-go/assets/34831323/6d671d76-6690-411d-b10e-472b72498cb7)



## Testing procedure
- will be tested with proxy branch [support_for_tx_pool_wild_card](https://github.com/multiversx/mx-chain-proxy-go/pull/432)
- standard system test + scenario:
   - add 2 transactions in pool for a sender, one guarded and another one not guarded. Then check `/transaction/pool?by-sender=erd1....&fields=` with the new fields.
   - also check that a combination of fields and wildcard is not possible. Eg fields=nonce,*

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
