### PR TITLE
Rename "keys" into "pairs"

### DIFF
--- a/node/chainSimulator/chainSimulator_test.go
+++ b/node/chainSimulator/chainSimulator_test.go
@@ -245,7 +245,7 @@ func TestChainSimulator_SetEntireState(t *testing.T) {
 		CodeMetadata:     "BQY=",
 		Owner:            "erd1ss6u80ruas2phpmr82r42xnkd6rxy40g9jl69frppl4qez9w2jpsqj8x97",
 		DeveloperRewards: "5401004999998",
-		Keys: map[string]string{
+		Pairs: map[string]string{
 			"73756d": "0a",
 		},
 	}
@@ -328,7 +328,7 @@ func TestChainSimulator_SetEntireStateWithRemoval(t *testing.T) {
 		CodeMetadata:     "BQY=",
 		Owner:            "erd1ss6u80ruas2phpmr82r42xnkd6rxy40g9jl69frppl4qez9w2jpsqj8x97",
 		DeveloperRewards: "5401004999998",
-		Keys: map[string]string{
+		Pairs: map[string]string{
 			"73756d": "0a",
 		},
 	}

--- a/node/chainSimulator/components/testOnlyProcessingNode.go
+++ b/node/chainSimulator/components/testOnlyProcessingNode.go
@@ -468,7 +468,7 @@ func (node *testOnlyProcessingNode) SetStateForAddress(address []byte, addressSt
 		return err
 	}
 
-	err = setKeyValueMap(userAccount, addressState.Keys)
+	err = setKeyValueMap(userAccount, addressState.Pairs)
 	if err != nil {
 		return err
 	}

--- a/node/chainSimulator/components/testOnlyProcessingNode_test.go
+++ b/node/chainSimulator/components/testOnlyProcessingNode_test.go
@@ -271,7 +271,7 @@ func TestTestOnlyProcessingNode_SetStateForAddress(t *testing.T) {
 		Address: "erd1qtc600lryvytxuy4h7vn7xmsy5tw6vuw3tskr75cwnmv4mnyjgsq6e5zgj",
 		Nonce:   &nonce,
 		Balance: "1000000000000000000",
-		Keys: map[string]string{
+		Pairs: map[string]string{
 			"01": "02",
 		},
 	}

--- a/node/chainSimulator/dtos/state.go
+++ b/node/chainSimulator/dtos/state.go
@@ -11,5 +11,5 @@ type AddressState struct {
 	CodeHash         string            `json:"codeHash,omitempty"`
 	DeveloperRewards string            `json:"developerReward,omitempty"`
 	Owner            string            `json:"ownerAddress,omitempty"`
-	Keys             map[string]string `json:"keys,omitempty"`
+	Pairs            map[string]string `json:"pairs,omitempty"`
 }


### PR DESCRIPTION
## Reasoning behind the pull request

The endpoint `/address/:address?withKeys=true` is going to return something of this type:

```
type AccountResponse struct {
	Address         string            `json:"address"`
	Nonce           uint64            `json:"nonce"`
	Balance         string            `json:"balance"`
	Username        string            `json:"username"`
	Code            string            `json:"code"`
	CodeHash        []byte            `json:"codeHash"`
	RootHash        []byte            `json:"rootHash"`
	CodeMetadata    []byte            `json:"codeMetadata"`
	DeveloperReward string            `json:"developerReward"`
	OwnerAddress    string            `json:"ownerAddress"`
	Pairs           map[string]string `json:"pairs,omitempty"`
}
```

Merged PR: https://github.com/multiversx/mx-chain-core-go/pull/298/files

For the sake of coherence, it would be best if the chain simulator uses `pairs` term instead of `keys`.
  
## Proposed changes
- 
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
