### PR TITLE
fix gas used and fee esdt transfer transactions

### DIFF
--- a/factory/processing/blockProcessorCreator.go
+++ b/factory/processing/blockProcessorCreator.go
@@ -1032,6 +1032,7 @@ func (pcf *processComponentsFactory) createOutportDataProvider(
 		MbsStorer:              mbsStorer,
 		EnableEpochsHandler:    pcf.coreData.EnableEpochsHandler(),
 		ExecutionOrderGetter:   pcf.txExecutionOrderHandler,
+		GasSchedule:            pcf.gasSchedule,
 	})
 }
 

--- a/outport/process/factory/check.go
+++ b/outport/process/factory/check.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/outport/process"
 	"github.com/multiversx/mx-chain-go/outport/process/alteredaccounts"
 	"github.com/multiversx/mx-chain-go/outport/process/transactionsfee"
@@ -49,6 +50,9 @@ func checkArgOutportDataProviderFactory(arg ArgOutportDataProviderFactory) error
 	}
 	if check.IfNil(arg.ExecutionOrderGetter) {
 		return process.ErrNilExecutionOrderGetter
+	}
+	if check.IfNil(arg.GasSchedule) {
+		return errors.ErrNilGasSchedule
 	}
 
 	return nil

--- a/outport/process/factory/check_test.go
+++ b/outport/process/factory/check_test.go
@@ -14,10 +14,12 @@ import (
 	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
 	"github.com/multiversx/mx-chain-go/testscommon/shardingMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/state"
+	"github.com/multiversx/mx-chain-go/vm/systemSmartContracts/defaults"
 	"github.com/stretchr/testify/require"
 )
 
 func createArgOutportDataProviderFactory() ArgOutportDataProviderFactory {
+
 	return ArgOutportDataProviderFactory{
 		HasDrivers:             false,
 		AddressConverter:       testscommon.NewPubkeyConverterMock(32),
@@ -34,6 +36,7 @@ func createArgOutportDataProviderFactory() ArgOutportDataProviderFactory {
 		MbsStorer:              &genericMocks.StorerMock{},
 		EnableEpochsHandler:    &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
 		ExecutionOrderGetter:   &commonMocks.TxExecutionOrderHandlerStub{},
+		GasSchedule:            testscommon.NewGasScheduleNotifierMock(defaults.FillGasMapInternal(map[string]map[string]uint64{}, 1)),
 	}
 }
 

--- a/outport/process/factory/outportDataProviderFactory.go
+++ b/outport/process/factory/outportDataProviderFactory.go
@@ -36,6 +36,7 @@ type ArgOutportDataProviderFactory struct {
 	MbsStorer              storage.Storer
 	EnableEpochsHandler    common.EnableEpochsHandler
 	ExecutionOrderGetter   common.ExecutionOrderGetter
+	GasSchedule            core.GasScheduleNotifier
 }
 
 // CreateOutportDataProvider will create a new instance of outport.DataProviderOutport
@@ -59,12 +60,18 @@ func CreateOutportDataProvider(arg ArgOutportDataProviderFactory) (outport.DataP
 		return nil, err
 	}
 
+	builtInCost, err := transactionsfee.NewBuiltInFunctionsCost(arg.GasSchedule)
+	if err != nil {
+		return nil, err
+	}
+
 	transactionsFeeProc, err := transactionsfee.NewTransactionsFeeProcessor(transactionsfee.ArgTransactionsFeeProcessor{
 		Marshaller:         arg.Marshaller,
 		TransactionsStorer: arg.TransactionsStorer,
 		ShardCoordinator:   arg.ShardCoordinator,
 		TxFeeCalculator:    arg.EconomicsData,
 		PubKeyConverter:    arg.AddressConverter,
+		BuiltInCost:        builtInCost,
 	})
 	if err != nil {
 		return nil, err

--- a/outport/process/transactionsfee/builtInCost.go
+++ b/outport/process/transactionsfee/builtInCost.go
@@ -1,0 +1,89 @@
+package transactionsfee
+
+import (
+	"github.com/mitchellh/mapstructure"
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/process"
+)
+
+// ArgsBuiltInFunctionCost holds all components that are needed to create a new instance of builtInFunctionsCost
+type ArgsBuiltInFunctionCost struct {
+	GasSchedule core.GasScheduleNotifier
+	ArgsParser  process.ArgumentsParser
+}
+
+type builtInFunctionsCost struct {
+	gasConfig *process.GasCost
+}
+
+// NewBuiltInFunctionsCost will create a new instance of builtInFunctionsCost
+func NewBuiltInFunctionsCost(gasSchedule core.GasScheduleNotifier) (*builtInFunctionsCost, error) {
+	if check.IfNil(gasSchedule) {
+		return nil, process.ErrNilGasSchedule
+	}
+
+	bs := &builtInFunctionsCost{}
+
+	var err error
+	bs.gasConfig, err = createGasConfig(gasSchedule.LatestGasSchedule())
+	if err != nil {
+		return nil, err
+	}
+
+	gasSchedule.RegisterNotifyHandler(bs)
+
+	return bs, nil
+}
+
+// GasScheduleChange is called when gas schedule is changed, thus all contracts must be updated
+func (bc *builtInFunctionsCost) GasScheduleChange(gasSchedule map[string]map[string]uint64) {
+	newGasConfig, err := createGasConfig(gasSchedule)
+	if err != nil {
+		return
+	}
+
+	bc.gasConfig = newGasConfig
+}
+
+// GetESDTTransferBuiltInCost -
+func (bc *builtInFunctionsCost) GetESDTTransferBuiltInCost() uint64 {
+	return bc.gasConfig.BuiltInCost.ESDTTransfer
+}
+
+// IsInterfaceNil returns true if underlying object is nil
+func (bc *builtInFunctionsCost) IsInterfaceNil() bool {
+	return bc == nil
+}
+
+func createGasConfig(gasMap map[string]map[string]uint64) (*process.GasCost, error) {
+	baseOps := &process.BaseOperationCost{}
+	err := mapstructure.Decode(gasMap[common.BaseOperationCost], baseOps)
+	if err != nil {
+		return nil, err
+	}
+
+	err = check.ForZeroUintFields(*baseOps)
+	if err != nil {
+		return nil, err
+	}
+
+	builtInOps := &process.BuiltInCost{}
+	err = mapstructure.Decode(gasMap[common.BuiltInCost], builtInOps)
+	if err != nil {
+		return nil, err
+	}
+
+	err = check.ForZeroUintFields(*builtInOps)
+	if err != nil {
+		return nil, err
+	}
+
+	gasCost := process.GasCost{
+		BaseOperationCost: *baseOps,
+		BuiltInCost:       *builtInOps,
+	}
+
+	return &gasCost, nil
+}

--- a/outport/process/transactionsfee/builtInCost_test.go
+++ b/outport/process/transactionsfee/builtInCost_test.go
@@ -1,0 +1,27 @@
+package transactionsfee
+
+import (
+	"testing"
+
+	"github.com/multiversx/mx-chain-go/process"
+	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/vm/systemSmartContracts/defaults"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBuiltInFunctionsCost(t *testing.T) {
+	t.Parallel()
+
+	builtInCostHandler, err := NewBuiltInFunctionsCost(nil)
+	require.Nil(t, builtInCostHandler)
+	require.Equal(t, err, process.ErrNilGasSchedule)
+}
+
+func TestBuiltInFunctionsCost_GetESDTTransferBuiltInCost(t *testing.T) {
+	t.Parallel()
+
+	builtInCostHandler, err := NewBuiltInFunctionsCost(testscommon.NewGasScheduleNotifierMock(defaults.FillGasMapInternal(map[string]map[string]uint64{}, 100)))
+	require.Nil(t, err)
+
+	require.Equal(t, uint64(100), builtInCostHandler.GetESDTTransferBuiltInCost())
+}

--- a/outport/process/transactionsfee/errors.go
+++ b/outport/process/transactionsfee/errors.go
@@ -13,3 +13,6 @@ var ErrNilStorage = errors.New("nil storage")
 
 // ErrNilMarshaller signals that a nil marshaller has been provided
 var ErrNilMarshaller = errors.New("nil Marshaller")
+
+// ErrNilBuiltInCostHandler signal that a nil builtin cost handler has been provided
+var ErrNilBuiltInCostHandler = errors.New("nil builtin cost handler")

--- a/outport/process/transactionsfee/interface.go
+++ b/outport/process/transactionsfee/interface.go
@@ -24,3 +24,9 @@ type transactionGetter interface {
 type dataFieldParser interface {
 	Parse(dataField []byte, sender, receiver []byte, numOfShards uint32) *datafield.ResponseParseData
 }
+
+// BuildInCostHandler defines the interface for the builtin cost handler
+type BuildInCostHandler interface {
+	GetESDTTransferBuiltInCost() uint64
+	IsInterfaceNil() bool
+}

--- a/outport/process/transactionsfee/transactionsFeeProcessor.go
+++ b/outport/process/transactionsfee/transactionsFeeProcessor.go
@@ -182,7 +182,9 @@ func (tep *transactionsFeeProcessor) prepareTxWithResultsBasedOnLogs(
 			tooMuchGas = strings.Contains(string(event.GetTopics()[1]), smartContract.TooMuchGasProvidedMessage)
 		}
 
-		if (isWriteLog && !hasRefund && !isESDTTransfer) || (isWriteLog && tooMuchGas) {
+		isWriteLogWithTooMuchGas := isWriteLog && tooMuchGas
+		isWriteLogNoRefundAndNoESDTTransfer := isWriteLog && !hasRefund && !isESDTTransfer
+		if isWriteLogNoRefundAndNoESDTTransfer || isWriteLogWithTooMuchGas {
 			gasUsed, fee := tep.txFeeCalculator.ComputeGasUsedAndFeeBasedOnRefundValue(txWithResults.GetTxHandler(), big.NewInt(0))
 			txWithResults.GetFeeInfo().SetGasUsed(gasUsed)
 			txWithResults.GetFeeInfo().SetFee(fee)


### PR DESCRIPTION
## Reasoning behind the pull request
- Bug: The fee and gasUsed fields is wrong calculated for cross-shard `ESDTTransfer` transactions
- Fixed the way gasUsed and fee for simple ESDTTransfer transactions are calculated
  
## Proposed changes
- Extended the transactions fee processor from the `outport` module to know how to compute the gas used and fee for `ESDTTransfer` transactions. 

## Testing procedure
- Do some ESDTTransfer transactions cross-shard and intra-shard and check the `gasUsed` and `fee` is correct
## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
