### PR TITLE
Fix gas for view "getAllNodeStates"

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -994,6 +994,7 @@ const (
 	AutoBalanceDataTriesFlag                           core.EnableEpochFlag = "AutoBalanceDataTriesFlag"
 	MigrateDataTrieFlag                                core.EnableEpochFlag = "MigrateDataTrieFlag"
 	FixDelegationChangeOwnerOnAccountFlag              core.EnableEpochFlag = "FixDelegationChangeOwnerOnAccountFlag"
+	FixDelegationGetAllNodeStatesViewGasFlag           core.EnableEpochFlag = "FixDelegationGetAllNodeStatesViewGasFlag"
 	FixOOGReturnCodeFlag                               core.EnableEpochFlag = "FixOOGReturnCodeFlag"
 	DeterministicSortOnValidatorsInfoFixFlag           core.EnableEpochFlag = "DeterministicSortOnValidatorsInfoFixFlag"
 	DynamicGasCostForDataTrieStorageLoadFlag           core.EnableEpochFlag = "DynamicGasCostForDataTrieStorageLoadFlag"

--- a/common/enablers/enableEpochsHandler.go
+++ b/common/enablers/enableEpochsHandler.go
@@ -629,6 +629,12 @@ func (handler *enableEpochsHandler) createAllFlagsMap() {
 			},
 			activationEpoch: handler.enableEpochsConfig.FixDelegationChangeOwnerOnAccountEnableEpoch,
 		},
+		common.FixDelegationGetAllNodeStatesViewGasFlag: {
+			isActiveInEpoch: func(epoch uint32) bool {
+				return epoch >= handler.enableEpochsConfig.FixDelegationGetAllNodeStatesViewEnableEpoch
+			},
+			activationEpoch: handler.enableEpochsConfig.FixDelegationGetAllNodeStatesViewEnableEpoch,
+		},
 		common.FixOOGReturnCodeFlag: {
 			isActiveInEpoch: func(epoch uint32) bool {
 				return epoch >= handler.enableEpochsConfig.FixOOGReturnCodeEnableEpoch

--- a/common/enablers/enableEpochsHandler_test.go
+++ b/common/enablers/enableEpochsHandler_test.go
@@ -114,6 +114,7 @@ func createEnableEpochsConfig() config.EnableEpochs {
 		StakingV4Step2EnableEpoch:                                97,
 		StakingV4Step3EnableEpoch:                                98,
 		AlwaysMergeContextsInEEIEnableEpoch:                      99,
+		FixDelegationGetAllNodeStatesViewEnableEpoch:             100,
 	}
 }
 
@@ -304,6 +305,7 @@ func TestEnableEpochsHandler_IsFlagEnabled(t *testing.T) {
 	require.True(t, handler.IsFlagEnabled(common.AutoBalanceDataTriesFlag))
 	require.True(t, handler.IsFlagEnabled(common.MigrateDataTrieFlag))
 	require.True(t, handler.IsFlagEnabled(common.FixDelegationChangeOwnerOnAccountFlag))
+	require.True(t, handler.IsFlagEnabled(common.FixDelegationGetAllNodeStatesViewGasFlag))
 	require.True(t, handler.IsFlagEnabled(common.FixOOGReturnCodeFlag))
 	require.True(t, handler.IsFlagEnabled(common.DeterministicSortOnValidatorsInfoFixFlag))
 	require.True(t, handler.IsFlagEnabled(common.DynamicGasCostForDataTrieStorageLoadFlag))
@@ -420,6 +422,7 @@ func TestEnableEpochsHandler_GetActivationEpoch(t *testing.T) {
 	require.Equal(t, cfg.AutoBalanceDataTriesEnableEpoch, handler.GetActivationEpoch(common.AutoBalanceDataTriesFlag))
 	require.Equal(t, cfg.MigrateDataTrieEnableEpoch, handler.GetActivationEpoch(common.MigrateDataTrieFlag))
 	require.Equal(t, cfg.FixDelegationChangeOwnerOnAccountEnableEpoch, handler.GetActivationEpoch(common.FixDelegationChangeOwnerOnAccountFlag))
+	require.Equal(t, cfg.FixDelegationGetAllNodeStatesViewEnableEpoch, handler.GetActivationEpoch(common.FixDelegationGetAllNodeStatesViewGasFlag))
 	require.Equal(t, cfg.FixOOGReturnCodeEnableEpoch, handler.GetActivationEpoch(common.FixOOGReturnCodeFlag))
 	require.Equal(t, cfg.DeterministicSortOnValidatorsInfoEnableEpoch, handler.GetActivationEpoch(common.DeterministicSortOnValidatorsInfoFixFlag))
 	require.Equal(t, cfg.DynamicGasCostForDataTrieStorageLoadEnableEpoch, handler.GetActivationEpoch(common.DynamicGasCostForDataTrieStorageLoadFlag))

--- a/config/epochConfig.go
+++ b/config/epochConfig.go
@@ -103,6 +103,7 @@ type EnableEpochs struct {
 	MigrateDataTrieEnableEpoch                               uint32
 	ConsistentTokensValuesLengthCheckEnableEpoch             uint32
 	FixDelegationChangeOwnerOnAccountEnableEpoch             uint32
+	FixDelegationGetAllNodeStatesViewEnableEpoch             uint32
 	DynamicGasCostForDataTrieStorageLoadEnableEpoch          uint32
 	NFTStopCreateEnableEpoch                                 uint32
 	ChangeOwnerAddressCrossShardThroughSCEnableEpoch         uint32

--- a/vm/systemSmartContracts/delegation.go
+++ b/vm/systemSmartContracts/delegation.go
@@ -662,7 +662,7 @@ func (d *delegation) getWhitelistForMerge(args *vmcommon.ContractCallInput) vmco
 		d.eei.AddReturnMessage(args.Function + " is an unknown function")
 		return vmcommon.UserError
 	}
-	returnCode := d.checkArgumentsForGeneralViewFunc(args)
+	returnCode := d.checkArgumentsForGeneralViewFunc(args, d.gasCost.MetaChainSystemSCsCost.DelegationOps)
 	if returnCode != vmcommon.Ok {
 		return returnCode
 	}
@@ -2347,12 +2347,12 @@ func (d *delegation) unStakeAtEndOfEpoch(args *vmcommon.ContractCallInput) vmcom
 	return vmcommon.Ok
 }
 
-func (d *delegation) checkArgumentsForGeneralViewFunc(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
+func (d *delegation) checkArgumentsForGeneralViewFunc(args *vmcommon.ContractCallInput, gasToUse uint64) vmcommon.ReturnCode {
 	if args.CallValue.Cmp(zero) != 0 {
 		d.eei.AddReturnMessage(vm.ErrCallValueMustBeZero.Error())
 		return vmcommon.UserError
 	}
-	err := d.eei.UseGas(d.gasCost.MetaChainSystemSCsCost.DelegationOps)
+	err := d.eei.UseGas(gasToUse)
 	if err != nil {
 		d.eei.AddReturnMessage(err.Error())
 		return vmcommon.OutOfGas
@@ -2366,7 +2366,7 @@ func (d *delegation) checkArgumentsForGeneralViewFunc(args *vmcommon.ContractCal
 }
 
 func (d *delegation) getTotalCumulatedRewards(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-	returnCode := d.checkArgumentsForGeneralViewFunc(args)
+	returnCode := d.checkArgumentsForGeneralViewFunc(args, d.gasCost.MetaChainSystemSCsCost.DelegationOps)
 	if returnCode != vmcommon.Ok {
 		return returnCode
 	}
@@ -2395,7 +2395,7 @@ func (d *delegation) getTotalCumulatedRewards(args *vmcommon.ContractCallInput) 
 }
 
 func (d *delegation) getNumUsers(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-	returnCode := d.checkArgumentsForGeneralViewFunc(args)
+	returnCode := d.checkArgumentsForGeneralViewFunc(args, d.gasCost.MetaChainSystemSCsCost.DelegationOps)
 	if returnCode != vmcommon.Ok {
 		return returnCode
 	}
@@ -2413,7 +2413,7 @@ func (d *delegation) getNumUsers(args *vmcommon.ContractCallInput) vmcommon.Retu
 }
 
 func (d *delegation) getTotalUnStaked(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-	returnCode := d.checkArgumentsForGeneralViewFunc(args)
+	returnCode := d.checkArgumentsForGeneralViewFunc(args, d.gasCost.MetaChainSystemSCsCost.DelegationOps)
 	if returnCode != vmcommon.Ok {
 		return returnCode
 	}
@@ -2429,7 +2429,7 @@ func (d *delegation) getTotalUnStaked(args *vmcommon.ContractCallInput) vmcommon
 }
 
 func (d *delegation) getTotalActiveStake(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-	returnCode := d.checkArgumentsForGeneralViewFunc(args)
+	returnCode := d.checkArgumentsForGeneralViewFunc(args, d.gasCost.MetaChainSystemSCsCost.DelegationOps)
 	if returnCode != vmcommon.Ok {
 		return returnCode
 	}
@@ -2445,7 +2445,7 @@ func (d *delegation) getTotalActiveStake(args *vmcommon.ContractCallInput) vmcom
 }
 
 func (d *delegation) getNumNodes(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-	returnCode := d.checkArgumentsForGeneralViewFunc(args)
+	returnCode := d.checkArgumentsForGeneralViewFunc(args, d.gasCost.MetaChainSystemSCsCost.DelegationOps)
 	if returnCode != vmcommon.Ok {
 		return returnCode
 	}
@@ -2467,7 +2467,7 @@ func (d *delegation) correctNodesStatus(args *vmcommon.ContractCallInput) vmcomm
 		d.eei.AddReturnMessage(args.Function + " is an unknown function")
 		return vmcommon.UserError
 	}
-	returnCode := d.checkArgumentsForGeneralViewFunc(args)
+	returnCode := d.checkArgumentsForGeneralViewFunc(args, d.gasCost.MetaChainSystemSCsCost.DelegationOps)
 	if returnCode != vmcommon.Ok {
 		return returnCode
 	}
@@ -2549,7 +2549,16 @@ func createMergedListWithoutDuplicates(status *DelegationContractStatus, blsKeys
 }
 
 func (d *delegation) getAllNodeStates(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-	returnCode := d.checkArgumentsForGeneralViewFunc(args)
+	var gasToUse uint64
+
+	if d.enableEpochsHandler.IsFlagEnabled(common.FixDelegationGetAllNodeStatesViewGasFlag) {
+		gasToUse = d.gasCost.MetaChainSystemSCsCost.GetAllNodeStates
+	} else {
+		gasToUse = d.gasCost.MetaChainSystemSCsCost.DelegationOps
+	}
+
+	returnCode := d.checkArgumentsForGeneralViewFunc(args, gasToUse)
+
 	if returnCode != vmcommon.Ok {
 		return returnCode
 	}
@@ -2585,7 +2594,7 @@ func (d *delegation) getAllNodeStates(args *vmcommon.ContractCallInput) vmcommon
 }
 
 func (d *delegation) getContractConfig(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-	returnCode := d.checkArgumentsForGeneralViewFunc(args)
+	returnCode := d.checkArgumentsForGeneralViewFunc(args, d.gasCost.MetaChainSystemSCsCost.DelegationOps)
 	if returnCode != vmcommon.Ok {
 		return returnCode
 	}
@@ -2891,7 +2900,7 @@ func (d *delegation) setMetaData(args *vmcommon.ContractCallInput) vmcommon.Retu
 }
 
 func (d *delegation) getMetaData(args *vmcommon.ContractCallInput) vmcommon.ReturnCode {
-	returnCode := d.checkArgumentsForGeneralViewFunc(args)
+	returnCode := d.checkArgumentsForGeneralViewFunc(args, d.gasCost.MetaChainSystemSCsCost.DelegationOps)
 	if returnCode != vmcommon.Ok {
 		return returnCode
 	}

--- a/vm/systemSmartContracts/delegation.go
+++ b/vm/systemSmartContracts/delegation.go
@@ -127,6 +127,7 @@ func NewDelegationSystemSC(args ArgsNewDelegation) (*delegation, error) {
 		common.ComputeRewardCheckpointFlag,
 		common.StakingV2FlagAfterEpoch,
 		common.FixDelegationChangeOwnerOnAccountFlag,
+		common.FixDelegationGetAllNodeStatesViewGasFlag,
 		common.MultiClaimOnDelegationFlag,
 	})
 	if err != nil {


### PR DESCRIPTION
## Reasoning behind the pull request
- Delegator SC's "getAllNodeState" view uses DelegationOps gas
- There is a gas amount in the config called GetAllNodeStates. So I guess "getAllNodeState" should use it instead of DelegationOps
- GetAllNodeStates = 20 * DelegationOps
  
## Proposed changes
- Added a flag "FixDelegationGetAllNodeStatesViewGasFlag"
- Used the gas value "GetAllNodeStates" when the above flag is activated
- Added and changed tests accordingly

## Testing procedure
- go test ./... on a Ubuntu AMD64 server

## Notes
- I'm not used to the mx-chain-go codebase therefore I might have missed something, I mainly checked at the pre-existing tests to learn what I had to do in order to fix this issue
- I see y'all are pushing fixes into the rc/v1.7.0 branch so I did the same, maybe I had to create the PR to target master or another branch?

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
