### PR TITLE
[sovereign] Add factory for NodesSetupChecker to override it easily.

### DIFF
--- a/cmd/sovereignnode/sovereignNodeRunner.go
+++ b/cmd/sovereignnode/sovereignNodeRunner.go
@@ -51,6 +51,7 @@ import (
 	statusComp "github.com/multiversx/mx-chain-go/factory/status"
 	"github.com/multiversx/mx-chain-go/factory/statusCore"
 	"github.com/multiversx/mx-chain-go/genesis"
+	"github.com/multiversx/mx-chain-go/genesis/checking"
 	"github.com/multiversx/mx-chain-go/genesis/parsing"
 	genesisProcess "github.com/multiversx/mx-chain-go/genesis/process"
 	"github.com/multiversx/mx-chain-go/health"
@@ -1377,6 +1378,7 @@ func (snr *sovereignNodeRunner) CreateManagedProcessComponents(
 		OutGoingOperationsPool:                outGoingOperationsPool,
 		DataCodec:                             dataCodec,
 		TopicsChecker:                         topicsChecker,
+		NodesSetupCheckerFactory:              checking.NewNodesSetupCheckerFactory(),
 	}
 	processComponentsFactory, err := processComp.NewProcessComponentsFactory(processArgs)
 	if err != nil {

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -180,6 +180,7 @@ type ProcessComponentsFactoryArgs struct {
 	OutGoingOperationsPool                block.OutGoingOperationsPool
 	DataCodec                             sovereign.DataCodecProcessor
 	TopicsChecker                         sovereign.TopicsChecker
+	NodesSetupCheckerFactory              checking.NodeSetupCheckerFactory
 }
 
 type processComponentsFactory struct {
@@ -234,6 +235,7 @@ type processComponentsFactory struct {
 	outGoingOperationsPool                block.OutGoingOperationsPool
 	dataCodec                             sovereign.DataCodecProcessor
 	topicsChecker                         sovereign.TopicsChecker
+	nodesSetupCheckerFactory              checking.NodeSetupCheckerFactory
 }
 
 // NewProcessComponentsFactory will return a new instance of processComponentsFactory
@@ -287,6 +289,7 @@ func NewProcessComponentsFactory(args ProcessComponentsFactoryArgs) (*processCom
 		outGoingOperationsPool:                args.OutGoingOperationsPool,
 		dataCodec:                             args.DataCodec,
 		topicsChecker:                         args.TopicsChecker,
+		nodesSetupCheckerFactory:              args.NodesSetupCheckerFactory,
 	}, nil
 }
 
@@ -668,7 +671,7 @@ func (pcf *processComponentsFactory) Create() (*processComponents, error) {
 		return nil, errors.New("invalid genesis node price")
 	}
 
-	nodesSetupChecker, err := checking.NewNodesSetupChecker(
+	nodesSetupChecker, err := pcf.nodesSetupCheckerFactory.Create(
 		pcf.accountsParser,
 		genesisNodePrice,
 		pcf.coreData.ValidatorPubKeyConverter(),

--- a/factory/processing/processComponents_test.go
+++ b/factory/processing/processComponents_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/multiversx/mx-chain-go/factory/mock"
 	processComp "github.com/multiversx/mx-chain-go/factory/processing"
 	"github.com/multiversx/mx-chain-go/genesis"
+	"github.com/multiversx/mx-chain-go/genesis/checking"
 	genesisMocks "github.com/multiversx/mx-chain-go/genesis/mock"
 	genesisProcess "github.com/multiversx/mx-chain-go/genesis/process"
 	testsMocks "github.com/multiversx/mx-chain-go/integrationTests/mock"
@@ -285,6 +286,7 @@ func createMockProcessComponentsFactoryArgs() processComp.ProcessComponentsFacto
 		DataCodec:                             &sovereign.DataCodecMock{},
 		TopicsChecker:                         &sovereign.TopicsCheckerMock{},
 		RunTypeComponents:                     components.GetRunTypeComponents(),
+		NodesSetupCheckerFactory:              checking.NewNodesSetupCheckerFactory(),
 	}
 
 	args.State = components.GetStateComponents(args.CoreData, args.StatusCoreComponents)

--- a/genesis/checking/interface.go
+++ b/genesis/checking/interface.go
@@ -1,0 +1,25 @@
+package checking
+
+import (
+	"math/big"
+
+	"github.com/multiversx/mx-chain-core-go/core"
+	crypto "github.com/multiversx/mx-chain-crypto-go"
+	"github.com/multiversx/mx-chain-go/genesis"
+	"github.com/multiversx/mx-chain-go/sharding/nodesCoordinator"
+)
+
+type NodeSetupCheckerFactory interface {
+	Create(
+		accountsParser genesis.AccountsParser,
+		initialNodePrice *big.Int,
+		validatorPubkeyConverter core.PubkeyConverter,
+		keyGenerator crypto.KeyGenerator,
+	) (NodeSetupChecker, error)
+	IsInterfaceNil() bool
+}
+
+type NodeSetupChecker interface {
+	Check(initialNodes []nodesCoordinator.GenesisNodeInfoHandler) error
+	IsInterfaceNil() bool
+}

--- a/genesis/checking/nodesSetupChecker.go
+++ b/genesis/checking/nodesSetupChecker.go
@@ -31,38 +31,6 @@ type delegationAddress struct {
 	address string
 }
 
-// NewNodesSetupChecker will create a node setup checker able to check the initial nodes against the provided genesis values
-func NewNodesSetupChecker(
-	accountsParser genesis.AccountsParser,
-	initialNodePrice *big.Int,
-	validatorPubkeyConverter core.PubkeyConverter,
-	keyGenerator crypto.KeyGenerator,
-) (*nodeSetupChecker, error) {
-	if check.IfNil(accountsParser) {
-		return nil, genesis.ErrNilAccountsParser
-	}
-	if initialNodePrice == nil {
-		return nil, genesis.ErrNilInitialNodePrice
-	}
-	if initialNodePrice.Cmp(big.NewInt(minimumAcceptedNodePrice)) < 0 {
-		return nil, fmt.Errorf("%w, minimum accepted is %d",
-			genesis.ErrInvalidInitialNodePrice, minimumAcceptedNodePrice)
-	}
-	if check.IfNil(validatorPubkeyConverter) {
-		return nil, genesis.ErrNilPubkeyConverter
-	}
-	if check.IfNil(keyGenerator) {
-		return nil, genesis.ErrNilKeyGenerator
-	}
-
-	return &nodeSetupChecker{
-		accountsParser:           accountsParser,
-		initialNodePrice:         initialNodePrice,
-		validatorPubkeyConverter: validatorPubkeyConverter,
-		keyGenerator:             keyGenerator,
-	}, nil
-}
-
 // Check will check that each and every initial node has a backed staking address
 // also, it checks that the amount staked (either directly or delegated) matches exactly the total
 // staked value defined in the genesis file

--- a/genesis/checking/nodesSetupCheckerFactory.go
+++ b/genesis/checking/nodesSetupCheckerFactory.go
@@ -1,0 +1,53 @@
+package checking
+
+import (
+	"fmt"
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/core/check"
+	crypto "github.com/multiversx/mx-chain-crypto-go"
+	"github.com/multiversx/mx-chain-go/genesis"
+	"math/big"
+)
+
+type nodesSetupCheckerFactory struct{}
+
+func NewNodesSetupCheckerFactory() *nodesSetupCheckerFactory {
+	return &nodesSetupCheckerFactory{}
+}
+
+// Create will create a node setup checker able to check the initial nodes against the provided genesis values
+func (scf *nodesSetupCheckerFactory) Create(
+	accountsParser genesis.AccountsParser,
+	initialNodePrice *big.Int,
+	validatorPubkeyConverter core.PubkeyConverter,
+	keyGenerator crypto.KeyGenerator,
+) (NodeSetupChecker, error) {
+	if check.IfNil(accountsParser) {
+		return nil, genesis.ErrNilAccountsParser
+	}
+	if initialNodePrice == nil {
+		return nil, genesis.ErrNilInitialNodePrice
+	}
+	if initialNodePrice.Cmp(big.NewInt(minimumAcceptedNodePrice)) < 0 {
+		return nil, fmt.Errorf("%w, minimum accepted is %d",
+			genesis.ErrInvalidInitialNodePrice, minimumAcceptedNodePrice)
+	}
+	if check.IfNil(validatorPubkeyConverter) {
+		return nil, genesis.ErrNilPubkeyConverter
+	}
+	if check.IfNil(keyGenerator) {
+		return nil, genesis.ErrNilKeyGenerator
+	}
+
+	return &nodeSetupChecker{
+		accountsParser:           accountsParser,
+		initialNodePrice:         initialNodePrice,
+		validatorPubkeyConverter: validatorPubkeyConverter,
+		keyGenerator:             keyGenerator,
+	}, nil
+}
+
+// IsInterfaceNil returns if underlying object is true
+func (f *nodesSetupCheckerFactory) IsInterfaceNil() bool {
+	return f == nil
+}

--- a/genesis/checking/nodesSetupChecker_test.go
+++ b/genesis/checking/nodesSetupChecker_test.go
@@ -33,7 +33,7 @@ func createEmptyInitialAccount() *data.InitialAccount {
 func TestNewNodesSetupChecker_NilGenesisParserShouldErr(t *testing.T) {
 	t.Parallel()
 
-	nsc, err := checking.NewNodesSetupChecker(
+	nsc, err := checking.NewNodesSetupCheckerFactory().Create(
 		nil,
 		big.NewInt(0),
 		testscommon.NewPubkeyConverterMock(32),
@@ -47,7 +47,7 @@ func TestNewNodesSetupChecker_NilGenesisParserShouldErr(t *testing.T) {
 func TestNewNodesSetupChecker_NilInitialNodePriceShouldErr(t *testing.T) {
 	t.Parallel()
 
-	nsc, err := checking.NewNodesSetupChecker(
+	nsc, err := checking.NewNodesSetupCheckerFactory().Create(
 		&mock.AccountsParserStub{},
 		nil,
 		testscommon.NewPubkeyConverterMock(32),
@@ -61,7 +61,7 @@ func TestNewNodesSetupChecker_NilInitialNodePriceShouldErr(t *testing.T) {
 func TestNewNodesSetupChecker_InvalidInitialNodePriceShouldErr(t *testing.T) {
 	t.Parallel()
 
-	nsc, err := checking.NewNodesSetupChecker(
+	nsc, err := checking.NewNodesSetupCheckerFactory().Create(
 		&mock.AccountsParserStub{},
 		big.NewInt(-1),
 		testscommon.NewPubkeyConverterMock(32),
@@ -75,7 +75,7 @@ func TestNewNodesSetupChecker_InvalidInitialNodePriceShouldErr(t *testing.T) {
 func TestNewNodesSetupChecker_NilValidatorPubkeyConverterShouldErr(t *testing.T) {
 	t.Parallel()
 
-	nsc, err := checking.NewNodesSetupChecker(
+	nsc, err := checking.NewNodesSetupCheckerFactory().Create(
 		&mock.AccountsParserStub{},
 		big.NewInt(0),
 		nil,
@@ -89,7 +89,7 @@ func TestNewNodesSetupChecker_NilValidatorPubkeyConverterShouldErr(t *testing.T)
 func TestNewNodesSetupChecker_NilKeyGeneratorShouldErr(t *testing.T) {
 	t.Parallel()
 
-	nsc, err := checking.NewNodesSetupChecker(
+	nsc, err := checking.NewNodesSetupCheckerFactory().Create(
 		&mock.AccountsParserStub{},
 		big.NewInt(0),
 		testscommon.NewPubkeyConverterMock(32),
@@ -103,7 +103,7 @@ func TestNewNodesSetupChecker_NilKeyGeneratorShouldErr(t *testing.T) {
 func TestNewNodesSetupChecker_ShouldWork(t *testing.T) {
 	t.Parallel()
 
-	nsc, err := checking.NewNodesSetupChecker(
+	nsc, err := checking.NewNodesSetupCheckerFactory().Create(
 		&mock.AccountsParserStub{},
 		big.NewInt(0),
 		testscommon.NewPubkeyConverterMock(32),
@@ -123,7 +123,7 @@ func TestNewNodesSetupChecker_CheckNotAValidPubkeyShouldErr(t *testing.T) {
 	ia.SetAddressBytes([]byte("staked address"))
 
 	expectedErr := errors.New("expected error")
-	nsc, _ := checking.NewNodesSetupChecker(
+	nsc, _ := checking.NewNodesSetupCheckerFactory().Create(
 		&mock.AccountsParserStub{
 			InitialAccountsCalled: func() []genesis.InitialAccountHandler {
 				return []genesis.InitialAccountHandler{ia}
@@ -157,7 +157,7 @@ func TestNewNodeSetupChecker_CheckNotStakedShouldErr(t *testing.T) {
 	ia := createEmptyInitialAccount()
 	ia.SetAddressBytes([]byte("staked address"))
 
-	nsc, _ := checking.NewNodesSetupChecker(
+	nsc, _ := checking.NewNodesSetupCheckerFactory().Create(
 		&mock.AccountsParserStub{
 			InitialAccountsCalled: func() []genesis.InitialAccountHandler {
 				return []genesis.InitialAccountHandler{ia}
@@ -189,7 +189,7 @@ func TestNewNodeSetupChecker_CheckNotEnoughStakedShouldErr(t *testing.T) {
 	ia.StakingValue = big.NewInt(0).Set(nodePrice)
 	ia.SetAddressBytes([]byte("staked address"))
 
-	nsc, _ := checking.NewNodesSetupChecker(
+	nsc, _ := checking.NewNodesSetupCheckerFactory().Create(
 		&mock.AccountsParserStub{
 			InitialAccountsCalled: func() []genesis.InitialAccountHandler {
 				return []genesis.InitialAccountHandler{ia}
@@ -221,7 +221,7 @@ func TestNewNodeSetupChecker_CheckTooMuchStakedShouldErr(t *testing.T) {
 	ia.StakingValue = big.NewInt(0).Set(nodePrice)
 	ia.SetAddressBytes([]byte("staked address"))
 
-	nsc, _ := checking.NewNodesSetupChecker(
+	nsc, _ := checking.NewNodesSetupCheckerFactory().Create(
 		&mock.AccountsParserStub{
 			InitialAccountsCalled: func() []genesis.InitialAccountHandler {
 				return []genesis.InitialAccountHandler{ia}
@@ -253,7 +253,7 @@ func TestNewNodeSetupChecker_CheckNotEnoughDelegatedShouldErr(t *testing.T) {
 	ia.Delegation.SetAddressBytes([]byte("delegated address"))
 	ia.Delegation.Value = big.NewInt(0).Set(nodePrice)
 
-	nsc, _ := checking.NewNodesSetupChecker(
+	nsc, _ := checking.NewNodesSetupCheckerFactory().Create(
 		&mock.AccountsParserStub{
 			InitialAccountsCalled: func() []genesis.InitialAccountHandler {
 				return []genesis.InitialAccountHandler{ia}
@@ -285,7 +285,7 @@ func TestNewNodeSetupChecker_CheckTooMuchDelegatedShouldErr(t *testing.T) {
 	ia.Delegation.SetAddressBytes([]byte("delegated address"))
 	ia.Delegation.Value = big.NewInt(0).Set(nodePrice)
 
-	nsc, _ := checking.NewNodesSetupChecker(
+	nsc, _ := checking.NewNodesSetupCheckerFactory().Create(
 		&mock.AccountsParserStub{
 			InitialAccountsCalled: func() []genesis.InitialAccountHandler {
 				return []genesis.InitialAccountHandler{ia}
@@ -321,7 +321,7 @@ func TestNewNodeSetupChecker_CheckStakedAndDelegatedShouldWork(t *testing.T) {
 	iaDelegated.Delegation.Value = big.NewInt(0).Set(nodePrice)
 	iaDelegated.Delegation.SetAddressBytes([]byte("delegated address"))
 
-	nsc, _ := checking.NewNodesSetupChecker(
+	nsc, _ := checking.NewNodesSetupCheckerFactory().Create(
 		&mock.AccountsParserStub{
 			InitialAccountsCalled: func() []genesis.InitialAccountHandler {
 				return []genesis.InitialAccountHandler{iaDelegated, iaStaked}

--- a/integrationTests/realcomponents/processorRunner.go
+++ b/integrationTests/realcomponents/processorRunner.go
@@ -34,6 +34,7 @@ import (
 	factoryStatus "github.com/multiversx/mx-chain-go/factory/status"
 	factoryStatusCore "github.com/multiversx/mx-chain-go/factory/statusCore"
 	"github.com/multiversx/mx-chain-go/genesis"
+	"github.com/multiversx/mx-chain-go/genesis/checking"
 	"github.com/multiversx/mx-chain-go/genesis/parsing"
 	"github.com/multiversx/mx-chain-go/genesis/process"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm"
@@ -480,6 +481,7 @@ func (pr *ProcessorRunner) createProcessComponents(tb testing.TB) {
 		RunTypeComponents:                     pr.RunTypeComponents,
 		TopicsChecker:                         disabled.NewDisabledTopicsChecker(),
 		DataCodec:                             disabled.NewDisabledDataCodec(),
+		NodesSetupCheckerFactory:              checking.NewNodesSetupCheckerFactory(),
 	}
 
 	processFactory, err := factoryProcessing.NewProcessComponentsFactory(argsProcess)

--- a/node/chainSimulator/components/processComponents.go
+++ b/node/chainSimulator/components/processComponents.go
@@ -22,6 +22,7 @@ import (
 	"github.com/multiversx/mx-chain-go/factory"
 	processComp "github.com/multiversx/mx-chain-go/factory/processing"
 	"github.com/multiversx/mx-chain-go/genesis"
+	"github.com/multiversx/mx-chain-go/genesis/checking"
 	"github.com/multiversx/mx-chain-go/genesis/parsing"
 	process2 "github.com/multiversx/mx-chain-go/genesis/process"
 	"github.com/multiversx/mx-chain-go/process"
@@ -231,6 +232,7 @@ func CreateProcessComponents(args ArgsProcessComponentsHolder) (*processComponen
 		InterceptorsContainerFactoryCreator:   interceptorscontainer.NewShardInterceptorsContainerFactoryCreator(),
 		RequesterContainerFactoryCreator:      requesterscontainer.NewShardRequestersContainerFactoryCreator(),
 		ShardResolversContainerFactoryCreator: resolverscontainer.NewShardResolversContainerFactoryCreator(),
+		NodesSetupCheckerFactory:              checking.NewNodesSetupCheckerFactory(),
 	}
 	processComponentsFactory, err := processComp.NewProcessComponentsFactory(processArgs)
 	if err != nil {

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -52,6 +52,7 @@ import (
 	statusComp "github.com/multiversx/mx-chain-go/factory/status"
 	"github.com/multiversx/mx-chain-go/factory/statusCore"
 	"github.com/multiversx/mx-chain-go/genesis"
+	"github.com/multiversx/mx-chain-go/genesis/checking"
 	"github.com/multiversx/mx-chain-go/genesis/parsing"
 	genesisProcess "github.com/multiversx/mx-chain-go/genesis/process"
 	"github.com/multiversx/mx-chain-go/health"
@@ -1305,6 +1306,7 @@ func (nr *nodeRunner) CreateManagedProcessComponents(
 		RunTypeComponents:                     runTypeComponents,
 		DataCodec:                             disabled.NewDisabledDataCodec(),
 		TopicsChecker:                         disabled.NewDisabledTopicsChecker(),
+		NodesSetupCheckerFactory:              checking.NewNodesSetupCheckerFactory(),
 	}
 	processComponentsFactory, err := processComp.NewProcessComponentsFactory(processArgs)
 	if err != nil {

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -35,6 +35,7 @@ import (
 	statusComp "github.com/multiversx/mx-chain-go/factory/status"
 	"github.com/multiversx/mx-chain-go/factory/statusCore"
 	"github.com/multiversx/mx-chain-go/genesis"
+	"github.com/multiversx/mx-chain-go/genesis/checking"
 	"github.com/multiversx/mx-chain-go/genesis/data"
 	"github.com/multiversx/mx-chain-go/genesis/process"
 	mockCoreComp "github.com/multiversx/mx-chain-go/integrationTests/mock"
@@ -631,6 +632,7 @@ func GetProcessArgs(
 		DataCodec:                             &sovereign.DataCodecMock{},
 		TopicsChecker:                         &sovereign.TopicsCheckerMock{},
 		RunTypeComponents:                     GetRunTypeComponents(),
+		NodesSetupCheckerFactory:              checking.NewNodesSetupCheckerFactory(),
 	}
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request

We need to override the NodesSetupChecker easily for a Sovereign Chain from the `sovereignNodeRunner.go` file. This way we can have `mx-chain-go` as a dependency of a Sovereign Chain GO project and not have to fork the code.

Currently this can be overwritten by implementing a custom `managedProcessComponents` and `processComponentsFactory`, but the `processComponentsFactory` `Create` method has a lot of logic that we would not want to maintain, hence we need an easier way to override the NodesSetupChecker
  
## Proposed changes
Added a NodesSetupCheckerFactory and a NodeSetupChecker interface to allow easier customization.

## Testing procedure
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
