### PR TITLE
FIX: Outgoing op tx hash

### DIFF
--- a/cmd/sovereignnode/chainSimulator/sovereignChainSimulator.go
+++ b/cmd/sovereignnode/chainSimulator/sovereignChainSimulator.go
@@ -41,7 +41,6 @@ func NewSovereignChainSimulator(args ArgsSovereignChainSimulator) (chainSimulato
 		return nil, err
 	}
 
-	alteredSovConfigs := *configs.SovereignExtraConfig
 	args.AlterConfigsFunction = func(cfg *config.Configs) {
 		cfg.EconomicsConfig = configs.EconomicsConfig
 		cfg.EpochConfig = configs.EpochConfig
@@ -51,7 +50,7 @@ func NewSovereignChainSimulator(args ArgsSovereignChainSimulator) (chainSimulato
 
 		if alterConfigs != nil {
 			alterConfigs(cfg)
-			alteredSovConfigs = cfg.GeneralConfig.SovereignConfig
+			configs.SovereignExtraConfig = &cfg.GeneralConfig.SovereignConfig
 		}
 	}
 
@@ -66,10 +65,10 @@ func NewSovereignChainSimulator(args ArgsSovereignChainSimulator) (chainSimulato
 		return rating.NewSovereignRatingsData(arg)
 	}
 	args.CreateIncomingHeaderSubscriber = func(config *config.NotifierConfig, dataPool dataRetriever.PoolsHolder, mainChainNotarizationStartRound uint64, runTypeComponents factory.RunTypeComponentsHolder) (process.IncomingHeaderSubscriber, error) {
-		return incomingHeader.CreateIncomingHeaderProcessor(&alteredSovConfigs.NotifierConfig, dataPool, mainChainNotarizationStartRound, runTypeComponents)
+		return incomingHeader.CreateIncomingHeaderProcessor(config, dataPool, mainChainNotarizationStartRound, runTypeComponents)
 	}
 	args.CreateRunTypeComponents = func(argsRunType runType.ArgsRunTypeComponents) (factory.RunTypeComponentsHolder, error) {
-		return createSovereignRunTypeComponents(argsRunType, alteredSovConfigs)
+		return createSovereignRunTypeComponents(argsRunType, *configs.SovereignExtraConfig)
 	}
 	args.NodeFactory = node.NewSovereignNodeFactory()
 	args.ChainProcessorFactory = NewSovereignChainHandlerFactory()

--- a/cmd/sovereignnode/chainSimulator/tests/bridge/bridge_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/bridge/bridge_test.go
@@ -95,7 +95,8 @@ func TestSovereignChainSimulator_DeployBridgeContractsThenIssueAndDeposit(t *tes
 	bridgeData := DeploySovereignBridgeSetup(t, cs, wallet, esdtSafeWasmPath, feeMarketWasmPath)
 	require.Equal(t, expectedESDTSafeAddressBytes, bridgeData.ESDTSafeAddress)
 
-	nonce := uint64(5)
+	nonce := GetNonce(t, nodeHandler, wallet.Bech32)
+
 	issueCost, _ := big.NewInt(0).SetString(issuePrice, 10)
 	supply, _ := big.NewInt(0).SetString("123000000000000000000", 10)
 	tokenName := "SovToken"

--- a/cmd/sovereignnode/chainSimulator/tests/bridge/bridge_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/bridge/bridge_test.go
@@ -111,7 +111,7 @@ func TestSovereignChainSimulator_DeployBridgeContractsThenIssueAndDeposit(t *tes
 		Amount:     amountToDeposit,
 	})
 
-	chainSim.Deposit(t, cs, wallet.Bytes, &nonce, bridgeData.ESDTSafeAddress, depositTokens, wallet.Bytes, nil)
+	Deposit(t, cs, wallet.Bytes, &nonce, bridgeData.ESDTSafeAddress, depositTokens, wallet.Bytes, nil)
 
 	tokens, _, err := nodeHandler.GetFacadeHandler().GetAllESDTTokens(wallet.Bech32, coreAPI.AccountQueryOptions{})
 	require.Nil(t, err)

--- a/cmd/sovereignnode/chainSimulator/tests/bridge/bridge_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/bridge/bridge_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/multiversx/mx-chain-core-go/core"
+	coreAPI "github.com/multiversx/mx-chain-core-go/data/api"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/stretchr/testify/require"
 
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
@@ -14,10 +17,6 @@ import (
 	"github.com/multiversx/mx-chain-go/node/chainSimulator/components/api"
 	"github.com/multiversx/mx-chain-go/node/chainSimulator/dtos"
 	sovereignChainSimulator "github.com/multiversx/mx-chain-go/sovereignnode/chainSimulator"
-
-	"github.com/multiversx/mx-chain-core-go/core"
-	coreAPI "github.com/multiversx/mx-chain-core-go/data/api"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -72,6 +71,9 @@ func TestSovereignChainSimulator_DeployBridgeContractsThenIssueAndDeposit(t *tes
 	require.NotNil(t, cs)
 
 	defer cs.Close()
+
+	err = cs.GenerateBlocks(1)
+	require.Nil(t, err)
 
 	nodeHandler := cs.GetNodeHandler(core.SovereignChainShardId)
 

--- a/cmd/sovereignnode/chainSimulator/tests/bridge/common.go
+++ b/cmd/sovereignnode/chainSimulator/tests/bridge/common.go
@@ -4,8 +4,10 @@ import (
 	"encoding/hex"
 	"testing"
 
+	coreAPI "github.com/multiversx/mx-chain-core-go/data/api"
 	chainSim "github.com/multiversx/mx-chain-go/integrationTests/chainSimulator"
 	"github.com/multiversx/mx-chain-go/node/chainSimulator/dtos"
+	"github.com/multiversx/mx-chain-go/node/chainSimulator/process"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
@@ -42,10 +44,8 @@ func DeploySovereignBridgeSetup(
 	feeMarketWasmPath string,
 ) *ArgsBridgeSetup {
 	nodeHandler := cs.GetNodeHandler(core.SovereignChainShardId)
-
 	systemScAddress := chainSim.GetSysAccBytesAddress(t, nodeHandler)
-
-	nonce := uint64(0)
+	nonce := GetNonce(t, nodeHandler, wallet.Bech32)
 
 	esdtSafeArgs := "@01" + // is_sovereign_chain
 		"@" + // min_valid_signers
@@ -70,6 +70,14 @@ func DeploySovereignBridgeSetup(
 		ESDTSafeAddress:  esdtSafeAddress,
 		FeeMarketAddress: feeMarketAddress,
 	}
+}
+
+// GetNonce returns account's nonce
+func GetNonce(t *testing.T, nodeHandler process.NodeHandler, address string) uint64 {
+	acc, _, err := nodeHandler.GetFacadeHandler().GetAccount(address, coreAPI.AccountQueryOptions{})
+	require.Nil(t, err)
+
+	return acc.Nonce
 }
 
 // Deposit will deposit tokens in the bridge sc safe contract

--- a/cmd/sovereignnode/chainSimulator/tests/bridge/common.go
+++ b/cmd/sovereignnode/chainSimulator/tests/bridge/common.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	chainSim "github.com/multiversx/mx-chain-go/integrationTests/chainSimulator"
+	"github.com/multiversx/mx-chain-go/node/chainSimulator/dtos"
 
 	"github.com/multiversx/mx-chain-core-go/core"
-	"github.com/stretchr/testify/require"
 )
 
 // ArgsBridgeSetup holds the arguments for bridge setup
@@ -26,6 +26,7 @@ type ArgsBridgeSetup struct {
 func DeploySovereignBridgeSetup(
 	t *testing.T,
 	cs chainSim.ChainSimulator,
+	wallet dtos.WalletAddress,
 	esdtSafeWasmPath string,
 	feeMarketWasmPath string,
 ) *ArgsBridgeSetup {
@@ -33,8 +34,6 @@ func DeploySovereignBridgeSetup(
 
 	systemScAddress := chainSim.GetSysAccBytesAddress(t, nodeHandler)
 
-	wallet, err := cs.GenerateAndMintWalletAddress(core.SovereignChainShardId, chainSim.InitialAmount)
-	require.Nil(t, err)
 	nonce := uint64(0)
 
 	esdtSafeArgs := "@01" + // is_sovereign_chain

--- a/process/block/preprocess/basePreProcess.go
+++ b/process/block/preprocess/basePreProcess.go
@@ -12,6 +12,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -938,11 +938,12 @@ func (scbp *sovereignChainBlockProcessor) addOutGoingTxToPool(outGoingOp *sovCor
 		Data:     outGoingOp.Data,
 	}
 
+	cacheID := fmt.Sprintf("%d_%d", core.SovereignChainShardId, core.MainChainShardId)
 	scbp.dataPool.Transactions().AddData(
 		outGoingOp.Hash,
 		tx,
 		tx.Size(),
-		fmt.Sprintf("%d_%d", core.SovereignChainShardId, core.MainChainShardId),
+		cacheID,
 	)
 }
 

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -6,7 +6,14 @@ import (
 	"sort"
 	"time"
 
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/block"
+	sovCore "github.com/multiversx/mx-chain-core-go/data/sovereign"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-core-go/hashing"
+	logger "github.com/multiversx/mx-chain-logger-go"
 
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/holders"
@@ -18,14 +25,6 @@ import (
 	"github.com/multiversx/mx-chain-go/process/block/processedMb"
 	"github.com/multiversx/mx-chain-go/process/block/sovereign"
 	"github.com/multiversx/mx-chain-go/state"
-
-	"github.com/multiversx/mx-chain-core-go/core"
-	"github.com/multiversx/mx-chain-core-go/core/check"
-	"github.com/multiversx/mx-chain-core-go/data"
-	"github.com/multiversx/mx-chain-core-go/data/block"
-	sovCore "github.com/multiversx/mx-chain-core-go/data/sovereign"
-	"github.com/multiversx/mx-chain-core-go/hashing"
-	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
 var rootHash = "uncomputed root hash"

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -973,9 +973,8 @@ func (scbp *sovereignChainBlockProcessor) setOutGoingMiniBlock(
 	}
 
 	createdBlockBody.MiniBlocks = append(createdBlockBody.MiniBlocks, outGoingMb)
-
 	scbp.txCoordinator.AddTxsFromMiniBlocks([]*block.MiniBlock{outGoingMb})
-	return err
+	return nil
 }
 
 func (scbp *sovereignChainBlockProcessor) waitForExtendedHeadersIfMissing(requestedExtendedShardHdrs uint32, haveTime func() time.Duration) error {

--- a/process/coordinator/process.go
+++ b/process/coordinator/process.go
@@ -1544,6 +1544,9 @@ func (tc *transactionCoordinator) VerifyCreatedMiniBlocks(
 	header data.HeaderHandler,
 	body *block.Body,
 ) error {
+	if header.GetEpoch() < tc.enableEpochsHandler.GetActivationEpoch(common.BlockGasAndFeesReCheckFlag) {
+		return nil
+	}
 
 	mapMiniBlockTypeAllTxs := tc.getAllTransactions(body)
 

--- a/process/coordinator/process.go
+++ b/process/coordinator/process.go
@@ -15,6 +15,8 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+	logger "github.com/multiversx/mx-chain-logger-go"
+
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/block/preprocess"
@@ -24,7 +26,6 @@ import (
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/storage"
 	"github.com/multiversx/mx-chain-go/storage/cache"
-	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
 var _ process.TransactionCoordinator = (*transactionCoordinator)(nil)
@@ -1543,9 +1544,6 @@ func (tc *transactionCoordinator) VerifyCreatedMiniBlocks(
 	header data.HeaderHandler,
 	body *block.Body,
 ) error {
-	if header.GetEpoch() < tc.enableEpochsHandler.GetActivationEpoch(common.BlockGasAndFeesReCheckFlag) {
-		return nil
-	}
 
 	mapMiniBlockTypeAllTxs := tc.getAllTransactions(body)
 


### PR DESCRIPTION
## Reasoning behind the pull request
- When setting outgoing mb after whole processing is done (which contain outgoing operations),  there are some extra checks that can cause the chain to halt. Mainly, we were missing some saved txs for the outgoing tx hashes, which were not found and also failed gas limit checks
  
## Proposed changes
-  Since we weren't saving outgoing operations anyway (especially the data inside time), I think it's better to save it in the storage as a "dummy" tx with the outGoingTxData that is used by the bridge service to format txs for main chain.

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
