### PR TITLE
Mx 15248 outgoing ops hasher

### DIFF
--- a/cmd/sovereignnode/config/sovereignConfig.toml
+++ b/cmd/sovereignnode/config/sovereignConfig.toml
@@ -69,3 +69,7 @@
 [GenesisConfig]
     # NativeESDT specifies the sovereign shard's native esdt currency
     NativeESDT = "WEGLD-bd4d79"
+
+[OutgoingOperationsConfig]
+    # Hasher type for outgoing operations
+    Hasher = "sha256"

--- a/cmd/sovereignnode/config/sovereignConfig.toml
+++ b/cmd/sovereignnode/config/sovereignConfig.toml
@@ -41,6 +41,8 @@
 [OutGoingBridge]
     GRPCHost = "localhost"
     GRPCPort = "8085"
+    # Hasher type for outgoing operations
+    Hasher = "sha256"
 
 [NotifierConfig]
     SubscribedEvents = [
@@ -69,7 +71,3 @@
 [GenesisConfig]
     # NativeESDT specifies the sovereign shard's native esdt currency
     NativeESDT = "WEGLD-bd4d79"
-
-[OutgoingOperationsConfig]
-    # Hasher type for outgoing operations
-    Hasher = "sha256"

--- a/config/sovereignConfig.go
+++ b/config/sovereignConfig.go
@@ -9,7 +9,6 @@ type SovereignConfig struct {
 	OutGoingBridge                   OutGoingBridge           `toml:"OutGoingBridge"`
 	NotifierConfig                   NotifierConfig           `toml:"NotifierConfig"`
 	GenesisConfig                    GenesisConfig            `toml:"GenesisConfig"`
-	OutGoingOperationsConfig         OutgoingOperationsConfig `toml:"OutgoingOperationsConfig"`
 	OutGoingBridgeCertificate        OutGoingBridgeCertificate
 }
 
@@ -28,6 +27,7 @@ type MainChainNotarization struct {
 type OutGoingBridge struct {
 	GRPCHost string `toml:"GRPCHost"`
 	GRPCPort string `toml:"GRPCPort"`
+	Hasher   string `toml:"Hasher"`
 }
 
 // OutGoingBridgeCertificate holds config for outgoing bridge certificate paths
@@ -64,9 +64,4 @@ type WebSocketConfig struct {
 // GenesisConfig should hold all sovereign genesis related configs
 type GenesisConfig struct {
 	NativeESDT string `toml:"NativeESDT"`
-}
-
-// OutgoingOperationsConfig should hold outgoing operations configs
-type OutgoingOperationsConfig struct {
-	Hasher string `toml:"Hasher"`
 }

--- a/config/sovereignConfig.go
+++ b/config/sovereignConfig.go
@@ -9,6 +9,7 @@ type SovereignConfig struct {
 	OutGoingBridge                   OutGoingBridge           `toml:"OutGoingBridge"`
 	NotifierConfig                   NotifierConfig           `toml:"NotifierConfig"`
 	GenesisConfig                    GenesisConfig            `toml:"GenesisConfig"`
+	OutGoingOperationsConfig         OutgoingOperationsConfig `toml:"OutgoingOperationsConfig"`
 	OutGoingBridgeCertificate        OutGoingBridgeCertificate
 }
 
@@ -63,4 +64,9 @@ type WebSocketConfig struct {
 // GenesisConfig should hold all sovereign genesis related configs
 type GenesisConfig struct {
 	NativeESDT string `toml:"NativeESDT"`
+}
+
+// OutgoingOperationsConfig should hold outgoing operations configs
+type OutgoingOperationsConfig struct {
+	Hasher string `toml:"Hasher"`
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -778,3 +778,6 @@ var ErrNilSerializer = errors.New("nil codec serializer")
 
 // ErrNilTopicsChecker signals that a nil topics checker has been provided
 var ErrNilTopicsChecker = errors.New("nil topics checker")
+
+// ErrNilOperationsHasher signals that a nil outgoing operations hasher has been provided
+var ErrNilOperationsHasher = errors.New("nil outgoing operations hasher")

--- a/process/block/sovereignBlockProcessorFactory.go
+++ b/process/block/sovereignBlockProcessorFactory.go
@@ -47,7 +47,7 @@ func (s *sovereignBlockProcessorFactory) CreateBlockProcessor(argumentsBaseProce
 		return nil, err
 	}
 
-	operationsHasher, err := factory.NewHasher(argumentsBaseProcessor.Config.SovereignConfig.OutGoingOperationsConfig.Hasher)
+	operationsHasher, err := factory.NewHasher(argumentsBaseProcessor.Config.SovereignConfig.OutGoingBridge.Hasher)
 	if err != nil {
 		return nil, err
 	}

--- a/process/block/sovereignBlockProcessorFactory.go
+++ b/process/block/sovereignBlockProcessorFactory.go
@@ -2,11 +2,13 @@ package block
 
 import (
 	"errors"
+
+	mxErrors "github.com/multiversx/mx-chain-go/errors"
+	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/block/sovereign"
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
-	mxErrors "github.com/multiversx/mx-chain-go/errors"
-	"github.com/multiversx/mx-chain-go/process"
+	"github.com/multiversx/mx-chain-core-go/hashing/factory"
 )
 
 type sovereignBlockProcessorFactory struct {
@@ -45,11 +47,17 @@ func (s *sovereignBlockProcessorFactory) CreateBlockProcessor(argumentsBaseProce
 		return nil, err
 	}
 
+	operationsHasher, err := factory.NewHasher(argumentsBaseProcessor.Config.SovereignConfig.OutGoingOperationsConfig.Hasher)
+	if err != nil {
+		return nil, err
+	}
+
 	args := ArgsSovereignChainBlockProcessor{
 		ShardProcessor:               shardProc,
 		ValidatorStatisticsProcessor: argumentsBaseProcessor.ValidatorStatisticsProcessor,
 		OutgoingOperationsFormatter:  outgoingOpFormatter,
 		OutGoingOperationsPool:       argumentsBaseProcessor.OutGoingOperationsPool,
+		OperationsHasher:             operationsHasher,
 	}
 
 	scbp, err := NewSovereignChainBlockProcessor(args)

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -6,14 +6,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/multiversx/mx-chain-core-go/core"
-	"github.com/multiversx/mx-chain-core-go/core/check"
-	"github.com/multiversx/mx-chain-core-go/data"
-	"github.com/multiversx/mx-chain-core-go/data/block"
-	sovCore "github.com/multiversx/mx-chain-core-go/data/sovereign"
-	"github.com/multiversx/mx-chain-core-go/hashing"
-	logger "github.com/multiversx/mx-chain-logger-go"
-
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/logging"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
@@ -22,6 +14,14 @@ import (
 	"github.com/multiversx/mx-chain-go/process/block/processedMb"
 	"github.com/multiversx/mx-chain-go/process/block/sovereign"
 	"github.com/multiversx/mx-chain-go/state"
+
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/block"
+	sovCore "github.com/multiversx/mx-chain-core-go/data/sovereign"
+	"github.com/multiversx/mx-chain-core-go/hashing"
+	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
 var rootHash = "uncomputed root hash"

--- a/process/block/sovereignChainBlock_test.go
+++ b/process/block/sovereignChainBlock_test.go
@@ -4,10 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/multiversx/mx-chain-core-go/core"
-	"github.com/multiversx/mx-chain-core-go/data"
-	"github.com/multiversx/mx-chain-core-go/data/block"
-	sovereignCore "github.com/multiversx/mx-chain-core-go/data/sovereign"
 	"github.com/multiversx/mx-chain-go/dataRetriever/requestHandlers"
 	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/process"
@@ -21,6 +17,11 @@ import (
 	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
 	"github.com/multiversx/mx-chain-go/testscommon/sovereign"
 	"github.com/multiversx/mx-chain-go/testscommon/storage"
+
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/block"
+	sovereignCore "github.com/multiversx/mx-chain-core-go/data/sovereign"
 	"github.com/stretchr/testify/require"
 )
 
@@ -85,6 +86,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterMock{},
 			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
+			OperationsHasher:             &mock.HasherStub{},
 		})
 
 		require.Nil(t, scbp)
@@ -101,6 +103,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ValidatorStatisticsProcessor: nil,
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterMock{},
 			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
+			OperationsHasher:             &mock.HasherStub{},
 		})
 
 		require.Nil(t, scbp)
@@ -117,6 +120,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  nil,
 			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
+			OperationsHasher:             &mock.HasherStub{},
 		})
 
 		require.Nil(t, scbp)
@@ -133,10 +137,28 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterMock{},
 			OutGoingOperationsPool:       nil,
+			OperationsHasher:             &mock.HasherStub{},
 		})
 
 		require.Nil(t, scbp)
 		require.Equal(t, errors.ErrNilOutGoingOperationsPool, err)
+	})
+
+	t.Run("should error when operations hasher is nil", func(t *testing.T) {
+		t.Parallel()
+
+		arguments := CreateMockArguments(createComponentHolderMocks())
+		sp, _ := blproc.NewShardProcessor(arguments)
+		scbp, err := blproc.NewSovereignChainBlockProcessor(blproc.ArgsSovereignChainBlockProcessor{
+			ShardProcessor:               sp,
+			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
+			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterMock{},
+			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
+			OperationsHasher:             nil,
+		})
+
+		require.Nil(t, scbp)
+		require.Equal(t, errors.ErrNilOperationsHasher, err)
 	})
 
 	t.Run("should error when type assertion to extendedShardHeaderTrackHandler fails", func(t *testing.T) {
@@ -149,6 +171,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterMock{},
 			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
+			OperationsHasher:             &mock.HasherStub{},
 		})
 
 		require.Nil(t, scbp)
@@ -169,6 +192,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterMock{},
 			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
+			OperationsHasher:             &mock.HasherStub{},
 		})
 
 		require.Nil(t, scbp)
@@ -185,6 +209,7 @@ func TestSovereignBlockProcessor_NewSovereignChainBlockProcessorShouldWork(t *te
 			ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 			OutgoingOperationsFormatter:  &sovereign.OutgoingOperationsFormatterMock{},
 			OutGoingOperationsPool:       &sovereign.OutGoingOperationsPoolMock{},
+			OperationsHasher:             &mock.HasherStub{},
 		})
 
 		require.NotNil(t, scbp)
@@ -208,10 +233,10 @@ func TestSovereignChainBlockProcessor_createAndSetOutGoingMiniBlock(t *testing.T
 	bridgeOp1 := []byte("bridgeOp@123@rcv1@token1@val1")
 	bridgeOp2 := []byte("bridgeOp@124@rcv2@token2@val2")
 
-	hasher := arguments.CoreComponents.Hasher()
-	bridgeOp1Hash := hasher.Compute(string(bridgeOp1))
-	bridgeOp2Hash := hasher.Compute(string(bridgeOp2))
-	bridgeOpsHash := hasher.Compute(string(append(bridgeOp1Hash, bridgeOp2Hash...)))
+	outgoingOpsHasher := &mock.HasherStub{}
+	bridgeOp1Hash := outgoingOpsHasher.Compute(string(bridgeOp1))
+	bridgeOp2Hash := outgoingOpsHasher.Compute(string(bridgeOp2))
+	bridgeOpsHash := outgoingOpsHasher.Compute(string(append(bridgeOp1Hash, bridgeOp2Hash...)))
 
 	outgoingOperationsFormatter := &sovereign.OutgoingOperationsFormatterMock{
 		CreateOutgoingTxDataCalled: func(logs []*data.LogData) ([][]byte, error) {
@@ -254,6 +279,7 @@ func TestSovereignChainBlockProcessor_createAndSetOutGoingMiniBlock(t *testing.T
 		ValidatorStatisticsProcessor: &mock.ValidatorStatisticsProcessorStub{},
 		OutgoingOperationsFormatter:  outgoingOperationsFormatter,
 		OutGoingOperationsPool:       outGoingOperationsPool,
+		OperationsHasher:             outgoingOpsHasher,
 	})
 
 	sovChainHdr := &block.SovereignChainHeader{}
@@ -279,7 +305,7 @@ func TestSovereignChainBlockProcessor_createAndSetOutGoingMiniBlock(t *testing.T
 	}
 	require.Equal(t, expectedBlockBody, blockBody)
 
-	expectedOutGoingMbHash, err := core.CalculateHash(arguments.CoreComponents.InternalMarshalizer(), hasher, expectedOutGoingMb)
+	expectedOutGoingMbHash, err := core.CalculateHash(arguments.CoreComponents.InternalMarshalizer(), arguments.CoreComponents.Hasher(), expectedOutGoingMb)
 	require.Nil(t, err)
 
 	expectedSovChainHeader := &block.SovereignChainHeader{

--- a/testscommon/generalConfig.go
+++ b/testscommon/generalConfig.go
@@ -432,6 +432,9 @@ func GetGeneralConfig() config.Config {
 					},
 				},
 			},
+			OutGoingOperationsConfig: config.OutgoingOperationsConfig{
+				Hasher: "sha256",
+			},
 		},
 	}
 }

--- a/testscommon/generalConfig.go
+++ b/testscommon/generalConfig.go
@@ -432,7 +432,7 @@ func GetGeneralConfig() config.Config {
 					},
 				},
 			},
-			OutGoingOperationsConfig: config.OutgoingOperationsConfig{
+			OutGoingBridge: config.OutGoingBridge{
 				Hasher: "sha256",
 			},
 		},


### PR DESCRIPTION
## Reasoning behind the pull request
- SHA256 hasher needed for outgoing operations because SC can only use SHA256 hasher
- 
- 
  
## Proposed changes
- add `OperationsHasher` in sovereign config
- 
- 

## Testing procedure
- unit tests
- running sovereign node
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
