### PR TITLE
Added block timestamp + scripts update for the round duration

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -100,6 +100,9 @@ const MetricCurrentRound = "erd_current_round"
 // MetricNonce is the metric for monitoring the nonce of a node
 const MetricNonce = "erd_nonce"
 
+// MetricBlockTimestamp is the metric for monitoring the timestamp of the last synchronized block
+const MetricBlockTimestamp = "erd_block_timestamp"
+
 // MetricProbableHighestNonce is the metric for monitoring the max speculative nonce received by the node by listening on the network
 const MetricProbableHighestNonce = "erd_probable_highest_nonce"
 

--- a/dataRetriever/blockchain/blockchain.go
+++ b/dataRetriever/blockchain/blockchain.go
@@ -69,6 +69,7 @@ func (bc *blockChain) SetCurrentBlockHeaderAndRootHash(header data.HeaderHandler
 
 	bc.appStatusHandler.SetUInt64Value(common.MetricNonce, h.GetNonce())
 	bc.appStatusHandler.SetUInt64Value(common.MetricSynchronizedRound, h.GetRound())
+	bc.appStatusHandler.SetUInt64Value(common.MetricBlockTimestamp, h.GetTimeStamp())
 
 	bc.mut.Lock()
 	bc.currentBlockHeader = h.ShallowClone()

--- a/dataRetriever/blockchain/metachain.go
+++ b/dataRetriever/blockchain/metachain.go
@@ -71,6 +71,7 @@ func (mc *metaChain) SetCurrentBlockHeaderAndRootHash(header data.HeaderHandler,
 
 	mc.appStatusHandler.SetUInt64Value(common.MetricNonce, currHead.Nonce)
 	mc.appStatusHandler.SetUInt64Value(common.MetricSynchronizedRound, currHead.Round)
+	mc.appStatusHandler.SetUInt64Value(common.MetricBlockTimestamp, currHead.GetTimeStamp())
 
 	mc.mut.Lock()
 	mc.currentBlockHeader = currHead.ShallowClone()

--- a/node/metrics/metrics.go
+++ b/node/metrics/metrics.go
@@ -30,6 +30,7 @@ func InitBaseMetrics(appStatusHandler core.AppStatusHandler) error {
 
 	appStatusHandler.SetUInt64Value(common.MetricSynchronizedRound, initUint)
 	appStatusHandler.SetUInt64Value(common.MetricNonce, initUint)
+	appStatusHandler.SetUInt64Value(common.MetricBlockTimestamp, initUint)
 	appStatusHandler.SetUInt64Value(common.MetricCountConsensus, initUint)
 	appStatusHandler.SetUInt64Value(common.MetricCountLeader, initUint)
 	appStatusHandler.SetUInt64Value(common.MetricCountAcceptedBlocks, initUint)

--- a/node/metrics/metrics_test.go
+++ b/node/metrics/metrics_test.go
@@ -23,6 +23,7 @@ func TestInitBaseMetrics(t *testing.T) {
 	expectedKeys := []string{
 		common.MetricSynchronizedRound,
 		common.MetricNonce,
+		common.MetricBlockTimestamp,
 		common.MetricCountConsensus,
 		common.MetricCountLeader,
 		common.MetricCountAcceptedBlocks,

--- a/scripts/testnet/include/config.sh
+++ b/scripts/testnet/include/config.sh
@@ -20,7 +20,8 @@ generateConfig() {
     -num-of-observers-in-metachain $TMP_META_OBSERVERCOUNT    \
     -metachain-consensus-group-size $META_CONSENSUS_SIZE      \
     -stake-type $GENESIS_STAKE_TYPE \
-    -hysteresis $HYSTERESIS
+    -hysteresis $HYSTERESIS \
+    -round-duration $ROUND_DURATION_IN_MS
   popd
 }
 

--- a/scripts/testnet/variables.sh
+++ b/scripts/testnet/variables.sh
@@ -62,6 +62,8 @@ export META_VALIDATORCOUNT=3
 export META_OBSERVERCOUNT=1
 export META_CONSENSUS_SIZE=$META_VALIDATORCOUNT
 
+export ROUND_DURATION_IN_MS=6000
+
 # MULTI_KEY_NODES if set to 1, one observer will be generated on each shard that will handle all generated keys
 export MULTI_KEY_NODES=0
 

--- a/statusHandler/persister/persistentHandler.go
+++ b/statusHandler/persister/persistentHandler.go
@@ -58,6 +58,7 @@ func (psh *PersistentStatusHandler) initMap() {
 	psh.persistentMetrics.Store(common.MetricNumProcessedTxs, initUint)
 	psh.persistentMetrics.Store(common.MetricNumShardHeadersProcessed, initUint)
 	psh.persistentMetrics.Store(common.MetricNonce, initUint)
+	psh.persistentMetrics.Store(common.MetricBlockTimestamp, initUint)
 	psh.persistentMetrics.Store(common.MetricCurrentRound, initUint)
 	psh.persistentMetrics.Store(common.MetricNonceAtEpochStart, initUint)
 	psh.persistentMetrics.Store(common.MetricRoundAtEpochStart, initUint)

--- a/statusHandler/statusMetricsProvider.go
+++ b/statusHandler/statusMetricsProvider.go
@@ -340,6 +340,7 @@ func (sm *statusMetrics) saveUint64NetworkMetricsInMap(networkMetrics map[string
 	currentNonce := sm.uint64Metrics[common.MetricNonce]
 	nonceAtEpochStart := sm.uint64Metrics[common.MetricNonceAtEpochStart]
 	networkMetrics[common.MetricNonce] = currentNonce
+	networkMetrics[common.MetricBlockTimestamp] = sm.uint64Metrics[common.MetricBlockTimestamp]
 	networkMetrics[common.MetricHighestFinalBlock] = sm.uint64Metrics[common.MetricHighestFinalBlock]
 	networkMetrics[common.MetricCurrentRound] = currentRound
 	networkMetrics[common.MetricRoundAtEpochStart] = roundNumberAtEpochStart

--- a/statusHandler/statusMetricsProvider_test.go
+++ b/statusHandler/statusMetricsProvider_test.go
@@ -231,6 +231,7 @@ func TestStatusMetrics_NetworkMetrics(t *testing.T) {
 	sm.SetUInt64Value(common.MetricCurrentRound, 200)
 	sm.SetUInt64Value(common.MetricRoundAtEpochStart, 100)
 	sm.SetUInt64Value(common.MetricNonce, 180)
+	sm.SetUInt64Value(common.MetricBlockTimestamp, 18000)
 	sm.SetUInt64Value(common.MetricHighestFinalBlock, 181)
 	sm.SetUInt64Value(common.MetricNonceAtEpochStart, 95)
 	sm.SetUInt64Value(common.MetricEpochNumber, 1)
@@ -240,6 +241,7 @@ func TestStatusMetrics_NetworkMetrics(t *testing.T) {
 		"erd_current_round":                  uint64(200),
 		"erd_round_at_epoch_start":           uint64(100),
 		"erd_nonce":                          uint64(180),
+		"erd_block_timestamp":                uint64(18000),
 		"erd_highest_final_nonce":            uint64(181),
 		"erd_nonce_at_epoch_start":           uint64(95),
 		"erd_epoch_number":                   uint64(1),
@@ -270,6 +272,7 @@ func TestStatusMetrics_StatusMetricsMapWithoutP2P(t *testing.T) {
 	sm.SetUInt64Value(common.MetricCurrentRound, 100)
 	sm.SetUInt64Value(common.MetricRoundAtEpochStart, 200)
 	sm.SetUInt64Value(common.MetricNonce, 300)
+	sm.SetUInt64Value(common.MetricBlockTimestamp, 30000)
 	sm.SetStringValue(common.MetricAppVersion, "400")
 	sm.SetUInt64Value(common.MetricRoundsPassedInCurrentEpoch, 95)
 	sm.SetUInt64Value(common.MetricNoncesPassedInCurrentEpoch, 1)
@@ -281,6 +284,7 @@ func TestStatusMetrics_StatusMetricsMapWithoutP2P(t *testing.T) {
 	require.Equal(t, uint64(100), res[common.MetricCurrentRound])
 	require.Equal(t, uint64(200), res[common.MetricRoundAtEpochStart])
 	require.Equal(t, uint64(300), res[common.MetricNonce])
+	require.Equal(t, uint64(30000), res[common.MetricBlockTimestamp])
 	require.Equal(t, "400", res[common.MetricAppVersion])
 	require.NotContains(t, res, common.MetricRoundsPassedInCurrentEpoch)
 	require.NotContains(t, res, common.MetricNoncesPassedInCurrentEpoch)


### PR DESCRIPTION
## Reasoning behind the pull request
- added block timestamp + scripts update for the round duration
- added the possibility to define the round duration in the local scripts (related PR: https://github.com/multiversx/mx-chain-deploy-go/pull/52) 
  
## Proposed changes
- 
- 
- 

## Testing procedure
- standard system test
- test that the proxy's API endpoint route `/network/status/0`, `/network/status/1` ... `/network/status/4294967295` returns the new field called `erd_block_timestamp` that matches the block's timestamp.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
