### PR TITLE
Adjust workflow runners (MacOS)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        runs-on: [ubuntu-latest, macos-latest, macos-13-xlarge]
+        runs-on: [ubuntu-latest, macos-13-xlarge]
     runs-on: ${{ matrix.runs-on }}
     name: Build
     steps:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        runs-on: [ubuntu-latest, macos-latest, macos-13-xlarge]
+        runs-on: [ubuntu-latest, macos-13-xlarge]
     runs-on: ${{ matrix.runs-on }}
     name: Build
     steps:


### PR DESCRIPTION
Drop `macos-latest` runner (for some time, that's an M1, as well, but with less memory). For non-ARM64 runners, we could have used `macos-13`. 

However, for practicality, we'll only run the workflows on Ubuntu (AMD64) and MacOS (ARM64).

References:
 - https://github.com/actions/runner-images/issues/9741
 - https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners