### PR TITLE
add batched changes to trie

### DIFF
--- a/common/interface.go
+++ b/common/interface.go
@@ -375,8 +375,8 @@ type ExecutionOrderGetter interface {
 // TrieBatcher defines the methods needed for a trie batcher
 type TrieBatcher interface {
 	BatchHandler
-	GetSortedDataForInsertion() ([]string, map[string]core.TrieData)
-	GetSortedDataForRemoval() []string
+	GetSortedDataForInsertion() []core.TrieData
+	GetSortedDataForRemoval() []core.TrieData
 	IsInterfaceNil() bool
 }
 
@@ -390,7 +390,7 @@ type TrieBatchManager interface {
 
 // BatchHandler is the interface for the batch handler
 type BatchHandler interface {
-	Add(key []byte, data core.TrieData)
+	Add(data core.TrieData)
 	MarkForRemoval(key []byte)
 	Get(key []byte) ([]byte, bool)
 }

--- a/integrationTests/vm/txsFee/migrateDataTrie_test.go
+++ b/integrationTests/vm/txsFee/migrateDataTrie_test.go
@@ -186,6 +186,7 @@ func TestMigrateDataTrieBuiltInFunc(t *testing.T) {
 		err = testContext.Accounts.SaveAccount(acc)
 		require.Nil(t, err)
 		_, err = testContext.Accounts.Commit()
+		require.Nil(t, err)
 
 		acc = getAccount(t, testContext, sndAddr)
 

--- a/integrationTests/vm/txsFee/migrateDataTrie_test.go
+++ b/integrationTests/vm/txsFee/migrateDataTrie_test.go
@@ -185,6 +185,7 @@ func TestMigrateDataTrieBuiltInFunc(t *testing.T) {
 
 		err = testContext.Accounts.SaveAccount(acc)
 		require.Nil(t, err)
+		_, err = testContext.Accounts.Commit()
 
 		acc = getAccount(t, testContext, sndAddr)
 

--- a/trie/branchNode.go
+++ b/trie/branchNode.go
@@ -495,8 +495,8 @@ func (bn *branchNode) insert(newData []core.TrieData, db common.TrieStorageInter
 }
 
 // the prerequisite for this to work is that the data is already sorted
-func splitDataForChildren(newData []core.TrieData) ([][]core.TrieData, error) {
-	if len(newData) == 0 {
+func splitDataForChildren(newSortedData []core.TrieData) ([][]core.TrieData, error) {
+	if len(newSortedData) == 0 {
 		return nil, ErrValueTooShort
 	}
 	childrenData := make([][]core.TrieData, nrOfChildren)
@@ -504,15 +504,15 @@ func splitDataForChildren(newData []core.TrieData) ([][]core.TrieData, error) {
 	startIndex := 0
 	childPos := byte(0)
 	prevChildPos := byte(0)
-	for i := range newData {
-		if len(newData[i].Key) == 0 {
+	for i := range newSortedData {
+		if len(newSortedData[i].Key) == 0 {
 			return nil, ErrValueTooShort
 		}
-		childPos = newData[i].Key[firstByte]
+		childPos = newSortedData[i].Key[firstByte]
 		if childPosOutOfRange(childPos) {
 			return nil, ErrChildPosOutOfRange
 		}
-		newData[i].Key = newData[i].Key[1:]
+		newSortedData[i].Key = newSortedData[i].Key[1:]
 
 		if i == 0 {
 			prevChildPos = childPos
@@ -523,12 +523,12 @@ func splitDataForChildren(newData []core.TrieData) ([][]core.TrieData, error) {
 			continue
 		}
 
-		childrenData[prevChildPos] = newData[startIndex:i]
+		childrenData[prevChildPos] = newSortedData[startIndex:i]
 		startIndex = i
 		prevChildPos = childPos
 	}
 
-	childrenData[childPos] = newData[startIndex:]
+	childrenData[childPos] = newSortedData[startIndex:]
 	return childrenData, nil
 }
 

--- a/trie/branchNode_test.go
+++ b/trie/branchNode_test.go
@@ -622,7 +622,8 @@ func TestBranchNode_insert(t *testing.T) {
 	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
 	nodeKey := []byte{0, 2, 3}
 
-	newBn, _, err := bn.insert(getTrieDataWithDefaultVersion(string(nodeKey), "dogs"), nil)
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
+	newBn, _, err := bn.insert(data, nil)
 	assert.NotNil(t, newBn)
 	assert.Nil(t, err)
 
@@ -636,7 +637,8 @@ func TestBranchNode_insertEmptyKey(t *testing.T) {
 
 	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
 
-	newBn, _, err := bn.insert(getTrieDataWithDefaultVersion("", "dogs"), nil)
+	data := []core.TrieData{getTrieDataWithDefaultVersion("", "dogs")}
+	newBn, _, err := bn.insert(data, nil)
 	assert.Equal(t, ErrValueTooShort, err)
 	assert.Nil(t, newBn)
 }
@@ -646,7 +648,8 @@ func TestBranchNode_insertChildPosOutOfRange(t *testing.T) {
 
 	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
 
-	newBn, _, err := bn.insert(getTrieDataWithDefaultVersion("dog", "dogs"), nil)
+	data := []core.TrieData{getTrieDataWithDefaultVersion("dog", "dogs")}
+	newBn, _, err := bn.insert(data, nil)
 	assert.Equal(t, ErrChildPosOutOfRange, err)
 	assert.Nil(t, newBn)
 }
@@ -662,7 +665,8 @@ func TestBranchNode_insertCollapsedNode(t *testing.T) {
 	_ = bn.setHash()
 	_ = bn.commitDirty(0, 5, db, db)
 
-	newBn, _, err := collapsedBn.insert(getTrieDataWithDefaultVersion(string(key), "dogs"), db)
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
+	newBn, _, err := collapsedBn.insert(data, db)
 	assert.NotNil(t, newBn)
 	assert.Nil(t, err)
 
@@ -684,7 +688,8 @@ func TestBranchNode_insertInStoredBnOnExistingPos(t *testing.T) {
 	lnHash := ln.getHash()
 	expectedHashes := [][]byte{lnHash, bnHash}
 
-	newNode, oldHashes, err := bn.insert(getTrieDataWithDefaultVersion(string(key), "dogs"), db)
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
+	newNode, oldHashes, err := bn.insert(data, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHashes, oldHashes)
@@ -702,7 +707,8 @@ func TestBranchNode_insertInStoredBnOnNilPos(t *testing.T) {
 	bnHash := bn.getHash()
 	expectedHashes := [][]byte{bnHash}
 
-	newNode, oldHashes, err := bn.insert(getTrieDataWithDefaultVersion(string(key), "dogs"), db)
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
+	newNode, oldHashes, err := bn.insert(data, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHashes, oldHashes)
@@ -715,7 +721,8 @@ func TestBranchNode_insertInDirtyBnOnNilPos(t *testing.T) {
 	nilChildPos := byte(11)
 	key := append([]byte{nilChildPos}, []byte("dog")...)
 
-	newNode, oldHashes, err := bn.insert(getTrieDataWithDefaultVersion(string(key), "dogs"), nil)
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
+	newNode, oldHashes, err := bn.insert(data, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -728,7 +735,8 @@ func TestBranchNode_insertInDirtyBnOnExistingPos(t *testing.T) {
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	newNode, oldHashes, err := bn.insert(getTrieDataWithDefaultVersion(string(key), "dogs"), nil)
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
+	newNode, oldHashes, err := bn.insert(data, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -739,7 +747,8 @@ func TestBranchNode_insertInNilNode(t *testing.T) {
 
 	var bn *branchNode
 
-	newBn, _, err := bn.insert(getTrieDataWithDefaultVersion("key", "dogs"), nil)
+	data := []core.TrieData{getTrieDataWithDefaultVersion("key", "dogs")}
+	newBn, _, err := bn.insert(data, nil)
 	assert.True(t, errors.Is(err, ErrNilBranchNode))
 	assert.Nil(t, newBn)
 }
@@ -756,8 +765,9 @@ func TestBranchNode_delete(t *testing.T) {
 
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
+	data := []core.TrieData{{Key: key}}
 
-	dirty, newBn, _, err := bn.delete(key, nil)
+	dirty, newBn, _, err := bn.delete(data, nil)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 
@@ -780,7 +790,8 @@ func TestBranchNode_deleteFromStoredBn(t *testing.T) {
 	lnHash := ln.getHash()
 	expectedHashes := [][]byte{lnHash, bnHash}
 
-	dirty, _, oldHashes, err := bn.delete(lnKey, db)
+	data := []core.TrieData{{Key: lnKey}}
+	dirty, _, oldHashes, err := bn.delete(data, db)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHashes, oldHashes)
@@ -792,8 +803,9 @@ func TestBranchNode_deleteFromDirtyBn(t *testing.T) {
 	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
 	childPos := byte(2)
 	lnKey := append([]byte{childPos}, []byte("dog")...)
+	data := []core.TrieData{{Key: lnKey}}
 
-	dirty, _, oldHashes, err := bn.delete(lnKey, nil)
+	dirty, _, oldHashes, err := bn.delete(data, nil)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -805,8 +817,9 @@ func TestBranchNode_deleteEmptyNode(t *testing.T) {
 	bn := emptyDirtyBranchNode()
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
+	data := []core.TrieData{{Key: key}}
 
-	dirty, newBn, _, err := bn.delete(key, nil)
+	dirty, newBn, _, err := bn.delete(data, nil)
 	assert.False(t, dirty)
 	assert.True(t, errors.Is(err, ErrEmptyBranchNode))
 	assert.Nil(t, newBn)
@@ -818,8 +831,9 @@ func TestBranchNode_deleteNilNode(t *testing.T) {
 	var bn *branchNode
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
+	data := []core.TrieData{{Key: key}}
 
-	dirty, newBn, _, err := bn.delete(key, nil)
+	dirty, newBn, _, err := bn.delete(data, nil)
 	assert.False(t, dirty)
 	assert.True(t, errors.Is(err, ErrNilBranchNode))
 	assert.Nil(t, newBn)
@@ -832,8 +846,9 @@ func TestBranchNode_deleteNonexistentNodeFromChild(t *testing.T) {
 
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("butterfly")...)
+	data := []core.TrieData{{Key: key}}
 
-	dirty, newBn, _, err := bn.delete(key, nil)
+	dirty, newBn, _, err := bn.delete(data, nil)
 	assert.False(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, bn, newBn)
@@ -843,8 +858,9 @@ func TestBranchNode_deleteEmptykey(t *testing.T) {
 	t.Parallel()
 
 	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	data := []core.TrieData{{Key: []byte{}}}
 
-	dirty, newBn, _, err := bn.delete([]byte{}, nil)
+	dirty, newBn, _, err := bn.delete(data, nil)
 	assert.False(t, dirty)
 	assert.Equal(t, ErrValueTooShort, err)
 	assert.Nil(t, newBn)
@@ -860,8 +876,9 @@ func TestBranchNode_deleteCollapsedNode(t *testing.T) {
 
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
+	data := []core.TrieData{{Key: key}}
 
-	dirty, newBn, _, err := collapsedBn.delete(key, db)
+	dirty, newBn, _, err := collapsedBn.delete(data, db)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 
@@ -885,7 +902,8 @@ func TestBranchNode_deleteAndReduceBn(t *testing.T) {
 	ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string(key), "dog"), bn.marsh, bn.hasher)
 
 	key = append([]byte{secondChildPos}, []byte("doe")...)
-	dirty, newBn, _, err := bn.delete(key, nil)
+	data := []core.TrieData{{Key: key}}
+	dirty, newBn, _, err := bn.delete(data, nil)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, ln, newBn)
@@ -1453,7 +1471,7 @@ func TestBranchNode_VerifyChildrenVersionIsSetCorrectlyAfterInsertAndDelete(t *t
 			Value:   []byte("value"),
 			Version: 0,
 		}
-		newBn, _, err := bn.insert(data, &testscommon.MemDbMock{})
+		newBn, _, err := bn.insert([]core.TrieData{data}, &testscommon.MemDbMock{})
 		assert.Nil(t, err)
 		assert.Nil(t, newBn.(*branchNode).ChildrenVersion)
 	})
@@ -1465,8 +1483,9 @@ func TestBranchNode_VerifyChildrenVersionIsSetCorrectlyAfterInsertAndDelete(t *t
 		bn.ChildrenVersion = make([]byte, nrOfChildren)
 		bn.ChildrenVersion[2] = byte(core.AutoBalanceEnabled)
 		childKey := []byte{2, 'd', 'o', 'g'}
+		data := []core.TrieData{{Key: childKey}}
 
-		_, newBn, _, err := bn.delete(childKey, &testscommon.MemDbMock{})
+		_, newBn, _, err := bn.delete(data, &testscommon.MemDbMock{})
 		assert.Nil(t, err)
 		assert.Nil(t, newBn.(*branchNode).ChildrenVersion)
 	})

--- a/trie/branchNode_test.go
+++ b/trie/branchNode_test.go
@@ -1678,7 +1678,8 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
 		var data []core.TrieData
 		modifiedHashes, err := bn.insertOnNilChild(data, 0, nil)
-		assert.Equal(t, 0, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 0
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		assert.Equal(t, ErrValueTooShort, err)
 	})
 	t.Run("insert one child in !dirty node", func(t *testing.T) {
@@ -1701,7 +1702,8 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 		childPos := byte(0)
 		modifiedHashes, err := bn.insertOnNilChild(newData, childPos, db)
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 1
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		assert.Equal(t, originalHash, modifiedHashes[0])
 		assert.True(t, bn.dirty)
 		assert.NotNil(t, bn.children[childPos])
@@ -1723,7 +1725,8 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 		childPos := byte(0)
 		modifiedHashes, err := bn.insertOnNilChild(newData, childPos, db)
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 0
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		assert.True(t, bn.dirty)
 		assert.NotNil(t, bn.children[childPos])
 		assert.Equal(t, byte(core.AutoBalanceEnabled), bn.ChildrenVersion[childPos])
@@ -1749,7 +1752,8 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 		childPos := byte(0)
 		modifiedHashes, err := bn.insertOnNilChild(newData, childPos, db)
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 0
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		assert.True(t, bn.dirty)
 		assert.NotNil(t, bn.children[childPos])
 		assert.Equal(t, byte(core.AutoBalanceEnabled), bn.ChildrenVersion[childPos])
@@ -1796,7 +1800,8 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 		assert.Nil(t, err)
 		assert.True(t, dirty)
 		assert.True(t, bn.dirty)
-		assert.Equal(t, 2, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 2
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		assert.Equal(t, originalChildHash, modifiedHashes[0])
 		assert.Equal(t, originalHash, modifiedHashes[1])
 		_, ok := bn.children[childPos].(*extensionNode)
@@ -1830,7 +1835,8 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 		assert.Nil(t, err)
 		assert.False(t, dirty)
 		assert.False(t, bn.dirty)
-		assert.Equal(t, 0, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 0
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		_, ok := bn.children[childPos].(*leafNode)
 		assert.True(t, ok)
 	})
@@ -1871,7 +1877,8 @@ func TestBranchNode_insertBatch(t *testing.T) {
 
 	newNode, modifiedHashes, err := bn.insert(newData, db)
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(modifiedHashes))
+	expectedNumTrieNodesChanged := 2
+	assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 	assert.True(t, newNode.isDirty())
 
 	bn, ok := newNode.(*branchNode)
@@ -1926,7 +1933,8 @@ func TestBranchNode_deleteBatch(t *testing.T) {
 		assert.Nil(t, err)
 		assert.True(t, dirty)
 		assert.True(t, newNode.isDirty())
-		assert.Equal(t, 5, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 5
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		bn, ok := newNode.(*branchNode)
 		assert.True(t, ok)
 
@@ -1958,7 +1966,8 @@ func TestBranchNode_deleteBatch(t *testing.T) {
 		assert.Nil(t, err)
 		assert.True(t, dirty)
 		assert.True(t, newNode.isDirty())
-		assert.Equal(t, 6, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 6
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		ln, ok := newNode.(*leafNode)
 		assert.True(t, ok)
 		assert.Equal(t, []byte{9, 3, 7, 8, 9}, ln.Key)
@@ -1988,6 +1997,7 @@ func TestBranchNode_deleteBatch(t *testing.T) {
 		assert.Nil(t, err)
 		assert.True(t, dirty)
 		assert.Nil(t, newNode)
-		assert.Equal(t, 6, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 6
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 	})
 }

--- a/trie/branchNode_test.go
+++ b/trie/branchNode_test.go
@@ -1793,6 +1793,7 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 		assert.True(t, len(originalChildHash) > 0)
 
 		dirty, modifiedHashes, err := bn.insertOnExistingChild(newData, childPos, db)
+		assert.Nil(t, err)
 		assert.True(t, dirty)
 		assert.True(t, bn.dirty)
 		assert.Equal(t, 2, len(modifiedHashes))
@@ -1826,6 +1827,7 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 		assert.False(t, bn.dirty)
 
 		dirty, modifiedHashes, err := bn.insertOnExistingChild(newData, childPos, db)
+		assert.Nil(t, err)
 		assert.False(t, dirty)
 		assert.False(t, bn.dirty)
 		assert.Equal(t, 0, len(modifiedHashes))

--- a/trie/extensionNode.go
+++ b/trie/extensionNode.go
@@ -358,20 +358,20 @@ func (en *extensionNode) insert(newData []core.TrieData, db common.TrieStorageIn
 }
 
 func getMinKeyMatchLen(newData []core.TrieData, enKey []byte) (int, int) {
-	keyMatchLen := len(enKey)
+	minKeyMatchLen := len(enKey)
 	index := 0
 	for i, data := range newData {
-		if keyMatchLen == 0 {
+		if minKeyMatchLen == 0 {
 			return 0, index
 		}
 		matchLen := prefixLen(data.Key, enKey)
-		if matchLen < keyMatchLen {
-			keyMatchLen = matchLen
+		if matchLen < minKeyMatchLen {
+			minKeyMatchLen = matchLen
 			index = i
 		}
 	}
 
-	return keyMatchLen, index
+	return minKeyMatchLen, index
 }
 
 func removeCommonPrefix(newData []core.TrieData, prefixLen int) error {

--- a/trie/extensionNode_test.go
+++ b/trie/extensionNode_test.go
@@ -493,7 +493,8 @@ func TestExtensionNode_insert(t *testing.T) {
 	en, _ := getEnAndCollapsedEn()
 	key := []byte{100, 15, 5, 6}
 
-	newNode, _, err := en.insert(getTrieDataWithDefaultVersion(string(key), "dogs"), nil)
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
+	newNode, _, err := en.insert(data, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 
@@ -511,7 +512,8 @@ func TestExtensionNode_insertCollapsedNode(t *testing.T) {
 	_ = en.setHash()
 	_ = en.commitDirty(0, 5, db, db)
 
-	newNode, _, err := collapsedEn.insert(getTrieDataWithDefaultVersion(string(key), "dogs"), db)
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
+	newNode, _, err := collapsedEn.insert(data, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 
@@ -533,7 +535,8 @@ func TestExtensionNode_insertInStoredEnSameKey(t *testing.T) {
 	bnHash := bn.getHash()
 	expectedHashes := [][]byte{bnHash, enHash}
 
-	newNode, oldHashes, err := en.insert(getTrieDataWithDefaultVersion(string(key), "dogs"), db)
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
+	newNode, oldHashes, err := en.insert(data, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHashes, oldHashes)
@@ -551,7 +554,8 @@ func TestExtensionNode_insertInStoredEnDifferentKey(t *testing.T) {
 	_ = en.commitDirty(0, 5, db, db)
 	expectedHashes := [][]byte{en.getHash()}
 
-	newNode, oldHashes, err := en.insert(getTrieDataWithDefaultVersion(string(nodeKey), "dogs"), db)
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
+	newNode, oldHashes, err := en.insert(data, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHashes, oldHashes)
@@ -563,7 +567,8 @@ func TestExtensionNode_insertInDirtyEnSameKey(t *testing.T) {
 	en, _ := getEnAndCollapsedEn()
 	nodeKey := []byte{100, 11, 12}
 
-	newNode, oldHashes, err := en.insert(getTrieDataWithDefaultVersion(string(nodeKey), "dogs"), nil)
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
+	newNode, oldHashes, err := en.insert(data, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -577,7 +582,8 @@ func TestExtensionNode_insertInDirtyEnDifferentKey(t *testing.T) {
 	en, _ := newExtensionNode(enKey, bn, bn.marsh, bn.hasher)
 	nodeKey := []byte{11, 12}
 
-	newNode, oldHashes, err := en.insert(getTrieDataWithDefaultVersion(string(nodeKey), "dogs"), nil)
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
+	newNode, oldHashes, err := en.insert(data, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -588,7 +594,8 @@ func TestExtensionNode_insertInNilNode(t *testing.T) {
 
 	var en *extensionNode
 
-	newNode, _, err := en.insert(getTrieDataWithDefaultVersion("key", "val"), nil)
+	data := []core.TrieData{getTrieDataWithDefaultVersion("key", "val")}
+	newNode, _, err := en.insert(data, nil)
 	assert.Nil(t, newNode)
 	assert.True(t, errors.Is(err, ErrNilExtensionNode))
 	assert.Nil(t, newNode)
@@ -608,8 +615,9 @@ func TestExtensionNode_delete(t *testing.T) {
 
 	val, _, _ := en.tryGet(key, 0, nil)
 	assert.Equal(t, dogBytes, val)
+	data := []core.TrieData{{Key: key}}
 
-	dirty, _, _, err := en.delete(key, nil)
+	dirty, _, _, err := en.delete(data, nil)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	val, _, _ = en.tryGet(key, 0, nil)
@@ -632,8 +640,9 @@ func TestExtensionNode_deleteFromStoredEn(t *testing.T) {
 	bn, key, _ := en.getNext(key, db)
 	ln, _, _ := bn.getNext(key, db)
 	expectedHashes := [][]byte{ln.getHash(), bn.getHash(), en.getHash()}
+	data := []core.TrieData{{Key: lnPathKey}}
 
-	dirty, _, oldHashes, err := en.delete(lnPathKey, db)
+	dirty, _, oldHashes, err := en.delete(data, db)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedHashes, oldHashes)
@@ -644,8 +653,9 @@ func TestExtensionNode_deleteFromDirtyEn(t *testing.T) {
 
 	en, _ := getEnAndCollapsedEn()
 	lnKey := []byte{100, 2, 100, 111, 103}
+	data := []core.TrieData{{Key: lnKey}}
 
-	dirty, _, oldHashes, err := en.delete(lnKey, nil)
+	dirty, _, oldHashes, err := en.delete(data, nil)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -655,8 +665,9 @@ func TestExtendedNode_deleteEmptyNode(t *testing.T) {
 	t.Parallel()
 
 	en := &extensionNode{}
+	data := []core.TrieData{{Key: []byte("dog")}}
 
-	dirty, newNode, _, err := en.delete([]byte("dog"), nil)
+	dirty, newNode, _, err := en.delete(data, nil)
 	assert.False(t, dirty)
 	assert.True(t, errors.Is(err, ErrEmptyExtensionNode))
 	assert.Nil(t, newNode)
@@ -666,21 +677,11 @@ func TestExtensionNode_deleteNilNode(t *testing.T) {
 	t.Parallel()
 
 	var en *extensionNode
+	data := []core.TrieData{{Key: []byte("dog")}}
 
-	dirty, newNode, _, err := en.delete([]byte("dog"), nil)
+	dirty, newNode, _, err := en.delete(data, nil)
 	assert.False(t, dirty)
 	assert.True(t, errors.Is(err, ErrNilExtensionNode))
-	assert.Nil(t, newNode)
-}
-
-func TestExtensionNode_deleteEmptykey(t *testing.T) {
-	t.Parallel()
-
-	en, _ := getEnAndCollapsedEn()
-
-	dirty, newNode, _, err := en.delete([]byte{}, nil)
-	assert.False(t, dirty)
-	assert.Equal(t, ErrValueTooShort, err)
 	assert.Nil(t, newNode)
 }
 
@@ -700,8 +701,9 @@ func TestExtensionNode_deleteCollapsedNode(t *testing.T) {
 
 	val, _, _ := en.tryGet(key, 0, db)
 	assert.Equal(t, []byte("dog"), val)
+	data := []core.TrieData{{Key: key}}
 
-	dirty, newNode, _, err := collapsedEn.delete(key, db)
+	dirty, newNode, _, err := collapsedEn.delete(data, db)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	val, _, _ = newNode.tryGet(key, 0, db)

--- a/trie/extensionNode_test.go
+++ b/trie/extensionNode_test.go
@@ -1228,7 +1228,8 @@ func TestExtensionNode_insertInSameEn(t *testing.T) {
 
 		newNode, modifiedHashes, err := en.insert(data, nil)
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 0
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		assert.Nil(t, newNode)
 		assert.False(t, en.dirty)
 	})
@@ -1246,7 +1247,8 @@ func TestExtensionNode_insertInSameEn(t *testing.T) {
 
 		newNode, modifiedHashes, err := en.insert(data, nil)
 		assert.Nil(t, err)
-		assert.Equal(t, 2, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 2
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		en, ok := newNode.(*extensionNode)
 		assert.True(t, ok)
 		assert.True(t, en.dirty)
@@ -1276,7 +1278,8 @@ func TestExtensionNode_insertInNewBn(t *testing.T) {
 
 		newNode, modifiedHashes, err := en.insert(data, nil)
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 1
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		en, ok := newNode.(*extensionNode)
 		assert.True(t, ok)
 		assert.True(t, en.dirty)
@@ -1304,7 +1307,8 @@ func TestExtensionNode_insertInNewBn(t *testing.T) {
 
 		newNode, modifiedHashes, err := en.insert(data, nil)
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 1
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		bn, ok := newNode.(*branchNode)
 		assert.True(t, ok)
 		assert.True(t, bn.dirty)
@@ -1332,7 +1336,8 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		dirty, newNode, modifiedHashes, err := en.delete(data, nil)
 		assert.False(t, dirty)
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 0
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		assert.Equal(t, en, newNode)
 	})
 	t.Run("reduce to leaf after delete", func(t *testing.T) {
@@ -1349,7 +1354,8 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		dirty, newNode, modifiedHashes, err := en.delete(data, nil)
 		assert.True(t, dirty)
 		assert.Nil(t, err)
-		assert.Equal(t, 4, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 4
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		ln, ok := newNode.(*leafNode)
 		assert.True(t, ok)
 		assert.Equal(t, []byte{1, 2, 7, 7, 8, 9}, ln.Key)
@@ -1373,7 +1379,8 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		dirty, newNode, modifiedHashes, err := en.delete(dataForRemoval, nil)
 		assert.True(t, dirty)
 		assert.Nil(t, err)
-		assert.Equal(t, 3, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 3
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		en, ok := newNode.(*extensionNode)
 		assert.True(t, ok)
 		assert.Equal(t, []byte{1, 2, 4}, en.Key)
@@ -1394,7 +1401,8 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		dirty, newNode, modifiedHashes, err := en.delete(data, nil)
 		assert.True(t, dirty)
 		assert.Nil(t, err)
-		assert.Equal(t, 4, len(modifiedHashes))
+		expectedNumTrieNodesChanged := 4
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
 		assert.Nil(t, newNode)
 	})
 }

--- a/trie/interface.go
+++ b/trie/interface.go
@@ -29,8 +29,8 @@ type node interface {
 	hashChildren() error
 	tryGet(key []byte, depth uint32, db common.TrieStorageInteractor) ([]byte, uint32, error)
 	getNext(key []byte, db common.TrieStorageInteractor) (node, []byte, error)
-	insert(newData core.TrieData, db common.TrieStorageInteractor) (node, [][]byte, error)
-	delete(key []byte, db common.TrieStorageInteractor) (bool, node, [][]byte, error)
+	insert(newData []core.TrieData, db common.TrieStorageInteractor) (node, [][]byte, error)
+	delete(data []core.TrieData, db common.TrieStorageInteractor) (bool, node, [][]byte, error)
 	reduceNode(pos int) (node, bool, error)
 	isEmptyOrNil() error
 	print(writer io.Writer, index int, db common.TrieStorageInteractor)

--- a/trie/leafNode_test.go
+++ b/trie/leafNode_test.go
@@ -321,8 +321,9 @@ func TestLeafNode_insertAtSameKey(t *testing.T) {
 	ln := getLn(getTestMarshalizerAndHasher())
 	key := "dog"
 	expectedVal := "dogs"
+	data := []core.TrieData{getTrieDataWithDefaultVersion(key, expectedVal)}
 
-	newNode, _, err := ln.insert(getTrieDataWithDefaultVersion(key, expectedVal), nil)
+	newNode, _, err := ln.insert(data, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 
@@ -340,8 +341,9 @@ func TestLeafNode_insertAtDifferentKey(t *testing.T) {
 
 	nodeKey := []byte{3, 4, 5}
 	nodeVal := []byte{3, 4, 5}
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), string(nodeVal))}
 
-	newNode, _, err := ln.insert(getTrieDataWithDefaultVersion(string(nodeKey), string(nodeVal)), nil)
+	newNode, _, err := ln.insert(data, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 
@@ -357,8 +359,9 @@ func TestLeafNode_insertInStoredLnAtSameKey(t *testing.T) {
 	ln := getLn(getTestMarshalizerAndHasher())
 	_ = ln.commitDirty(0, 5, db, db)
 	lnHash := ln.getHash()
+	data := []core.TrieData{getTrieDataWithDefaultVersion("dog", "dogs")}
 
-	newNode, oldHashes, err := ln.insert(getTrieDataWithDefaultVersion("dog", "dogs"), db)
+	newNode, oldHashes, err := ln.insert(data, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{lnHash}, oldHashes)
@@ -372,8 +375,9 @@ func TestLeafNode_insertInStoredLnAtDifferentKey(t *testing.T) {
 	ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3}), "dog"), marsh, hasher)
 	_ = ln.commitDirty(0, 5, db, db)
 	lnHash := ln.getHash()
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string([]byte{4, 5, 6}), "dogs")}
 
-	newNode, oldHashes, err := ln.insert(getTrieDataWithDefaultVersion(string([]byte{4, 5, 6}), "dogs"), db)
+	newNode, oldHashes, err := ln.insert(data, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{lnHash}, oldHashes)
@@ -383,8 +387,9 @@ func TestLeafNode_insertInDirtyLnAtSameKey(t *testing.T) {
 	t.Parallel()
 
 	ln := getLn(getTestMarshalizerAndHasher())
+	data := []core.TrieData{getTrieDataWithDefaultVersion("dog", "dogs")}
 
-	newNode, oldHashes, err := ln.insert(getTrieDataWithDefaultVersion("dog", "dogs"), nil)
+	newNode, oldHashes, err := ln.insert(data, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -395,8 +400,9 @@ func TestLeafNode_insertInDirtyLnAtDifferentKey(t *testing.T) {
 
 	marsh, hasher := getTestMarshalizerAndHasher()
 	ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3}), "dog"), marsh, hasher)
+	data := []core.TrieData{getTrieDataWithDefaultVersion(string([]byte{4, 5, 6}), "dogs")}
 
-	newNode, oldHashes, err := ln.insert(getTrieDataWithDefaultVersion(string([]byte{4, 5, 6}), "dogs"), nil)
+	newNode, oldHashes, err := ln.insert(data, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -406,8 +412,9 @@ func TestLeafNode_insertInNilNode(t *testing.T) {
 	t.Parallel()
 
 	var ln *leafNode
+	data := []core.TrieData{getTrieDataWithDefaultVersion("dog", "dogs")}
 
-	newNode, _, err := ln.insert(getTrieDataWithDefaultVersion("dog", "dogs"), nil)
+	newNode, _, err := ln.insert(data, nil)
 	assert.Nil(t, newNode)
 	assert.True(t, errors.Is(err, ErrNilLeafNode))
 	assert.Nil(t, newNode)
@@ -417,8 +424,9 @@ func TestLeafNode_deletePresent(t *testing.T) {
 	t.Parallel()
 
 	ln := getLn(getTestMarshalizerAndHasher())
+	data := []core.TrieData{{Key: []byte("dog")}}
 
-	dirty, newNode, _, err := ln.delete([]byte("dog"), nil)
+	dirty, newNode, _, err := ln.delete(data, nil)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Nil(t, newNode)
@@ -431,8 +439,9 @@ func TestLeafNode_deleteFromStoredLnAtSameKey(t *testing.T) {
 	ln := getLn(getTestMarshalizerAndHasher())
 	_ = ln.commitDirty(0, 5, db, db)
 	lnHash := ln.getHash()
+	data := []core.TrieData{{Key: []byte("dog")}}
 
-	dirty, _, oldHashes, err := ln.delete([]byte("dog"), db)
+	dirty, _, oldHashes, err := ln.delete(data, db)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{lnHash}, oldHashes)
@@ -445,8 +454,9 @@ func TestLeafNode_deleteFromLnAtDifferentKey(t *testing.T) {
 	ln := getLn(getTestMarshalizerAndHasher())
 	_ = ln.commitDirty(0, 5, db, db)
 	wrongKey := []byte{1, 2, 3}
+	data := []core.TrieData{{Key: wrongKey}}
 
-	dirty, _, oldHashes, err := ln.delete(wrongKey, db)
+	dirty, _, oldHashes, err := ln.delete(data, db)
 	assert.False(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -456,8 +466,9 @@ func TestLeafNode_deleteFromDirtyLnAtSameKey(t *testing.T) {
 	t.Parallel()
 
 	ln := getLn(getTestMarshalizerAndHasher())
+	data := []core.TrieData{{Key: []byte("dog")}}
 
-	dirty, _, oldHashes, err := ln.delete([]byte("dog"), nil)
+	dirty, _, oldHashes, err := ln.delete(data, nil)
 	assert.True(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, [][]byte{}, oldHashes)
@@ -468,8 +479,9 @@ func TestLeafNode_deleteNotPresent(t *testing.T) {
 
 	ln := getLn(getTestMarshalizerAndHasher())
 	wrongKey := []byte{1, 2, 3}
+	data := []core.TrieData{{Key: wrongKey}}
 
-	dirty, newNode, _, err := ln.delete(wrongKey, nil)
+	dirty, newNode, _, err := ln.delete(data, nil)
 	assert.False(t, dirty)
 	assert.Nil(t, err)
 	assert.Equal(t, ln, newNode)

--- a/trie/patriciaMerkleTrie.go
+++ b/trie/patriciaMerkleTrie.go
@@ -117,8 +117,6 @@ func (tr *patriciaMerkleTrie) Get(key []byte) ([]byte, uint32, error) {
 		return nil, depth, err
 	}
 
-	log.Trace("get trie", "key", key, "val", val)
-
 	return val, depth, nil
 }
 
@@ -126,7 +124,7 @@ func (tr *patriciaMerkleTrie) Get(key []byte) ([]byte, uint32, error) {
 // If the key is not in the trie, it will be added.
 // If the value is empty, the key will be removed from the trie
 func (tr *patriciaMerkleTrie) Update(key, value []byte) error {
-	log.Debug("update trie",
+	log.Trace("update trie",
 		"key", hex.EncodeToString(key),
 		"val", hex.EncodeToString(value),
 	)
@@ -136,7 +134,7 @@ func (tr *patriciaMerkleTrie) Update(key, value []byte) error {
 
 // UpdateWithVersion does the same thing as Update, but the new leaf that is created will be of the specified version
 func (tr *patriciaMerkleTrie) UpdateWithVersion(key []byte, value []byte, version core.TrieNodeVersion) error {
-	log.Debug("update trie with version",
+	log.Trace("update trie with version",
 		"key", hex.EncodeToString(key),
 		"val", hex.EncodeToString(value),
 		"version", version,

--- a/trie/patriciaMerkleTrie.go
+++ b/trie/patriciaMerkleTrie.go
@@ -117,6 +117,8 @@ func (tr *patriciaMerkleTrie) Get(key []byte) ([]byte, uint32, error) {
 		return nil, depth, err
 	}
 
+	log.Trace("get trie", "key", key, "val", val)
+
 	return val, depth, nil
 }
 
@@ -124,7 +126,7 @@ func (tr *patriciaMerkleTrie) Get(key []byte) ([]byte, uint32, error) {
 // If the key is not in the trie, it will be added.
 // If the value is empty, the key will be removed from the trie
 func (tr *patriciaMerkleTrie) Update(key, value []byte) error {
-	log.Trace("update trie",
+	log.Debug("update trie",
 		"key", hex.EncodeToString(key),
 		"val", hex.EncodeToString(value),
 	)
@@ -134,7 +136,7 @@ func (tr *patriciaMerkleTrie) Update(key, value []byte) error {
 
 // UpdateWithVersion does the same thing as Update, but the new leaf that is created will be of the specified version
 func (tr *patriciaMerkleTrie) UpdateWithVersion(key []byte, value []byte, version core.TrieNodeVersion) error {
-	log.Trace("update trie with version",
+	log.Debug("update trie with version",
 		"key", hex.EncodeToString(key),
 		"val", hex.EncodeToString(value),
 		"version", version,
@@ -151,7 +153,7 @@ func (tr *patriciaMerkleTrie) updateBatch(key []byte, value []byte, version core
 			Value:   value,
 			Version: version,
 		}
-		tr.batchManager.Add(hexKey, newData)
+		tr.batchManager.Add(newData)
 		return nil
 	}
 
@@ -172,56 +174,73 @@ func (tr *patriciaMerkleTrie) updateTrie() error {
 	}
 	defer tr.batchManager.MarkTrieUpdateCompleted()
 
-	keys, data := batch.GetSortedDataForInsertion()
-	for _, key := range keys {
-		newData := data[key]
-		if tr.root == nil {
-			newRoot, err := newLeafNode(newData, tr.marshalizer, tr.hasher)
-			if err != nil {
-				return err
-			}
+	err = tr.insertBatch(batch.GetSortedDataForInsertion())
+	if err != nil {
+		return err
+	}
 
-			tr.root = newRoot
-			continue
-		}
+	return tr.deleteBatch(batch.GetSortedDataForRemoval())
+}
 
-		if !tr.root.isDirty() {
-			tr.oldRoot = tr.root.getHash()
-		}
+func (tr *patriciaMerkleTrie) insertBatch(sortedDataForInsertion []core.TrieData) error {
+	if len(sortedDataForInsertion) == 0 {
+		return nil
+	}
 
-		newRoot, oldHashes, err := tr.root.insert(newData, tr.trieStorage)
+	if tr.root == nil {
+		newRoot, err := newLeafNode(sortedDataForInsertion[0], tr.marshalizer, tr.hasher)
 		if err != nil {
 			return err
 		}
 
-		if check.IfNil(newRoot) {
-			continue
-		}
-
 		tr.root = newRoot
-		tr.oldHashes = append(tr.oldHashes, oldHashes...)
+		sortedDataForInsertion = sortedDataForInsertion[1:]
 
-		logArrayWithTrace("oldHashes after insert", "hash", oldHashes)
-	}
-
-	keysToBeRemoved := batch.GetSortedDataForRemoval()
-	for _, hexKey := range keysToBeRemoved {
-		if tr.root == nil {
+		if len(sortedDataForInsertion) == 0 {
 			return nil
 		}
-
-		if !tr.root.isDirty() {
-			tr.oldRoot = tr.root.getHash()
-		}
-
-		_, newRoot, oldHashes, err := tr.root.delete([]byte(hexKey), tr.trieStorage)
-		if err != nil {
-			return err
-		}
-		tr.root = newRoot
-		tr.oldHashes = append(tr.oldHashes, oldHashes...)
-		logArrayWithTrace("oldHashes after delete", "hash", oldHashes)
 	}
+
+	if !tr.root.isDirty() {
+		tr.oldRoot = tr.root.getHash()
+	}
+
+	newRoot, oldHashes, err := tr.root.insert(sortedDataForInsertion, tr.trieStorage)
+	if err != nil {
+		return err
+	}
+
+	if check.IfNil(newRoot) {
+		return nil
+	}
+
+	tr.root = newRoot
+	tr.oldHashes = append(tr.oldHashes, oldHashes...)
+
+	logArrayWithTrace("oldHashes after insert", "hash", oldHashes)
+	return nil
+}
+
+func (tr *patriciaMerkleTrie) deleteBatch(data []core.TrieData) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	if tr.root == nil {
+		return nil
+	}
+
+	if !tr.root.isDirty() {
+		tr.oldRoot = tr.root.getHash()
+	}
+
+	_, newRoot, oldHashes, err := tr.root.delete(data, tr.trieStorage)
+	if err != nil {
+		return err
+	}
+	tr.root = newRoot
+	tr.oldHashes = append(tr.oldHashes, oldHashes...)
+	logArrayWithTrace("oldHashes after delete", "hash", oldHashes)
 
 	return nil
 }

--- a/trie/patriciaMerkleTrie_test.go
+++ b/trie/patriciaMerkleTrie_test.go
@@ -1536,6 +1536,21 @@ func TestPatriciaMerkleTrie_IsMigrated(t *testing.T) {
 	})
 }
 
+func TestPatriciaMerkleTrie_InsertOneValInNilTrie(t *testing.T) {
+	t.Parallel()
+
+	tr := emptyTrie()
+	key := []byte("dog")
+	value := []byte("cat")
+	_ = tr.Update(key, value)
+	trie.ExecuteUpdatesFromBatch(tr)
+
+	val, depth, err := tr.Get(key)
+	assert.Nil(t, err)
+	assert.Equal(t, value, val)
+	assert.Equal(t, uint32(0), depth)
+}
+
 func BenchmarkPatriciaMerkleTree_Insert(b *testing.B) {
 	tr := emptyTrie()
 	hsh := keccak.NewKeccak()

--- a/trie/trieBatchManager/trieBatchManager.go
+++ b/trie/trieBatchManager/trieBatchManager.go
@@ -56,11 +56,11 @@ func (t *trieBatchManager) MarkTrieUpdateCompleted() {
 }
 
 // Add adds a new key and data to the current batch
-func (t *trieBatchManager) Add(key []byte, data core.TrieData) {
+func (t *trieBatchManager) Add(data core.TrieData) {
 	t.mutex.RLock()
 	defer t.mutex.RUnlock()
 
-	t.currentBatch.Add(key, data)
+	t.currentBatch.Add(data)
 }
 
 // Get returns the data for the given key checking first the current batch and then the temp batch if the trie update is in progress

--- a/trie/trieBatchManager/trieBatchManager_test.go
+++ b/trie/trieBatchManager/trieBatchManager_test.go
@@ -23,8 +23,8 @@ func TestTrieBatchManager_TrieUpdateInProgress(t *testing.T) {
 	t.Parallel()
 
 	tbm := NewTrieBatchManager()
-	tbm.Add([]byte("key1"), core.TrieData{})
-	tbm.Add([]byte("key2"), core.TrieData{})
+	tbm.Add(core.TrieData{Key: []byte("key1")})
+	tbm.Add(core.TrieData{Key: []byte("key2")})
 	assert.False(t, tbm.isUpdateInProgress)
 	assert.True(t, check.IfNil(tbm.tempBatch))
 
@@ -50,12 +50,12 @@ func TestTrieBatchManager_AddUpdatesCurrentBatch(t *testing.T) {
 	t.Parallel()
 
 	tbm := NewTrieBatchManager()
-	tbm.Add([]byte("key1"), core.TrieData{})
+	tbm.Add(core.TrieData{Key: []byte("key1")})
 	_, found := tbm.currentBatch.Get([]byte("key1"))
 	assert.True(t, found)
 
 	_, _ = tbm.MarkTrieUpdateInProgress()
-	tbm.Add([]byte("key2"), core.TrieData{})
+	tbm.Add(core.TrieData{Key: []byte("key2")})
 	_, found = tbm.currentBatch.Get([]byte("key2"))
 	assert.True(t, found)
 }
@@ -70,7 +70,8 @@ func TestTrieBatchManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tbm := NewTrieBatchManager()
-		tbm.currentBatch.Add(key, core.TrieData{
+		tbm.currentBatch.Add(core.TrieData{
+			Key:   key,
 			Value: value,
 		})
 
@@ -82,7 +83,8 @@ func TestTrieBatchManager_Get(t *testing.T) {
 		t.Parallel()
 
 		tbm := NewTrieBatchManager()
-		tbm.currentBatch.Add(key, core.TrieData{
+		tbm.currentBatch.Add(core.TrieData{
+			Key:   key,
 			Value: value,
 		})
 		_, _ = tbm.MarkTrieUpdateInProgress()

--- a/trie/trieChangesBatch/trieChangesBatch_test.go
+++ b/trie/trieChangesBatch/trieChangesBatch_test.go
@@ -20,7 +20,6 @@ func TestNewTrieChangesBatch(t *testing.T) {
 func TestTrieChangesBatch_Add(t *testing.T) {
 	t.Parallel()
 
-	keyForInsertion := []byte("keyForInsertion")
 	dataForInsertion := core.TrieData{
 		Key:     []byte("trieKey"),
 		Value:   []byte("trieValue"),
@@ -28,12 +27,12 @@ func TestTrieChangesBatch_Add(t *testing.T) {
 	}
 
 	tcb := NewTrieChangesBatch()
-	tcb.deletedKeys[string(keyForInsertion)] = struct{}{}
+	tcb.deletedKeys[string(dataForInsertion.Key)] = struct{}{}
 
-	tcb.Add(keyForInsertion, dataForInsertion)
+	tcb.Add(dataForInsertion)
 	assert.Equal(t, 0, len(tcb.deletedKeys))
 	assert.Equal(t, 1, len(tcb.insertedData))
-	assert.Equal(t, dataForInsertion, tcb.insertedData[string(keyForInsertion)])
+	assert.Equal(t, dataForInsertion, tcb.insertedData[string(dataForInsertion.Key)])
 }
 
 func TestTrieChangesBatch_MarkForRemoval(t *testing.T) {
@@ -102,14 +101,15 @@ func TestTrieChangesBatch_GetSortedDataForInsertion(t *testing.T) {
 	t.Parallel()
 
 	tcb := NewTrieChangesBatch()
+	tcb.insertedData["key3"] = core.TrieData{Key: []byte("key3")}
+	tcb.insertedData["key1"] = core.TrieData{Key: []byte("key1")}
+	tcb.insertedData["key2"] = core.TrieData{Key: []byte("key2")}
 
-	tcb.insertedData["key3"] = core.TrieData{}
-	tcb.insertedData["key1"] = core.TrieData{}
-	tcb.insertedData["key2"] = core.TrieData{}
-
-	keys, data := tcb.GetSortedDataForInsertion()
-	assert.Equal(t, []string{"key1", "key2", "key3"}, keys)
+	data := tcb.GetSortedDataForInsertion()
 	assert.Equal(t, 3, len(data))
+	assert.Equal(t, "key1", string(data[0].Key))
+	assert.Equal(t, "key2", string(data[1].Key))
+	assert.Equal(t, "key3", string(data[2].Key))
 }
 
 func TestTrieChangesBatch_GetSortedDataForRemoval(t *testing.T) {
@@ -121,6 +121,9 @@ func TestTrieChangesBatch_GetSortedDataForRemoval(t *testing.T) {
 	tcb.deletedKeys["key1"] = struct{}{}
 	tcb.deletedKeys["key2"] = struct{}{}
 
-	keys := tcb.GetSortedDataForRemoval()
-	assert.Equal(t, []string{"key1", "key2", "key3"}, keys)
+	data := tcb.GetSortedDataForRemoval()
+	assert.Equal(t, 3, len(data))
+	assert.Equal(t, "key1", string(data[0].Key))
+	assert.Equal(t, "key2", string(data[1].Key))
+	assert.Equal(t, "key3", string(data[2].Key))
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- All the trie changes are added to a batch before being added to the trie. When the batch is commited to the trie, the changes are added one by one. 
  
## Proposed changes
- In order to reduce the time spent on saving the changes from the batch to the trie, add all the batched data to the trie in one go. 
- The next step will be to add the data to the trie using goroutines

## Testing procedure
- Normal testing procedure

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
