### PR TITLE
FIX: System sc end of epoch init for genesis block on sovereign

### DIFF
--- a/epochStart/metachain/common.go
+++ b/epochStart/metachain/common.go
@@ -1,6 +1,8 @@
 package metachain
 
-import "github.com/multiversx/mx-chain-go/state"
+import (
+	"github.com/multiversx/mx-chain-go/state"
+)
 
 // GetAllNodeKeys returns all <shard,pubKeys> from the provided map
 func GetAllNodeKeys(validatorsInfo state.ShardValidatorsInfoMapHandler) map[uint32][][]byte {

--- a/epochStart/metachain/legacySystemSCs.go
+++ b/epochStart/metachain/legacySystemSCs.go
@@ -820,7 +820,36 @@ func (s *legacySystemSCProcessor) getUserAccount(address []byte) (state.UserAcco
 func (s *legacySystemSCProcessor) processSCOutputAccounts(
 	vmOutput *vmcommon.VMOutput,
 ) error {
-	return genesisCommon.ProcessSCOutputAccounts(vmOutput, s.userAccountsDB)
+
+	outputAccounts := process.SortVMOutputInsideData(vmOutput)
+	for _, outAcc := range outputAccounts {
+		acc, err := s.getUserAccount(outAcc.Address)
+		if err != nil {
+			return err
+		}
+
+		storageUpdates := process.GetSortedStorageUpdates(outAcc)
+		for _, storeUpdate := range storageUpdates {
+			err = acc.SaveKeyValue(storeUpdate.Offset, storeUpdate.Data)
+			if err != nil {
+				return err
+			}
+		}
+
+		if outAcc.BalanceDelta != nil && outAcc.BalanceDelta.Cmp(zero) != 0 {
+			err = acc.AddToBalance(outAcc.BalanceDelta)
+			if err != nil {
+				return err
+			}
+		}
+
+		err = s.userAccountsDB.SaveAccount(acc)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (s *legacySystemSCProcessor) getSortedJailedNodes(validatorsInfoMap state.ShardValidatorsInfoMapHandler) []state.ValidatorInfoHandler {
@@ -1031,7 +1060,41 @@ func (s *legacySystemSCProcessor) callSetOwnersOnAddresses(arguments [][]byte) e
 }
 
 func (s *legacySystemSCProcessor) initDelegationSystemSC() error {
-	return genesisCommon.InitDelegationSystemSC(s.systemVM, s.userAccountsDB)
+	codeMetaData := &vmcommon.CodeMetadata{
+		Upgradeable: false,
+		Payable:     false,
+		Readable:    true,
+	}
+
+	vmInput := &vmcommon.ContractCreateInput{
+		VMInput: vmcommon.VMInput{
+			CallerAddr: vm.DelegationManagerSCAddress,
+			Arguments:  [][]byte{},
+			CallValue:  big.NewInt(0),
+		},
+		ContractCode:         vm.DelegationManagerSCAddress,
+		ContractCodeMetadata: codeMetaData.ToBytes(),
+	}
+
+	vmOutput, err := s.systemVM.RunSmartContractCreate(vmInput)
+	if err != nil {
+		return err
+	}
+	if vmOutput.ReturnCode != vmcommon.Ok {
+		return epochStart.ErrCouldNotInitDelegationSystemSC
+	}
+
+	err = s.processSCOutputAccounts(vmOutput)
+	if err != nil {
+		return err
+	}
+
+	err = genesisCommon.UpdateSystemSCContractsCode(vmInput.ContractCodeMetadata, s.userAccountsDB)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *legacySystemSCProcessor) cleanAdditionalQueue() error {

--- a/epochStart/metachain/systemSCs.go
+++ b/epochStart/metachain/systemSCs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/epochStart"
+	genesisCommon "github.com/multiversx/mx-chain-go/genesis/process/common"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/sharding"
 	"github.com/multiversx/mx-chain-go/sharding/nodesCoordinator"
@@ -225,29 +226,7 @@ func (s *systemSCProcessor) unStakeNodesWithNotEnoughFundsWithStakingV4(
 }
 
 func (s *systemSCProcessor) updateToGovernanceV2() error {
-	vmInput := &vmcommon.ContractCallInput{
-		VMInput: vmcommon.VMInput{
-			CallerAddr: vm.GovernanceSCAddress,
-			CallValue:  big.NewInt(0),
-			Arguments:  [][]byte{},
-		},
-		RecipientAddr: vm.GovernanceSCAddress,
-		Function:      "initV2",
-	}
-	vmOutput, errRun := s.systemVM.RunSmartContractCall(vmInput)
-	if errRun != nil {
-		return fmt.Errorf("%w when updating to governanceV2", errRun)
-	}
-	if vmOutput.ReturnCode != vmcommon.Ok {
-		return fmt.Errorf("got return code %s when updating to governanceV2", vmOutput.ReturnCode)
-	}
-
-	err := s.processSCOutputAccounts(vmOutput)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return genesisCommon.InitGovernanceV2(s.systemVM, s.userAccountsDB)
 }
 
 // IsInterfaceNil returns true if underlying object is nil

--- a/factory/processing/processComponents_test.go
+++ b/factory/processing/processComponents_test.go
@@ -135,6 +135,7 @@ func createProcessComponentsFactoryArgs(runTypeComponents *mainFactoryMocks.RunT
 				},
 				Active: config.GovernanceSystemSCConfigActive{
 					ProposalCost:     "500",
+					LostProposalFee:  "100",
 					MinQuorum:        0.5,
 					MinPassThreshold: 0.5,
 					MinVetoThreshold: 0.5,

--- a/genesis/mock/coreComponentsMock.go
+++ b/genesis/mock/coreComponentsMock.go
@@ -76,6 +76,7 @@ func (ccm *CoreComponentsMock) TxVersionChecker() process.TxVersionCheckerHandle
 	return ccm.TxVersionCheck
 }
 
+// Rater -
 func (ccm *CoreComponentsMock) Rater() sharding.PeerAccountListAndRatingHandler {
 	return ccm.RaterField
 }

--- a/genesis/mock/coreComponentsMock.go
+++ b/genesis/mock/coreComponentsMock.go
@@ -7,6 +7,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/process"
+	"github.com/multiversx/mx-chain-go/sharding"
 )
 
 // CoreComponentsMock -
@@ -22,6 +23,7 @@ type CoreComponentsMock struct {
 	StatHandler              core.AppStatusHandler
 	EnableEpochsHandlerField common.EnableEpochsHandler
 	TxVersionCheck           process.TxVersionCheckerHandler
+	RaterField               sharding.PeerAccountListAndRatingHandler
 }
 
 // InternalMarshalizer -
@@ -72,6 +74,10 @@ func (ccm *CoreComponentsMock) EnableEpochsHandler() common.EnableEpochsHandler 
 // TxVersionChecker -
 func (ccm *CoreComponentsMock) TxVersionChecker() process.TxVersionCheckerHandler {
 	return ccm.TxVersionCheck
+}
+
+func (ccm *CoreComponentsMock) Rater() sharding.PeerAccountListAndRatingHandler {
+	return ccm.RaterField
 }
 
 // IsInterfaceNil -

--- a/genesis/process/argGenesisBlockCreator.go
+++ b/genesis/process/argGenesisBlockCreator.go
@@ -9,12 +9,11 @@ import (
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
-	factoryVm "github.com/multiversx/mx-chain-go/factory/vm"
-
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/dblookupext"
+	factoryVm "github.com/multiversx/mx-chain-go/factory/vm"
 	"github.com/multiversx/mx-chain-go/genesis"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/block/preprocess"
@@ -36,6 +35,7 @@ type coreComponentsHandler interface {
 	TxVersionChecker() process.TxVersionCheckerHandler
 	ChainID() string
 	EnableEpochsHandler() common.EnableEpochsHandler
+	Rater() sharding.PeerAccountListAndRatingHandler
 	IsInterfaceNil() bool
 }
 

--- a/genesis/process/argGenesisBlockCreator.go
+++ b/genesis/process/argGenesisBlockCreator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
+	factoryVm "github.com/multiversx/mx-chain-go/factory/vm"
 
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/config"
@@ -57,6 +58,7 @@ type runTypeComponentsHandler interface {
 	ShardCoordinatorCreator() sharding.ShardCoordinatorFactory
 	TxPreProcessorCreator() preprocess.TxPreProcessorCreator
 	VMContextCreator() systemSmartContracts.VMContextCreatorHandler
+	VmContainerShardFactoryCreator() factoryVm.VmContainerCreator
 	IsInterfaceNil() bool
 }
 

--- a/genesis/process/argGenesisBlockCreator.go
+++ b/genesis/process/argGenesisBlockCreator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/typeConverters"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+
 	crypto "github.com/multiversx/mx-chain-crypto-go"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/config"

--- a/genesis/process/common/initialization.go
+++ b/genesis/process/common/initialization.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"math/big"
 
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+
 	"github.com/multiversx/mx-chain-go/epochStart"
 	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/vm"
-	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
 var zero = big.NewInt(0)

--- a/genesis/process/common/initialization.go
+++ b/genesis/process/common/initialization.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/multiversx/mx-chain-go/epochStart"
@@ -125,6 +126,32 @@ func ProcessSCOutputAccounts(
 		if err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func InitGovernanceV2(systemVM vmcommon.VMExecutionHandler, userAccountsDB state.AccountsAdapter) error {
+	vmInput := &vmcommon.ContractCallInput{
+		VMInput: vmcommon.VMInput{
+			CallerAddr: vm.GovernanceSCAddress,
+			CallValue:  big.NewInt(0),
+			Arguments:  [][]byte{},
+		},
+		RecipientAddr: vm.GovernanceSCAddress,
+		Function:      "initV2",
+	}
+	vmOutput, errRun := systemVM.RunSmartContractCall(vmInput)
+	if errRun != nil {
+		return fmt.Errorf("%w when updating to governanceV2", errRun)
+	}
+	if vmOutput.ReturnCode != vmcommon.Ok {
+		return fmt.Errorf("got return code %s when updating to governanceV2", vmOutput.ReturnCode)
+	}
+
+	err := ProcessSCOutputAccounts(vmOutput, userAccountsDB)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/genesis/process/common/initialization.go
+++ b/genesis/process/common/initialization.go
@@ -58,6 +58,7 @@ func getUserAccount(address []byte, userAccountsDB state.AccountsAdapter) (state
 	return userAcc, nil
 }
 
+// InitDelegationSystemSC inits the delegation system sc
 func InitDelegationSystemSC(systemVM vmcommon.VMExecutionHandler, userAccountsDB state.AccountsAdapter) error {
 	codeMetaData := &vmcommon.CodeMetadata{
 		Upgradeable: false,
@@ -96,6 +97,7 @@ func InitDelegationSystemSC(systemVM vmcommon.VMExecutionHandler, userAccountsDB
 	return nil
 }
 
+// ProcessSCOutputAccounts processes sc output accounts
 func ProcessSCOutputAccounts(
 	vmOutput *vmcommon.VMOutput,
 	userAccountsDB state.AccountsAdapter,
@@ -132,6 +134,7 @@ func ProcessSCOutputAccounts(
 	return nil
 }
 
+// InitGovernanceV2 inits governance v2
 func InitGovernanceV2(systemVM vmcommon.VMExecutionHandler, userAccountsDB state.AccountsAdapter) error {
 	vmInput := &vmcommon.ContractCallInput{
 		VMInput: vmcommon.VMInput{

--- a/genesis/process/common/initialization.go
+++ b/genesis/process/common/initialization.go
@@ -1,10 +1,17 @@
 package common
 
 import (
+	"math/big"
+
+	"github.com/multiversx/mx-chain-go/epochStart"
 	"github.com/multiversx/mx-chain-go/errors"
+	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/vm"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
+
+var zero = big.NewInt(0)
 
 // UpdateSystemSCContractsCode will update system accounts contract codes, code, and owner, except for the sys account for each shard
 func UpdateSystemSCContractsCode(contractMetadata []byte, userAccountsDB state.AccountsAdapter) error {
@@ -47,4 +54,78 @@ func getUserAccount(address []byte, userAccountsDB state.AccountsAdapter) (state
 	}
 
 	return userAcc, nil
+}
+
+func InitDelegationSystemSC(systemVM vmcommon.VMExecutionHandler, userAccountsDB state.AccountsAdapter) error {
+	codeMetaData := &vmcommon.CodeMetadata{
+		Upgradeable: false,
+		Payable:     false,
+		Readable:    true,
+	}
+
+	vmInput := &vmcommon.ContractCreateInput{
+		VMInput: vmcommon.VMInput{
+			CallerAddr: vm.DelegationManagerSCAddress,
+			Arguments:  [][]byte{},
+			CallValue:  big.NewInt(0),
+		},
+		ContractCode:         vm.DelegationManagerSCAddress,
+		ContractCodeMetadata: codeMetaData.ToBytes(),
+	}
+
+	vmOutput, err := systemVM.RunSmartContractCreate(vmInput)
+	if err != nil {
+		return err
+	}
+	if vmOutput.ReturnCode != vmcommon.Ok {
+		return epochStart.ErrCouldNotInitDelegationSystemSC
+	}
+
+	err = ProcessSCOutputAccounts(vmOutput, userAccountsDB)
+	if err != nil {
+		return err
+	}
+
+	err = UpdateSystemSCContractsCode(vmInput.ContractCodeMetadata, userAccountsDB)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ProcessSCOutputAccounts(
+	vmOutput *vmcommon.VMOutput,
+	userAccountsDB state.AccountsAdapter,
+) error {
+
+	outputAccounts := process.SortVMOutputInsideData(vmOutput)
+	for _, outAcc := range outputAccounts {
+		acc, err := getUserAccount(outAcc.Address, userAccountsDB)
+		if err != nil {
+			return err
+		}
+
+		storageUpdates := process.GetSortedStorageUpdates(outAcc)
+		for _, storeUpdate := range storageUpdates {
+			err = acc.SaveKeyValue(storeUpdate.Offset, storeUpdate.Data)
+			if err != nil {
+				return err
+			}
+		}
+
+		if outAcc.BalanceDelta != nil && outAcc.BalanceDelta.Cmp(zero) != 0 {
+			err = acc.AddToBalance(outAcc.BalanceDelta)
+			if err != nil {
+				return err
+			}
+		}
+
+		err = userAccountsDB.SaveAccount(acc)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/genesis/process/genesisBlockCreator.go
+++ b/genesis/process/genesisBlockCreator.go
@@ -185,6 +185,9 @@ func checkArgumentsForBlockCreator(arg ArgsGenesisBlockCreator) error {
 	if check.IfNil(arg.Data.Datapool()) {
 		return process.ErrNilPoolsHolder
 	}
+	if check.IfNil(arg.Core.Rater()) {
+		return process.ErrNilRater
+	}
 	if check.IfNil(arg.GasSchedule) {
 		return process.ErrNilGasSchedule
 	}
@@ -217,6 +220,12 @@ func checkArgumentsForBlockCreator(arg ArgsGenesisBlockCreator) error {
 	}
 	if check.IfNil(arg.RunTypeComponents.TxPreProcessorCreator()) {
 		return errors.ErrNilTxPreProcessorCreator
+	}
+	if check.IfNil(arg.RunTypeComponents.VMContextCreator()) {
+		return errors.ErrNilVMContextCreator
+	}
+	if check.IfNil(arg.RunTypeComponents.VmContainerShardFactoryCreator()) {
+		return errors.ErrNilVmContainerShardFactoryCreator
 	}
 	if arg.TrieStorageManagers == nil {
 		return genesis.ErrNilTrieStorageManager

--- a/genesis/process/genesisBlockCreator_test.go
+++ b/genesis/process/genesisBlockCreator_test.go
@@ -92,6 +92,7 @@ func createArgument(
 			TxVersionCheck:           &testscommon.TxVersionCheckerStub{},
 			MinTxVersion:             1,
 			EnableEpochsHandlerField: &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
+			RaterField:               &testscommon.RaterMock{},
 		},
 		Data: &mock.DataComponentsMock{
 			Storage: &storageCommon.ChainStorerStub{

--- a/genesis/process/genesisBlockCreator_test.go
+++ b/genesis/process/genesisBlockCreator_test.go
@@ -339,6 +339,21 @@ func TestNewGenesisBlockCreator(t *testing.T) {
 		require.ErrorIs(t, err, process.ErrNilPubkeyConverter)
 		require.Nil(t, gbc)
 	})
+	t.Run("nil Rater should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgument(t, "testdata/genesisTest1.json", &mock.InitialNodesHandlerStub{}, big.NewInt(22000))
+		arg.Core = &mock.CoreComponentsMock{
+			AddrPubKeyConv: testscommon.NewPubkeyConverterMock(32),
+			IntMarsh:       &mock.MarshalizerMock{},
+			Hash:           &hashingMocks.HasherMock{},
+			RaterField:     nil,
+		}
+
+		gbc, err := NewGenesisBlockCreator(arg)
+		require.ErrorIs(t, err, process.ErrNilRater)
+		require.Nil(t, gbc)
+	})
 	t.Run("nil InitialNodesSetup should error", func(t *testing.T) {
 		t.Parallel()
 
@@ -545,6 +560,30 @@ func TestNewGenesisBlockCreator(t *testing.T) {
 
 		gbc, err := NewGenesisBlockCreator(arg)
 		require.True(t, errors.Is(err, errorsMx.ErrNilTxPreProcessorCreator))
+		require.Nil(t, gbc)
+	})
+	t.Run("nil VMContextCreator, should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgument(t, "testdata/genesisTest1.json", &mock.InitialNodesHandlerStub{}, big.NewInt(22000))
+		rtComponents := genesisMocks.NewRunTypeComponentsStub()
+		rtComponents.VMContextCreatorHandler = nil
+		arg.RunTypeComponents = rtComponents
+
+		gbc, err := NewGenesisBlockCreator(arg)
+		require.True(t, errors.Is(err, errorsMx.ErrNilVMContextCreator))
+		require.Nil(t, gbc)
+	})
+	t.Run("nil VmContainerShardFactoryCreator, should error", func(t *testing.T) {
+		t.Parallel()
+
+		arg := createMockArgument(t, "testdata/genesisTest1.json", &mock.InitialNodesHandlerStub{}, big.NewInt(22000))
+		rtComponents := genesisMocks.NewRunTypeComponentsStub()
+		rtComponents.VmContainerShardFactory = nil
+		arg.RunTypeComponents = rtComponents
+
+		gbc, err := NewGenesisBlockCreator(arg)
+		require.True(t, errors.Is(err, errorsMx.ErrNilVmContainerShardFactoryCreator))
 		require.Nil(t, gbc)
 	})
 	t.Run("nil TrieStorageManagers should error", func(t *testing.T) {

--- a/genesis/process/shardGenesisBlockCreator.go
+++ b/genesis/process/shardGenesisBlockCreator.go
@@ -420,7 +420,7 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, enableEpo
 		return nil, err
 	}
 
-	pubKeyVerifier, err := disabled.NewMessageSignVerifier(arg.BlockSignKeyGen)
+	messageSignVerifier, err := disabled.NewMessageSignVerifier(arg.BlockSignKeyGen)
 	if err != nil {
 		return nil, err
 	}
@@ -455,7 +455,7 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, enableEpo
 		ValidatorAccountsDB: arg.ValidatorAccounts,
 		ChanceComputer:      arg.Core.Rater(),
 		NodesConfigProvider: arg.InitialNodesSetup,
-		MessageSignVerifier: pubKeyVerifier,
+		MessageSignVerifier: messageSignVerifier,
 		NodesCoordinator:    liteNodesCoordinator,
 	})
 	if err != nil {

--- a/genesis/process/shardGenesisBlockCreator.go
+++ b/genesis/process/shardGenesisBlockCreator.go
@@ -11,7 +11,6 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	dataBlock "github.com/multiversx/mx-chain-core-go/data/block"
-	"github.com/multiversx/mx-chain-go/testscommon/shardingMocks"
 	logger "github.com/multiversx/mx-chain-logger-go"
 	"github.com/multiversx/mx-chain-vm-common-go/parsers"
 
@@ -428,11 +427,9 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, enableEpo
 	// VM container only needs to know the number of eligible nodes.
 	// At genesis, we don't need a full nodes coordinator, and this information
 	// is already available in initial nodes setup from genesis
-	liteNodesCoordinator := &shardingMocks.NodesCoordinatorMock{
-		GetNumTotalEligibleCalled: func() uint64 {
-			eligible, _ := arg.InitialNodesSetup.InitialNodesInfo()
-			return uint64(len(eligible))
-		},
+	eligible, _ := arg.InitialNodesSetup.InitialNodesInfo()
+	liteNodesCoordinator := &vmNodesCoordinator{
+		numEligible: uint64(len(eligible)),
 	}
 
 	vmContainer, vmFactoryImpl, err := arg.RunTypeComponents.VmContainerShardFactoryCreator().CreateVmContainerFactory(argsHook, vm.ArgsVmContainerFactory{

--- a/genesis/process/shardGenesisBlockCreator.go
+++ b/genesis/process/shardGenesisBlockCreator.go
@@ -458,6 +458,9 @@ func createProcessorsForShardGenesisBlock(arg ArgsGenesisBlockCreator, enableEpo
 		MessageSignVerifier: pubKeyVerifier,
 		NodesCoordinator:    liteNodesCoordinator,
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	err = blockChainHookImpl.SetVMContainer(vmContainer)
 	if err != nil {

--- a/genesis/process/sovereignGenesisBlockCreator.go
+++ b/genesis/process/sovereignGenesisBlockCreator.go
@@ -183,6 +183,11 @@ func createSovereignShardGenesisBlock(
 		return nil, nil, nil, err
 	}
 
+	err = initSystemSCs(shardProcessors.vmContainer, arg.Accounts)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	deploySystemSCTxs, err := deploySystemSmartContracts(arg, metaProcessor.txProcessor, metaProcessor.systemSCs)
 	if err != nil {
 		return nil, nil, nil, err
@@ -197,11 +202,6 @@ func createSovereignShardGenesisBlock(
 
 	metaScrsTxs := metaProcessor.txCoordinator.GetAllCurrentUsedTxs(block.SmartContractResultBlock)
 	indexingData.ScrsTxs = mergeScrs(indexingData.ScrsTxs, metaScrsTxs)
-
-	err = initSystemSCs(shardProcessors.vmContainer, arg.Accounts)
-	if err != nil {
-		return nil, nil, nil, err
-	}
 
 	rootHash, err := arg.Accounts.Commit()
 	if err != nil {

--- a/genesis/process/sovereignGenesisBlockCreator_test.go
+++ b/genesis/process/sovereignGenesisBlockCreator_test.go
@@ -373,12 +373,15 @@ func TestSovereignGenesisBlockCreator_InitSystemSCs(t *testing.T) {
 	arg, sgbc := createSovereignGenesisBlockCreator(t)
 	require.NotNil(t, sgbc)
 
+	_, err := sgbc.CreateGenesisBlocks()
+	require.Nil(t, err)
+
 	accountsDB := arg.Accounts
 
 	// Check delegation manager is initialized
 	val := retrieveAccValue(t, accountsDB, vm.DelegationManagerSCAddress, []byte("delegationContracts"))
 	delegationList := &systemSmartContracts.DelegationContractList{}
-	err := arg.Core.InternalMarshalizer().Unmarshal(delegationList, val)
+	err = arg.Core.InternalMarshalizer().Unmarshal(delegationList, val)
 	require.Nil(t, err)
 	require.Equal(t, [][]byte{vm.FirstDelegationSCAddress}, delegationList.Addresses)
 

--- a/genesis/process/sovereignGenesisBlockCreator_test.go
+++ b/genesis/process/sovereignGenesisBlockCreator_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/state"
 	"github.com/multiversx/mx-chain-go/vm"
+	"github.com/multiversx/mx-chain-go/vm/systemSmartContracts"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
@@ -364,4 +365,35 @@ func TestSovereignGenesisBlockCreator_InitSystemAccountCalled(t *testing.T) {
 	acc, err = arg.Accounts.GetExistingAccount(core.SystemAccountAddress)
 	require.NotNil(t, acc)
 	require.Nil(t, err)
+}
+
+func TestSovereignGenesisBlockCreator_InitSystemSCs(t *testing.T) {
+	t.Parallel()
+
+	arg, sgbc := createSovereignGenesisBlockCreator(t)
+	require.NotNil(t, sgbc)
+
+	accountsDB := arg.Accounts
+
+	// Check delegation manager is initialized
+	val := retrieveAccValue(t, accountsDB, vm.DelegationManagerSCAddress, []byte("delegationContracts"))
+	delegationList := &systemSmartContracts.DelegationContractList{}
+	err := arg.Core.InternalMarshalizer().Unmarshal(delegationList, val)
+	require.Nil(t, err)
+	require.Equal(t, [][]byte{vm.FirstDelegationSCAddress}, delegationList.Addresses)
+
+	// Check governance manager is initialized
+	val = retrieveAccValue(t, accountsDB, vm.GovernanceSCAddress, []byte("owner"))
+	require.Equal(t, vm.GovernanceSCAddress, val)
+}
+
+func retrieveAccValue(t *testing.T, accountsDB stateAcc.AccountsAdapter, address []byte, key []byte) []byte {
+	acc, err := accountsDB.GetExistingAccount(address)
+	require.Nil(t, err)
+
+	val, _, err := acc.(data.UserAccountHandler).RetrieveValue(key)
+	require.Nil(t, err)
+	require.NotEmpty(t, val)
+
+	return val
 }

--- a/genesis/process/sovereignGenesisBlockCreator_test.go
+++ b/genesis/process/sovereignGenesisBlockCreator_test.go
@@ -351,12 +351,7 @@ func TestSovereignGenesisBlockCreator_setSovereignStakedData(t *testing.T) {
 func TestSovereignGenesisBlockCreator_InitSystemAccountCalled(t *testing.T) {
 	t.Parallel()
 
-	arg := createMockArgument(t, "testdata/genesisTest1.json", &mock.InitialNodesHandlerStub{}, big.NewInt(22000))
-	arg.ShardCoordinator = sharding.NewSovereignShardCoordinator(core.SovereignChainShardId)
-	arg.DNSV2Addresses = []string{"00000000000000000500761b8c4a25d3979359223208b412285f635e71300102"}
-
-	gbc, _ := NewGenesisBlockCreator(arg)
-	sgbc, _ := NewSovereignGenesisBlockCreator(gbc)
+	arg, sgbc := createSovereignGenesisBlockCreator(t)
 	require.NotNil(t, sgbc)
 
 	acc, err := arg.Accounts.GetExistingAccount(core.SystemAccountAddress)

--- a/genesis/process/vmNodesCoord.go
+++ b/genesis/process/vmNodesCoord.go
@@ -1,0 +1,15 @@
+package process
+
+type vmNodesCoordinator struct {
+	numEligible uint64
+}
+
+// GetNumTotalEligible returns the number of eligible nodes
+func (vnc *vmNodesCoordinator) GetNumTotalEligible() uint64 {
+	return vnc.numEligible
+}
+
+// IsInterfaceNil checks if the underlying pointer is nil
+func (vnc *vmNodesCoordinator) IsInterfaceNil() bool {
+	return vnc == nil
+}

--- a/testscommon/genesisMocks/runTypeComponentsStub.go
+++ b/testscommon/genesisMocks/runTypeComponentsStub.go
@@ -1,6 +1,7 @@
 package genesisMocks
 
 import (
+	factoryVm "github.com/multiversx/mx-chain-go/factory/vm"
 	"github.com/multiversx/mx-chain-go/genesis"
 	"github.com/multiversx/mx-chain-go/process/block/preprocess"
 	"github.com/multiversx/mx-chain-go/process/coordinator"
@@ -29,6 +30,7 @@ type RunTypeComponentsStub struct {
 	VMContextCreatorHandler       systemSmartContracts.VMContextCreatorHandler
 	ShardCoordinatorFactory       sharding.ShardCoordinatorFactory
 	TxPreProcessorFactory         preprocess.TxPreProcessorCreator
+	VmContainerShardFactory       factoryVm.VmContainerCreator
 }
 
 // NewRunTypeComponentsStub -
@@ -42,6 +44,7 @@ func NewRunTypeComponentsStub() *RunTypeComponentsStub {
 		Marshaller:          &marshallerMock.MarshalizerMock{},
 		EnableEpochsHandler: &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
 	})
+	vmContainer, _ := factoryVm.NewVmContainerShardFactory(blockChainHookHandlerFactory)
 
 	return &RunTypeComponentsStub{
 		BlockChainHookHandlerFactory:  blockChainHookHandlerFactory,
@@ -53,6 +56,7 @@ func NewRunTypeComponentsStub() *RunTypeComponentsStub {
 		VMContextCreatorHandler:       systemSmartContracts.NewVMContextCreator(),
 		ShardCoordinatorFactory:       sharding.NewMultiShardCoordinatorFactory(),
 		TxPreProcessorFactory:         preprocess.NewTxPreProcessorCreator(),
+		VmContainerShardFactory:       vmContainer,
 	}
 }
 
@@ -73,6 +77,10 @@ func NewSovereignRunTypeComponentsStub() *RunTypeComponentsStub {
 		BaseTokenID: "WEGLD-bd4d79",
 	})
 
+	oneShardVM := systemSmartContracts.NewOneShardSystemVMEEICreator()
+	vmMetaFactory, _ := factoryVm.NewVmContainerMetaFactory(blockChainHookHandlerFactory, oneShardVM)
+	sovVMContainerShardFactory, _ := factoryVm.NewSovereignVmContainerShardFactory(blockChainHookHandlerFactory, vmMetaFactory, runTypeComponents.VmContainerShardFactory)
+
 	return &RunTypeComponentsStub{
 		BlockChainHookHandlerFactory:  blockChainHookHandlerFactory,
 		TransactionCoordinatorFactory: transactionCoordinatorFactory,
@@ -83,6 +91,7 @@ func NewSovereignRunTypeComponentsStub() *RunTypeComponentsStub {
 		VMContextCreatorHandler:       &vmContext.VMContextCreatorStub{},
 		ShardCoordinatorFactory:       sharding.NewSovereignShardCoordinatorFactory(),
 		TxPreProcessorFactory:         preprocess.NewSovereignTxPreProcessorCreator(),
+		VmContainerShardFactory:       sovVMContainerShardFactory,
 	}
 }
 
@@ -129,6 +138,10 @@ func (r *RunTypeComponentsStub) ShardCoordinatorCreator() sharding.ShardCoordina
 // TxPreProcessorCreator -
 func (r *RunTypeComponentsStub) TxPreProcessorCreator() preprocess.TxPreProcessorCreator {
 	return r.TxPreProcessorFactory
+}
+
+func (r *RunTypeComponentsStub) VmContainerShardFactoryCreator() factoryVm.VmContainerCreator {
+	return r.VmContainerShardFactory
 }
 
 // IsInterfaceNil -

--- a/testscommon/genesisMocks/runTypeComponentsStub.go
+++ b/testscommon/genesisMocks/runTypeComponentsStub.go
@@ -140,6 +140,7 @@ func (r *RunTypeComponentsStub) TxPreProcessorCreator() preprocess.TxPreProcesso
 	return r.TxPreProcessorFactory
 }
 
+// VmContainerShardFactoryCreator -
 func (r *RunTypeComponentsStub) VmContainerShardFactoryCreator() factoryVm.VmContainerCreator {
 	return r.VmContainerShardFactory
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- If we start a sovereign chain with all enable epochs on 0, some system sc init execution that happen at the end of epoch are not executed. 
  
## Proposed changes
- In sovereign genesis processing, we will init system sc contract funcs(delegation + governance) by default
- Moved some code from system sc in the common genesis package to be used by sov genesis block creator

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
