### PR TITLE
fixed unstaked list on delegation when nodes are unstaked from queue

### DIFF
--- a/integrationTests/chainSimulator/staking/stakingProviderWithNodesinQueue_test.go
+++ b/integrationTests/chainSimulator/staking/stakingProviderWithNodesinQueue_test.go
@@ -125,6 +125,7 @@ func testStakingProviderWithNodesReStakeUnStaked(t *testing.T, stakingV4Activati
 	require.Equal(t, "staked", status)
 
 	err = cs.GenerateBlocks(20)
+	require.Nil(t, err)
 
 	checkValidatorStatus(t, cs, blsKeys[0], "auction")
 }

--- a/integrationTests/chainSimulator/staking/stakingProviderWithNodesinQueue_test.go
+++ b/integrationTests/chainSimulator/staking/stakingProviderWithNodesinQueue_test.go
@@ -115,6 +115,10 @@ func testStakingProviderWithNodesReStakeUnStaked(t *testing.T, stakingV4Activati
 	status = getBLSKeyStatus(t, metachainNode, decodedBLSKey0)
 	require.Equal(t, "unStaked", status)
 
+	result := getAllNodeStates(t, metachainNode, delegationAddressBytes)
+	require.NotNil(t, result)
+	require.Equal(t, "unStaked", result[blsKeys[0]])
+
 	ownerNonce = getNonce(t, cs, validatorOwner)
 	reStakeTxData := fmt.Sprintf("reStakeUnStakedNodes@%s", blsKeys[0])
 	reStakeNodes := generateTransaction(validatorOwner.Bytes, ownerNonce, delegationAddressBytes, big.NewInt(0), reStakeTxData, gasLimitForStakeOperation)
@@ -125,7 +129,7 @@ func testStakingProviderWithNodesReStakeUnStaked(t *testing.T, stakingV4Activati
 	status = getBLSKeyStatus(t, metachainNode, decodedBLSKey0)
 	require.Equal(t, "staked", status)
 
-	result := getAllNodeStates(t, metachainNode, delegationAddressBytes)
+	result = getAllNodeStates(t, metachainNode, delegationAddressBytes)
 	require.NotNil(t, result)
 	require.Equal(t, "staked", result[blsKeys[0]])
 

--- a/integrationTests/chainSimulator/staking/stakingProviderWithNodesinQueue_test.go
+++ b/integrationTests/chainSimulator/staking/stakingProviderWithNodesinQueue_test.go
@@ -3,6 +3,10 @@ package staking
 import (
 	"encoding/hex"
 	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-go/config"
@@ -11,9 +15,6 @@ import (
 	"github.com/multiversx/mx-chain-go/node/chainSimulator/configs"
 	"github.com/multiversx/mx-chain-go/vm"
 	"github.com/stretchr/testify/require"
-	"math/big"
-	"testing"
-	"time"
 )
 
 func TestStakingProviderWithNodes(t *testing.T) {
@@ -123,6 +124,10 @@ func testStakingProviderWithNodesReStakeUnStaked(t *testing.T, stakingV4Activati
 
 	status = getBLSKeyStatus(t, metachainNode, decodedBLSKey0)
 	require.Equal(t, "staked", status)
+
+	result := getAllNodeStates(t, metachainNode, delegationAddressBytes)
+	require.NotNil(t, result)
+	require.Equal(t, "staked", result[blsKeys[0]])
 
 	err = cs.GenerateBlocks(20)
 	require.Nil(t, err)

--- a/integrationTests/chainSimulator/staking/stakingProviderWithNodesinQueue_test.go
+++ b/integrationTests/chainSimulator/staking/stakingProviderWithNodesinQueue_test.go
@@ -1,0 +1,130 @@
+package staking
+
+import (
+	"encoding/hex"
+	"fmt"
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/node/chainSimulator"
+	"github.com/multiversx/mx-chain-go/node/chainSimulator/components/api"
+	"github.com/multiversx/mx-chain-go/node/chainSimulator/configs"
+	"github.com/multiversx/mx-chain-go/vm"
+	"github.com/stretchr/testify/require"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func TestStakingProviderWithNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	stakingV4ActivationEpoch := uint32(2)
+
+	t.Run("staking ph 4 step 1 active", func(t *testing.T) {
+		testStakingProviderWithNodesReStakeUnStaked(t, stakingV4ActivationEpoch)
+	})
+
+	t.Run("staking ph 4 step 2 active", func(t *testing.T) {
+		testStakingProviderWithNodesReStakeUnStaked(t, stakingV4ActivationEpoch+1)
+	})
+
+	t.Run("staking ph 4 step 3 active", func(t *testing.T) {
+		testStakingProviderWithNodesReStakeUnStaked(t, stakingV4ActivationEpoch+2)
+	})
+}
+
+func testStakingProviderWithNodesReStakeUnStaked(t *testing.T, stakingV4ActivationEpoch uint32) {
+	roundDurationInMillis := uint64(6000)
+	roundsPerEpoch := core.OptionalUint64{
+		HasValue: true,
+		Value:    20,
+	}
+
+	cs, err := chainSimulator.NewChainSimulator(chainSimulator.ArgsChainSimulator{
+		BypassTxSignatureCheck:   false,
+		TempDir:                  t.TempDir(),
+		PathToInitialConfig:      defaultPathToInitialConfig,
+		NumOfShards:              3,
+		GenesisTimestamp:         time.Now().Unix(),
+		RoundDurationInMillis:    roundDurationInMillis,
+		RoundsPerEpoch:           roundsPerEpoch,
+		ApiInterface:             api.NewNoApiInterface(),
+		MinNodesPerShard:         3,
+		MetaChainMinNodes:        3,
+		NumNodesWaitingListMeta:  3,
+		NumNodesWaitingListShard: 3,
+		AlterConfigsFunction: func(cfg *config.Configs) {
+			configs.SetStakingV4ActivationEpochs(cfg, stakingV4ActivationEpoch)
+		},
+	})
+	require.Nil(t, err)
+	require.NotNil(t, cs)
+	defer cs.Close()
+
+	mintValue := big.NewInt(0).Mul(big.NewInt(5000), oneEGLD)
+	validatorOwner, err := cs.GenerateAndMintWalletAddress(0, mintValue)
+	require.Nil(t, err)
+	require.Nil(t, err)
+
+	err = cs.GenerateBlocksUntilEpochIsReached(1)
+	require.Nil(t, err)
+
+	// create delegation contract
+	stakeValue, _ := big.NewInt(0).SetString("4250000000000000000000", 10)
+	dataField := "createNewDelegationContract@00@0ea1"
+	txStake := generateTransaction(validatorOwner.Bytes, getNonce(t, cs, validatorOwner), vm.DelegationManagerSCAddress, stakeValue, dataField, 80_000_000)
+	stakeTx, err := cs.SendTxAndGenerateBlockTilTxIsExecuted(txStake, maxNumOfBlockToGenerateWhenExecutingTx)
+	require.Nil(t, err)
+	require.NotNil(t, stakeTx)
+
+	delegationAddress := stakeTx.Logs.Events[2].Address
+	delegationAddressBytes, _ := cs.GetNodeHandler(0).GetCoreComponents().AddressPubKeyConverter().Decode(delegationAddress)
+
+	// add nodes in queue
+	_, blsKeys, err := chainSimulator.GenerateBlsPrivateKeys(1)
+	require.Nil(t, err)
+
+	txDataFieldAddNodes := fmt.Sprintf("addNodes@%s@%s", blsKeys[0], mockBLSSignature+"02")
+	ownerNonce := getNonce(t, cs, validatorOwner)
+	txAddNodes := generateTransaction(validatorOwner.Bytes, ownerNonce, delegationAddressBytes, big.NewInt(0), txDataFieldAddNodes, gasLimitForStakeOperation)
+	addNodesTx, err := cs.SendTxAndGenerateBlockTilTxIsExecuted(txAddNodes, maxNumOfBlockToGenerateWhenExecutingTx)
+	require.Nil(t, err)
+	require.NotNil(t, addNodesTx)
+
+	txDataFieldStakeNodes := fmt.Sprintf("stakeNodes@%s", blsKeys[0])
+	ownerNonce = getNonce(t, cs, validatorOwner)
+	txStakeNodes := generateTransaction(validatorOwner.Bytes, ownerNonce, delegationAddressBytes, big.NewInt(0), txDataFieldStakeNodes, gasLimitForStakeOperation)
+
+	stakeNodesTxs, err := cs.SendTxsAndGenerateBlocksTilAreExecuted([]*transaction.Transaction{txStakeNodes}, maxNumOfBlockToGenerateWhenExecutingTx)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(stakeNodesTxs))
+
+	metachainNode := cs.GetNodeHandler(core.MetachainShardId)
+	decodedBLSKey0, _ := hex.DecodeString(blsKeys[0])
+	status := getBLSKeyStatus(t, metachainNode, decodedBLSKey0)
+	require.Equal(t, "queued", status)
+
+	// activate staking v4
+	err = cs.GenerateBlocksUntilEpochIsReached(int32(stakingV4ActivationEpoch))
+	require.Nil(t, err)
+
+	status = getBLSKeyStatus(t, metachainNode, decodedBLSKey0)
+	require.Equal(t, "unStaked", status)
+
+	ownerNonce = getNonce(t, cs, validatorOwner)
+	reStakeTxData := fmt.Sprintf("reStakeUnStakedNodes@%s", blsKeys[0])
+	reStakeNodes := generateTransaction(validatorOwner.Bytes, ownerNonce, delegationAddressBytes, big.NewInt(0), reStakeTxData, gasLimitForStakeOperation)
+	reStakeTx, err := cs.SendTxAndGenerateBlockTilTxIsExecuted(reStakeNodes, maxNumOfBlockToGenerateWhenExecutingTx)
+	require.Nil(t, err)
+	require.NotNil(t, reStakeTx)
+
+	status = getBLSKeyStatus(t, metachainNode, decodedBLSKey0)
+	require.Equal(t, "staked", status)
+
+	err = cs.GenerateBlocks(20)
+
+	checkValidatorStatus(t, cs, blsKeys[0], "auction")
+}

--- a/vm/systemSmartContracts/delegation.go
+++ b/vm/systemSmartContracts/delegation.go
@@ -2322,7 +2322,8 @@ func (d *delegation) deleteDelegatorIfNeeded(address []byte, delegator *Delegato
 }
 
 func (d *delegation) unStakeAtEndOfEpoch(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-	if !bytes.Equal(args.CallerAddr, d.endOfEpochAddr) {
+	if !bytes.Equal(args.CallerAddr, d.endOfEpochAddr) &&
+		!bytes.Equal(args.CallerAddr, d.stakingSCAddr) {
 		d.eei.AddReturnMessage("can be called by end of epoch address only")
 		return vmcommon.UserError
 	}

--- a/vm/systemSmartContracts/eei.go
+++ b/vm/systemSmartContracts/eei.go
@@ -144,12 +144,16 @@ func (host *vmContext) GetStorageFromAddress(address []byte, key []byte) []byte 
 		if value, isInMap := storageAdrMap[string(key)]; isInMap {
 			return value
 		}
+	} else {
+		storageAdrMap = make(map[string][]byte)
 	}
 
 	data, _, err := host.blockChainHook.GetStorageData(address, key)
 	if err != nil {
 		return nil
 	}
+
+	storageAdrMap[string(key)] = data
 
 	return data
 }

--- a/vm/systemSmartContracts/staking_test.go
+++ b/vm/systemSmartContracts/staking_test.go
@@ -3755,7 +3755,7 @@ func TestStakingSc_UnStakeAllFromQueueWithDelegationContracts(t *testing.T) {
 	doStake(t, stakingSmartContract, stakingAccessAddress, stakerAddress, []byte("fourthKey"))
 
 	waitingReturn := doGetWaitingListRegisterNonceAndRewardAddress(t, stakingSmartContract, eei)
-	assert.Equal(t, len(waitingReturn), 9)
+	requireSliceContains(t, waitingReturn, [][]byte{[]byte("secondKey"), []byte("thirdKey "), []byte("fourthKey")})
 
 	dStatus := &DelegationContractStatus{
 		StakedKeys:    make([]*NodesData, 4),
@@ -3801,12 +3801,19 @@ func TestStakingSc_UnStakeAllFromQueueWithDelegationContracts(t *testing.T) {
 	assert.Equal(t, len(dStatus.StakedKeys), 1)
 
 	doGetStatus(t, stakingSmartContract, eei, []byte("secondKey"), "unStaked")
+	doGetStatus(t, stakingSmartContract, eei, []byte("thirdKey "), "unStaked")
+	doGetStatus(t, stakingSmartContract, eei, []byte("fourthKey"), "unStaked")
 
 	// stake them again - as they were deleted from waiting list
 	doStake(t, stakingSmartContract, stakingAccessAddress, stakerAddress, []byte("thirdKey "))
 	doStake(t, stakingSmartContract, stakingAccessAddress, stakerAddress, []byte("fourthKey"))
 
-	// surprisingly, the queue works again as we did not activate the staking v4
 	doGetStatus(t, stakingSmartContract, eei, []byte("thirdKey "), "staked")
 	doGetStatus(t, stakingSmartContract, eei, []byte("fourthKey"), "staked")
+}
+
+func requireSliceContains(t *testing.T, s1, s2 [][]byte) {
+	for _, elemInS2 := range s2 {
+		require.Contains(t, s1, elemInS2)
+	}
 }


### PR DESCRIPTION
## Reasoning behind the pull request
Bugfix as nodes remain in undefined state from the delegation contract perspective after the activation of staking v4 and unStaking of nodes from queue

## Proposed changes
Called unStakeAtEndOfEpoch on delegation contracts to fix thee state of nodes.

## Testing procedure
Before activation of staking v4, create a delegation contract and add nodes to the queue. After the activation call reStakeUnStakedNodes and it should work

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
