### PR TITLE
[sovereign] Fix non payable by sc cross shard

### DIFF
--- a/process/smartContract/hooks/blockChainHook.go
+++ b/process/smartContract/hooks/blockChainHook.go
@@ -556,7 +556,11 @@ func (bh *BlockChainHookImpl) IsPayable(sndAddress []byte, recvAddress []byte) (
 		return true, nil
 	}
 
-	userAcc, err := bh.GetUserAccount(recvAddress)
+	return bh.baseIsPayable(sndAddress, recvAddress)
+}
+
+func (bh *BlockChainHookImpl) baseIsPayable(sndAddress []byte, rcvAddress []byte) (bool, error) {
+	userAcc, err := bh.GetUserAccount(rcvAddress)
 	if err == state.ErrAccNotFound {
 		return false, nil
 	}

--- a/process/smartContract/hooks/export_test.go
+++ b/process/smartContract/hooks/export_test.go
@@ -4,3 +4,8 @@ package hooks
 func (bh *BlockChainHookImpl) GetMapActivationEpochs() map[uint32]struct{} {
 	return bh.mapActivationEpochs
 }
+
+// IsCrossShardForPayableCheck -
+func (sbh *sovereignBlockChainHook) IsCrossShardForPayableCheck(sndAddress []byte, rcvAddress []byte) bool {
+	return sbh.isCrossShardForPayableCheck(sndAddress, rcvAddress)
+}

--- a/process/smartContract/hooks/sovereignBlockChainHook.go
+++ b/process/smartContract/hooks/sovereignBlockChainHook.go
@@ -78,15 +78,11 @@ func (sbh *sovereignBlockChainHook) IsPayable(sndAddress []byte, rcvAddress []by
 		return true, nil
 	}
 
-	if sbh.isNotSystemAccountAndCrossShardInSovereign(sndAddress, rcvAddress) {
+	if sbh.isCrossShardForPayableCheck(sndAddress, rcvAddress) {
 		return true, nil
 	}
 
 	return sbh.baseIsPayable(sndAddress, rcvAddress)
-}
-
-func (sbh *sovereignBlockChainHook) isNotSystemAccountAndCrossShardInSovereign(sndAddress []byte, rcvAddress []byte) bool {
-	return !core.IsSystemAccountAddress(rcvAddress) && sbh.isCrossShardForPayableCheck(sndAddress, rcvAddress)
 }
 
 func (sbh *sovereignBlockChainHook) isCrossShardForPayableCheck(sndAddress []byte, rcvAddress []byte) bool {

--- a/process/smartContract/hooks/sovereignBlockChainHook_test.go
+++ b/process/smartContract/hooks/sovereignBlockChainHook_test.go
@@ -154,7 +154,7 @@ func TestSovereignBlockChainHook_IsPayable(t *testing.T) {
 		require.True(t, payable)
 	})
 
-	t.Run("sender is sc, receiver is sys acc address, should be cross payable", func(t *testing.T) {
+	t.Run("sender is sc, receiver is esdt sc address, should be cross payable", func(t *testing.T) {
 		sender := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 255, 255}
 		receiver := vm.ESDTSCAddress
 

--- a/process/smartContract/hooks/sovereignBlockChainHook_test.go
+++ b/process/smartContract/hooks/sovereignBlockChainHook_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/multiversx/mx-chain-go/process/mock"
 	"github.com/multiversx/mx-chain-go/process/smartContract/hooks"
 	stateMock "github.com/multiversx/mx-chain-go/testscommon/state"
+	"github.com/multiversx/mx-chain-go/vm"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	vmcommonBuiltInFunctions "github.com/multiversx/mx-chain-vm-common-go/builtInFunctions"
 	"github.com/stretchr/testify/require"
@@ -127,4 +128,20 @@ func TestSovereignBlockChainHook_ProcessBuiltInFunction(t *testing.T) {
 		require.True(t, getReceiverAccountCalled.IsSet())
 		require.Equal(t, int64(1), ctSaveAccount.Get())
 	})
+}
+
+func TestSovereignBlockChainHook_isCrossShardForPayableCheck(t *testing.T) {
+	t.Parallel()
+
+	args := createMockBlockChainHookArgs()
+	bh, _ := hooks.NewBlockChainHookImpl(args)
+	sbh, _ := hooks.NewSovereignBlockChainHook(bh)
+
+	userAddr := make([]byte, 32)
+
+	require.True(t, sbh.IsCrossShardForPayableCheck(userAddr, vm.ESDTSCAddress))
+	require.True(t, sbh.IsCrossShardForPayableCheck(vm.StakingSCAddress, userAddr))
+
+	require.False(t, sbh.IsCrossShardForPayableCheck(userAddr, userAddr))
+	require.False(t, sbh.IsCrossShardForPayableCheck(vm.StakingSCAddress, vm.ESDTSCAddress))
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- When checking the payable property for a "cross" shard (meta chain) system account(esdt, delegation, etc.)  for calls between scs -> sys accounts, the cross check in `BlockChainHook` would fail to detect it as "cross shard". This caused reading meta data properties for system accounts for payable byte, which is by default false for all of them.
## Proposed changes
- "Faked" cross shard(to meta sys accounts) checks in blockchain hook.
- Newly created func for sovereign blockchain hook `isCrossShardForPayableCheck` should be equivalent to `isNotSystemAccountAndCrossShard` from normal blockchain hook

## Testing procedure
- Tested on a separate branch with chain simulator.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
