### PR TITLE
Chain simulator custom transactions sender component

### DIFF
--- a/node/chainSimulator/chainSimulator_test.go
+++ b/node/chainSimulator/chainSimulator_test.go
@@ -245,7 +245,7 @@ func TestChainSimulator_SetEntireState(t *testing.T) {
 		CodeMetadata:     "BQY=",
 		Owner:            "erd1ss6u80ruas2phpmr82r42xnkd6rxy40g9jl69frppl4qez9w2jpsqj8x97",
 		DeveloperRewards: "5401004999998",
-		Keys: map[string]string{
+		Pairs: map[string]string{
 			"73756d": "0a",
 		},
 	}
@@ -328,7 +328,7 @@ func TestChainSimulator_SetEntireStateWithRemoval(t *testing.T) {
 		CodeMetadata:     "BQY=",
 		Owner:            "erd1ss6u80ruas2phpmr82r42xnkd6rxy40g9jl69frppl4qez9w2jpsqj8x97",
 		DeveloperRewards: "5401004999998",
-		Keys: map[string]string{
+		Pairs: map[string]string{
 			"73756d": "0a",
 		},
 	}

--- a/node/chainSimulator/components/interface.go
+++ b/node/chainSimulator/components/interface.go
@@ -16,3 +16,9 @@ type SyncedBroadcastNetworkHandler interface {
 type APIConfigurator interface {
 	RestApiInterface(shardID uint32) string
 }
+
+// NetworkMessenger defines what a network messenger should do
+type NetworkMessenger interface {
+	Broadcast(topic string, buff []byte)
+	IsInterfaceNil() bool
+}

--- a/node/chainSimulator/components/processComponents.go
+++ b/node/chainSimulator/components/processComponents.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/multiversx/mx-chain-core-go/core/partitioning"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/forking"
 	"github.com/multiversx/mx-chain-go/common/ordering"
@@ -265,7 +266,7 @@ func CreateProcessComponents(args ArgsProcessComponentsHolder) (*processComponen
 		nodeRedundancyHandler:            managedProcessComponents.NodeRedundancyHandler(),
 		currentEpochProvider:             managedProcessComponents.CurrentEpochProvider(),
 		scheduledTxsExecutionHandler:     managedProcessComponents.ScheduledTxsExecutionHandler(),
-		txsSenderHandler:                 managedProcessComponents.TxsSenderHandler(),
+		txsSenderHandler:                 managedProcessComponents.TxsSenderHandler(), // warning: this will be replaced
 		hardforkTrigger:                  managedProcessComponents.HardforkTrigger(),
 		processedMiniBlocksTracker:       managedProcessComponents.ProcessedMiniBlocksTracker(),
 		esdtDataStorageHandlerForAPI:     managedProcessComponents.ESDTDataStorageHandlerForAPI(),
@@ -273,6 +274,30 @@ func CreateProcessComponents(args ArgsProcessComponentsHolder) (*processComponen
 		sentSignatureTracker:             managedProcessComponents.SentSignaturesTracker(),
 		epochStartSystemSCProcessor:      managedProcessComponents.EpochSystemSCProcessor(),
 		managedProcessComponentsCloser:   managedProcessComponents,
+	}
+
+	return replaceWithCustomProcessSubComponents(instance, processArgs)
+}
+
+func replaceWithCustomProcessSubComponents(
+	instance *processComponentsHolder,
+	processArgs processComp.ProcessComponentsFactoryArgs,
+) (*processComponentsHolder, error) {
+	dataPacker, err := partitioning.NewSimpleDataPacker(processArgs.CoreData.InternalMarshalizer())
+	if err != nil {
+		return nil, fmt.Errorf("%w in replaceWithCustomProcessSubComponents", err)
+	}
+
+	argsSyncedTxsSender := ArgsSyncedTxsSender{
+		Marshaller:       processArgs.CoreData.InternalMarshalizer(),
+		ShardCoordinator: processArgs.BootstrapComponents.ShardCoordinator(),
+		NetworkMessenger: processArgs.Network.NetworkMessenger(),
+		DataPacker:       dataPacker,
+	}
+
+	instance.txsSenderHandler, err = NewSyncedTxsSender(argsSyncedTxsSender)
+	if err != nil {
+		return nil, fmt.Errorf("%w in replaceWithCustomProcessSubComponents", err)
 	}
 
 	return instance, nil

--- a/node/chainSimulator/components/syncedTxsSender.go
+++ b/node/chainSimulator/components/syncedTxsSender.go
@@ -1,0 +1,110 @@
+package components
+
+import (
+	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-core-go/marshal"
+	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/dataRetriever"
+	"github.com/multiversx/mx-chain-go/process"
+	"github.com/multiversx/mx-chain-go/process/factory"
+	"github.com/multiversx/mx-chain-go/sharding"
+)
+
+// ArgsSyncedTxsSender is a holder struct for all necessary arguments to create a NewSyncedTxsSender
+type ArgsSyncedTxsSender struct {
+	Marshaller       marshal.Marshalizer
+	ShardCoordinator sharding.Coordinator
+	NetworkMessenger NetworkMessenger
+	DataPacker       process.DataPacker
+}
+
+type syncedTxsSender struct {
+	marshaller       marshal.Marshalizer
+	shardCoordinator sharding.Coordinator
+	networkMessenger NetworkMessenger
+	dataPacker       process.DataPacker
+}
+
+// NewSyncedTxsSender creates a new instance of syncedTxsSender
+func NewSyncedTxsSender(args ArgsSyncedTxsSender) (*syncedTxsSender, error) {
+	if check.IfNil(args.Marshaller) {
+		return nil, process.ErrNilMarshalizer
+	}
+	if check.IfNil(args.ShardCoordinator) {
+		return nil, process.ErrNilShardCoordinator
+	}
+	if check.IfNil(args.NetworkMessenger) {
+		return nil, process.ErrNilMessenger
+	}
+	if check.IfNil(args.DataPacker) {
+		return nil, dataRetriever.ErrNilDataPacker
+	}
+
+	ret := &syncedTxsSender{
+		marshaller:       args.Marshaller,
+		shardCoordinator: args.ShardCoordinator,
+		networkMessenger: args.NetworkMessenger,
+		dataPacker:       args.DataPacker,
+	}
+
+	return ret, nil
+}
+
+// SendBulkTransactions sends the provided transactions as a bulk, optimizing transfer between nodes
+func (sender *syncedTxsSender) SendBulkTransactions(txs []*transaction.Transaction) (uint64, error) {
+	if len(txs) == 0 {
+		return 0, process.ErrNoTxToProcess
+	}
+
+	sender.sendBulkTransactions(txs)
+
+	return uint64(len(txs)), nil
+}
+
+func (sender *syncedTxsSender) sendBulkTransactions(txs []*transaction.Transaction) {
+	transactionsByShards := make(map[uint32][][]byte)
+	for _, tx := range txs {
+		marshalledTx, err := sender.marshaller.Marshal(tx)
+		if err != nil {
+			log.Warn("txsSender.sendBulkTransactions",
+				"marshaller error", err,
+			)
+			continue
+		}
+
+		senderShardId := sender.shardCoordinator.ComputeId(tx.SndAddr)
+		transactionsByShards[senderShardId] = append(transactionsByShards[senderShardId], marshalledTx)
+	}
+
+	for shardId, txsForShard := range transactionsByShards {
+		err := sender.sendBulkTransactionsFromShard(txsForShard, shardId)
+		log.LogIfError(err)
+	}
+}
+
+func (sender *syncedTxsSender) sendBulkTransactionsFromShard(transactions [][]byte, senderShardId uint32) error {
+	// the topic identifier is made of the current shard id and sender's shard id
+	identifier := factory.TransactionTopic + sender.shardCoordinator.CommunicationIdentifier(senderShardId)
+
+	packets, err := sender.dataPacker.PackDataInChunks(transactions, common.MaxBulkTransactionSize)
+	if err != nil {
+		return err
+	}
+
+	for _, buff := range packets {
+		sender.networkMessenger.Broadcast(identifier, buff)
+	}
+
+	return nil
+}
+
+// Close returns nil
+func (sender *syncedTxsSender) Close() error {
+	return nil
+}
+
+// IsInterfaceNil checks if the underlying pointer is nil
+func (sender *syncedTxsSender) IsInterfaceNil() bool {
+	return sender == nil
+}

--- a/node/chainSimulator/components/syncedTxsSender_test.go
+++ b/node/chainSimulator/components/syncedTxsSender_test.go
@@ -1,0 +1,211 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-go/dataRetriever"
+	"github.com/multiversx/mx-chain-go/dataRetriever/mock"
+	"github.com/multiversx/mx-chain-go/process"
+	processMock "github.com/multiversx/mx-chain-go/process/mock"
+	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
+	"github.com/multiversx/mx-chain-go/testscommon/p2pmocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func createMockSyncedTxsSenderArgs() ArgsSyncedTxsSender {
+	return ArgsSyncedTxsSender{
+		Marshaller:       &marshallerMock.MarshalizerMock{},
+		ShardCoordinator: testscommon.NewMultiShardsCoordinatorMock(3),
+		NetworkMessenger: &p2pmocks.MessengerStub{},
+		DataPacker:       &mock.DataPackerStub{},
+	}
+}
+
+func TestNewSyncedTxsSender(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil marshaller should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockSyncedTxsSenderArgs()
+		args.Marshaller = nil
+		sender, err := NewSyncedTxsSender(args)
+
+		assert.Equal(t, process.ErrNilMarshalizer, err)
+		assert.Nil(t, sender)
+	})
+	t.Run("nil shard coordinator should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockSyncedTxsSenderArgs()
+		args.ShardCoordinator = nil
+		sender, err := NewSyncedTxsSender(args)
+
+		assert.Equal(t, process.ErrNilShardCoordinator, err)
+		assert.Nil(t, sender)
+	})
+	t.Run("nil network messenger should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockSyncedTxsSenderArgs()
+		args.NetworkMessenger = nil
+		sender, err := NewSyncedTxsSender(args)
+
+		assert.Equal(t, process.ErrNilMessenger, err)
+		assert.Nil(t, sender)
+	})
+	t.Run("nil data packer should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockSyncedTxsSenderArgs()
+		args.DataPacker = nil
+		sender, err := NewSyncedTxsSender(args)
+
+		assert.Equal(t, dataRetriever.ErrNilDataPacker, err)
+		assert.Nil(t, sender)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockSyncedTxsSenderArgs()
+		sender, err := NewSyncedTxsSender(args)
+
+		assert.Nil(t, err)
+		assert.NotNil(t, sender)
+	})
+}
+
+func TestSyncedTxsSender_IsInterfaceNil(t *testing.T) {
+	t.Parallel()
+
+	var instance *syncedTxsSender
+	assert.True(t, instance.IsInterfaceNil())
+
+	instance = &syncedTxsSender{}
+	assert.False(t, instance.IsInterfaceNil())
+}
+
+func TestSyncedTxsSender_Close(t *testing.T) {
+	t.Parallel()
+
+	args := createMockSyncedTxsSenderArgs()
+	sender, _ := NewSyncedTxsSender(args)
+
+	err := sender.Close()
+	assert.Nil(t, err)
+}
+
+func TestSyncedTxsSender_SendBulkTransactions(t *testing.T) {
+	t.Parallel()
+
+	senderAShard0 := []byte("sender A shard 0")
+	senderBShard1 := []byte("sender B shard 1")
+	senderCShard0 := []byte("sender C shard 0")
+	senderDShard1 := []byte("sender D shard 1")
+	testTransactions := []*transaction.Transaction{
+		{
+			SndAddr: senderAShard0,
+		},
+		{
+			SndAddr: senderBShard1,
+		},
+		{
+			SndAddr: senderCShard0,
+		},
+		{
+			SndAddr: senderDShard1,
+		},
+	}
+	marshaller := &marshallerMock.MarshalizerMock{}
+
+	marshalledTxs := make([][]byte, 0, len(testTransactions))
+	for _, tx := range testTransactions {
+		buff, _ := marshaller.Marshal(tx)
+		marshalledTxs = append(marshalledTxs, buff)
+	}
+
+	mockShardCoordinator := &processMock.ShardCoordinatorStub{
+		ComputeIdCalled: func(address []byte) uint32 {
+			addrString := string(address)
+			if strings.Contains(addrString, "shard 0") {
+				return 0
+			}
+			if strings.Contains(addrString, "shard 1") {
+				return 1
+			}
+
+			return core.MetachainShardId
+		},
+		SelfIdCalled: func() uint32 {
+			return 1
+		},
+		CommunicationIdentifierCalled: func(destShardID uint32) string {
+			if destShardID == 1 {
+				return "_1"
+			}
+			if destShardID < 1 {
+				return fmt.Sprintf("_%d_1", destShardID)
+			}
+
+			return fmt.Sprintf("_1_%d", destShardID)
+		},
+	}
+	sentData := make(map[string][][]byte)
+	netMessenger := &p2pmocks.MessengerStub{
+		BroadcastCalled: func(topic string, buff []byte) {
+			sentData[topic] = append(sentData[topic], buff)
+		},
+	}
+	mockDataPacker := &mock.DataPackerStub{
+		PackDataInChunksCalled: func(data [][]byte, limit int) ([][]byte, error) {
+			return data, nil
+		},
+	}
+
+	t.Run("no transactions provided should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockSyncedTxsSenderArgs()
+		sender, _ := NewSyncedTxsSender(args)
+
+		num, err := sender.SendBulkTransactions(nil)
+		assert.Equal(t, process.ErrNoTxToProcess, err)
+		assert.Zero(t, num)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		args := ArgsSyncedTxsSender{
+			Marshaller:       marshaller,
+			ShardCoordinator: mockShardCoordinator,
+			NetworkMessenger: netMessenger,
+			DataPacker:       mockDataPacker,
+		}
+		sender, _ := NewSyncedTxsSender(args)
+
+		num, err := sender.SendBulkTransactions(testTransactions)
+		assert.Nil(t, err)
+		assert.Equal(t, uint64(4), num)
+
+		expectedSentSliceForShard0 := make([][]byte, 0)
+		expectedSentSliceForShard0 = append(expectedSentSliceForShard0, marshalledTxs[0])
+		expectedSentSliceForShard0 = append(expectedSentSliceForShard0, marshalledTxs[2])
+
+		expectedSentSliceForShard1 := make([][]byte, 0)
+		expectedSentSliceForShard1 = append(expectedSentSliceForShard1, marshalledTxs[1])
+		expectedSentSliceForShard1 = append(expectedSentSliceForShard1, marshalledTxs[3])
+
+		expectedSentMap := map[string][][]byte{
+			"transactions_1":   expectedSentSliceForShard1,
+			"transactions_0_1": expectedSentSliceForShard0,
+		}
+
+		assert.Equal(t, expectedSentMap, sentData)
+
+	})
+}

--- a/node/chainSimulator/components/testOnlyProcessingNode.go
+++ b/node/chainSimulator/components/testOnlyProcessingNode.go
@@ -468,7 +468,7 @@ func (node *testOnlyProcessingNode) SetStateForAddress(address []byte, addressSt
 		return err
 	}
 
-	err = setKeyValueMap(userAccount, addressState.Keys)
+	err = setKeyValueMap(userAccount, addressState.Pairs)
 	if err != nil {
 		return err
 	}

--- a/node/chainSimulator/components/testOnlyProcessingNode_test.go
+++ b/node/chainSimulator/components/testOnlyProcessingNode_test.go
@@ -271,7 +271,7 @@ func TestTestOnlyProcessingNode_SetStateForAddress(t *testing.T) {
 		Address: "erd1qtc600lryvytxuy4h7vn7xmsy5tw6vuw3tskr75cwnmv4mnyjgsq6e5zgj",
 		Nonce:   &nonce,
 		Balance: "1000000000000000000",
-		Keys: map[string]string{
+		Pairs: map[string]string{
 			"01": "02",
 		},
 	}

--- a/node/chainSimulator/dtos/state.go
+++ b/node/chainSimulator/dtos/state.go
@@ -11,5 +11,5 @@ type AddressState struct {
 	CodeHash         string            `json:"codeHash,omitempty"`
 	DeveloperRewards string            `json:"developerReward,omitempty"`
 	Owner            string            `json:"ownerAddress,omitempty"`
-	Keys             map[string]string `json:"keys,omitempty"`
+	Pairs            map[string]string `json:"pairs,omitempty"`
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- the chain simulator uses the same component used by the regular node to broadcast the transactions. The default component contains an accumulator that gathers transactions for about 100 milliseconds and then dispatches them as a group of transactions. The dispatching mechanism uses a data packer to split the accumulated transactions into smaller packets (if required and if it is possible)
- renaming the `keys` to `pairs` (related to https://github.com/multiversx/mx-chain-go/pull/6179):
The endpoint `/address/:address?withKeys=true` is going to return something of this type:

```
type AccountResponse struct {
	Address         string            `json:"address"`
	Nonce           uint64            `json:"nonce"`
	Balance         string            `json:"balance"`
	Username        string            `json:"username"`
	Code            string            `json:"code"`
	CodeHash        []byte            `json:"codeHash"`
	RootHash        []byte            `json:"rootHash"`
	CodeMetadata    []byte            `json:"codeMetadata"`
	DeveloperReward string            `json:"developerReward"`
	OwnerAddress    string            `json:"ownerAddress"`
	Pairs           map[string]string `json:"pairs,omitempty"`
}
```

Merged PR: https://github.com/multiversx/mx-chain-core-go/pull/298/files

For the sake of coherence, it would be best if the chain simulator uses `pairs` term instead of `keys`.
  
## Proposed changes
- add a new transactions send handler that does not accumulate transactions but rather sends them directly, without delay to the network messenger. This component should be used only in the chain simulator, hence the definition and implementation in the `chainSimulator` package.

## Testing procedure
- standard system test (no production code involving the node was touched)
- chain simulator tests should pass

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
