### PR TITLE
FIX: Revert state in sovereign

### DIFF
--- a/process/interface.go
+++ b/process/interface.go
@@ -289,10 +289,16 @@ type ScheduledBlockProcessor interface {
 	IsInterfaceNil() bool
 }
 
+// ValidatorStatsHeader defines a common header which contains validator stats root hash
+type ValidatorStatsHeader interface {
+	data.HeaderHandler
+	GetValidatorStatsRootHash() []byte
+}
+
 // ValidatorStatisticsProcessor is the main interface for validators' consensus participation statistics
 type ValidatorStatisticsProcessor interface {
 	UpdatePeerState(header data.CommonHeaderHandler, cache map[string]data.CommonHeaderHandler) ([]byte, error)
-	RevertPeerState(header data.MetaHeaderHandler) error
+	RevertPeerState(header ValidatorStatsHeader) error
 	Process(shardValidatorInfo data.ShardValidatorInfoHandler) error
 	IsInterfaceNil() bool
 	RootHash() ([]byte, error)

--- a/process/peer/process.go
+++ b/process/peer/process.go
@@ -887,9 +887,8 @@ func (vs *validatorStatistics) decreaseForConsensusValidators(
 	return nil
 }
 
-// RevertPeerState takes the current and previous headers and undos the peer state
-// for all of the consensus members
-func (vs *validatorStatistics) RevertPeerState(header data.MetaHeaderHandler) error {
+// RevertPeerState takes the current and previous headers and undoes the peer state for all consensus members
+func (vs *validatorStatistics) RevertPeerState(header process.ValidatorStatsHeader) error {
 	rootHashHolder := holders.NewDefaultRootHashesHolder(header.GetValidatorStatsRootHash())
 	return vs.peerAdapter.RecreateTrie(rootHashHolder)
 }

--- a/testscommon/validatorStatisticsProcessorStub.go
+++ b/testscommon/validatorStatisticsProcessorStub.go
@@ -2,6 +2,7 @@ package testscommon
 
 import (
 	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/state"
 )
 
@@ -121,7 +122,7 @@ func (vsp *ValidatorStatisticsProcessorStub) SaveNodesCoordinatorUpdates(epoch u
 }
 
 // RevertPeerState -
-func (vsp *ValidatorStatisticsProcessorStub) RevertPeerState(header data.MetaHeaderHandler) error {
+func (vsp *ValidatorStatisticsProcessorStub) RevertPeerState(header process.ValidatorStatsHeader) error {
 	if vsp.RevertPeerStateCalled != nil {
 		return vsp.RevertPeerStateCalled(header)
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- When reverting state, the header was cast to a meta header
  
## Proposed changes
- Changed interfaces and `RevertState` in sovereign not to cast to meta header

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
