### PR TITLE
FIX [sovereign] Resend of unconfirmed operation by next leader if no current operation found

### DIFF
--- a/consensus/spos/bls/sovereignSubRoundEnd.go
+++ b/consensus/spos/bls/sovereignSubRoundEnd.go
@@ -60,7 +60,7 @@ func (sr *sovereignSubRoundEnd) doSovereignEndRoundJob(ctx context.Context) bool
 
 	outGoingMBHeader := sovHeader.GetOutGoingMiniBlockHeaderHandler()
 	if check.IfNil(outGoingMBHeader) {
-		sr.sendUnconfirmedOperationsIfExist(ctx)
+		sr.sendUnconfirmedOperationsIfFound(ctx)
 		return true
 	}
 
@@ -80,7 +80,7 @@ func (sr *sovereignSubRoundEnd) doSovereignEndRoundJob(ctx context.Context) bool
 	return true
 }
 
-func (sr *sovereignSubRoundEnd) sendUnconfirmedOperationsIfExist(ctx context.Context) {
+func (sr *sovereignSubRoundEnd) sendUnconfirmedOperationsIfFound(ctx context.Context) {
 	if !sr.isSelfLeader() {
 		return
 	}

--- a/consensus/spos/bls/sovereignSubRoundEnd.go
+++ b/consensus/spos/bls/sovereignSubRoundEnd.go
@@ -60,6 +60,7 @@ func (sr *sovereignSubRoundEnd) doSovereignEndRoundJob(ctx context.Context) bool
 
 	outGoingMBHeader := sovHeader.GetOutGoingMiniBlockHeaderHandler()
 	if check.IfNil(outGoingMBHeader) {
+		sr.sendUnconfirmedOperationsIfExist(ctx)
 		return true
 	}
 
@@ -69,7 +70,7 @@ func (sr *sovereignSubRoundEnd) doSovereignEndRoundJob(ctx context.Context) bool
 		return false
 	}
 
-	if !(sr.IsSelfLeaderInCurrentRound() || sr.IsMultiKeyLeaderInCurrentRound()) {
+	if !sr.isSelfLeader() {
 		return true
 	}
 
@@ -77,6 +78,20 @@ func (sr *sovereignSubRoundEnd) doSovereignEndRoundJob(ctx context.Context) bool
 	go sr.sendOutGoingOperations(ctx, outGoingOperations)
 
 	return true
+}
+
+func (sr *sovereignSubRoundEnd) sendUnconfirmedOperationsIfExist(ctx context.Context) {
+	if !sr.isSelfLeader() {
+		return
+	}
+
+	unconfirmedOperations := sr.outGoingOperationsPool.GetUnconfirmedOperations()
+	if len(unconfirmedOperations) == 0 {
+		return
+	}
+
+	log.Debug("found unconfirmed operations", "num unconfirmed operations", len(unconfirmedOperations))
+	go sr.sendOutGoingOperations(ctx, unconfirmedOperations)
 }
 
 func (sr *sovereignSubRoundEnd) updateBridgeDataWithSignatures(
@@ -95,6 +110,10 @@ func (sr *sovereignSubRoundEnd) updateBridgeDataWithSignatures(
 	sr.outGoingOperationsPool.Delete(hash)
 	sr.outGoingOperationsPool.Add(currBridgeData)
 	return currBridgeData, nil
+}
+
+func (sr *sovereignSubRoundEnd) isSelfLeader() bool {
+	return sr.IsSelfLeaderInCurrentRound() || sr.IsMultiKeyLeaderInCurrentRound()
 }
 
 func (sr *sovereignSubRoundEnd) getAllOutGoingOperations(currentOperations *sovereign.BridgeOutGoingData) []*sovereign.BridgeOutGoingData {


### PR DESCRIPTION
## Reasoning behind the pull request
- Unconfirmed operations were only resent by the next leader if there were also operations in the current block to be bridged 

## Proposed changes
- If there is no outgoing operation in the current block, leader should check for unconfirmed operations and resend them

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
