### PR TITLE
Rename FixRelayedMoveBalanceFlag to FixRelayedBaseCostFlag + proper fix

### DIFF
--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -321,8 +321,8 @@
     # RelayedTransactionsV3EnableEpoch represents the epoch when the relayed transactions V3 will be enabled
     RelayedTransactionsV3EnableEpoch = 7
 
-    # FixRelayedMoveBalanceEnableEpoch represents the epoch when the fix for relayed for move balance will be enabled
-    FixRelayedMoveBalanceEnableEpoch = 7
+    # FixRelayedBaseCostEnableEpoch represents the epoch when the fix for relayed base cost will be enabled
+    FixRelayedBaseCostEnableEpoch = 7
 
     # BLSMultiSignerEnableEpoch represents the activation epoch for different types of BLS multi-signers
     BLSMultiSignerEnableEpoch = [

--- a/common/constants.go
+++ b/common/constants.go
@@ -498,8 +498,8 @@ const (
 	// MetricRelayedTransactionsV3EnableEpoch represents the epoch when the relayed transactions v3 is enabled
 	MetricRelayedTransactionsV3EnableEpoch = "erd_relayed_transactions_v3_enable_epoch"
 
-	// MetricFixRelayedMoveBalanceEnableEpoch represents the epoch when the fix for relayed move balance is enabled
-	MetricFixRelayedMoveBalanceEnableEpoch = "erd_fix_relayed_move_balance_enable_epoch"
+	// MetricFixRelayedBaseCostEnableEpoch represents the epoch when the fix for relayed base cost is enabled
+	MetricFixRelayedBaseCostEnableEpoch = "erd_fix_relayed_base_cost_enable_epoch"
 
 	// MetricUnbondTokensV2EnableEpoch represents the epoch when the unbond tokens v2 is applied
 	MetricUnbondTokensV2EnableEpoch = "erd_unbond_tokens_v2_enable_epoch"
@@ -1227,6 +1227,6 @@ const (
 	EGLDInESDTMultiTransferFlag                        core.EnableEpochFlag = "EGLDInESDTMultiTransferFlag"
 	CryptoOpcodesV2Flag                                core.EnableEpochFlag = "CryptoOpcodesV2Flag"
 	RelayedTransactionsV3Flag                          core.EnableEpochFlag = "RelayedTransactionsV3Flag"
-	FixRelayedMoveBalanceFlag                          core.EnableEpochFlag = "FixRelayedMoveBalanceFlag"
+	FixRelayedBaseCostFlag                             core.EnableEpochFlag = "FixRelayedBaseCostFlag"
 	// all new flags must be added to createAllFlagsMap method, as part of enableEpochsHandler allFlagsDefined
 )

--- a/common/enablers/enableEpochsHandler.go
+++ b/common/enablers/enableEpochsHandler.go
@@ -756,11 +756,11 @@ func (handler *enableEpochsHandler) createAllFlagsMap() {
 			},
 			activationEpoch: handler.enableEpochsConfig.RelayedTransactionsV3EnableEpoch,
 		},
-		common.FixRelayedMoveBalanceFlag: {
+		common.FixRelayedBaseCostFlag: {
 			isActiveInEpoch: func(epoch uint32) bool {
-				return epoch >= handler.enableEpochsConfig.FixRelayedMoveBalanceEnableEpoch
+				return epoch >= handler.enableEpochsConfig.FixRelayedBaseCostEnableEpoch
 			},
-			activationEpoch: handler.enableEpochsConfig.FixRelayedMoveBalanceEnableEpoch,
+			activationEpoch: handler.enableEpochsConfig.FixRelayedBaseCostEnableEpoch,
 		},
 	}
 }

--- a/common/enablers/enableEpochsHandler_test.go
+++ b/common/enablers/enableEpochsHandler_test.go
@@ -120,7 +120,7 @@ func createEnableEpochsConfig() config.EnableEpochs {
 		EGLDInMultiTransferEnableEpoch:                           103,
 		CryptoOpcodesV2EnableEpoch:                               104,
 		RelayedTransactionsV3EnableEpoch:                         105,
-		FixRelayedMoveBalanceEnableEpoch:                         106,
+		FixRelayedBaseCostEnableEpoch:                            106,
 	}
 }
 
@@ -322,7 +322,7 @@ func TestEnableEpochsHandler_IsFlagEnabled(t *testing.T) {
 	require.True(t, handler.IsFlagEnabled(common.AlwaysMergeContextsInEEIFlag))
 	require.True(t, handler.IsFlagEnabled(common.DynamicESDTFlag))
 	require.True(t, handler.IsFlagEnabled(common.RelayedTransactionsV3Flag))
-	require.True(t, handler.IsFlagEnabled(common.FixRelayedMoveBalanceFlag))
+	require.True(t, handler.IsFlagEnabled(common.FixRelayedBaseCostFlag))
 }
 
 func TestEnableEpochsHandler_GetActivationEpoch(t *testing.T) {
@@ -443,7 +443,7 @@ func TestEnableEpochsHandler_GetActivationEpoch(t *testing.T) {
 	require.Equal(t, cfg.EGLDInMultiTransferEnableEpoch, handler.GetActivationEpoch(common.EGLDInESDTMultiTransferFlag))
 	require.Equal(t, cfg.CryptoOpcodesV2EnableEpoch, handler.GetActivationEpoch(common.CryptoOpcodesV2Flag))
 	require.Equal(t, cfg.RelayedTransactionsV3EnableEpoch, handler.GetActivationEpoch(common.RelayedTransactionsV3Flag))
-	require.Equal(t, cfg.FixRelayedMoveBalanceEnableEpoch, handler.GetActivationEpoch(common.FixRelayedMoveBalanceFlag))
+	require.Equal(t, cfg.FixRelayedBaseCostEnableEpoch, handler.GetActivationEpoch(common.FixRelayedBaseCostFlag))
 }
 
 func TestEnableEpochsHandler_IsInterfaceNil(t *testing.T) {

--- a/config/epochConfig.go
+++ b/config/epochConfig.go
@@ -117,8 +117,8 @@ type EnableEpochs struct {
 	DynamicESDTEnableEpoch                                   uint32
 	EGLDInMultiTransferEnableEpoch                           uint32
 	CryptoOpcodesV2EnableEpoch                               uint32
-	RelayedTransactionsV3EnableEpoch                  		 uint32
-	FixRelayedMoveBalanceEnableEpoch                  		 uint32
+	RelayedTransactionsV3EnableEpoch                         uint32
+	FixRelayedBaseCostEnableEpoch                            uint32
 	BLSMultiSignerEnableEpoch                                []MultiSignerConfig
 }
 

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -875,8 +875,8 @@ func TestEnableEpochConfig(t *testing.T) {
     # RelayedTransactionsV3EnableEpoch represents the epoch when the relayed transactions V3 will be enabled
     RelayedTransactionsV3EnableEpoch = 99
 
-    # FixRelayedMoveBalanceEnableEpoch represents the epoch when the fix for relayed for move balance will be enabled
-    FixRelayedMoveBalanceEnableEpoch = 100
+    # FixRelayedBaseCostEnableEpoch represents the epoch when the fix for relayed base cost will be enabled
+    FixRelayedBaseCostEnableEpoch = 100
 
     # MaxNodesChangeEnableEpoch holds configuration for changing the maximum number of nodes and the enabling epoch
     MaxNodesChangeEnableEpoch = [
@@ -994,8 +994,8 @@ func TestEnableEpochConfig(t *testing.T) {
 			DynamicESDTEnableEpoch:                                   96,
 			EGLDInMultiTransferEnableEpoch:                           97,
 			CryptoOpcodesV2EnableEpoch:                               98,
-			RelayedTransactionsV3EnableEpoch:                  		  99,
-			FixRelayedMoveBalanceEnableEpoch:                  		  100,
+			RelayedTransactionsV3EnableEpoch:                         99,
+			FixRelayedBaseCostEnableEpoch:                            100,
 			MaxNodesChangeEnableEpoch: []MaxNodesChangeConfig{
 				{
 					EpochEnable:            44,

--- a/integrationTests/chainSimulator/relayedTx/relayedTx_test.go
+++ b/integrationTests/chainSimulator/relayedTx/relayedTx_test.go
@@ -38,7 +38,7 @@ var (
 	oneEGLD                                  = big.NewInt(1000000000000000000)
 	alterConfigsFuncRelayedV3EarlyActivation = func(cfg *config.Configs) {
 		cfg.EpochConfig.EnableEpochs.RelayedTransactionsV3EnableEpoch = 1
-		cfg.EpochConfig.EnableEpochs.FixRelayedMoveBalanceEnableEpoch = 1
+		cfg.EpochConfig.EnableEpochs.FixRelayedBaseCostEnableEpoch = 1
 	}
 )
 
@@ -268,8 +268,9 @@ func TestFixRelayedMoveBalanceWithChainSimulator(t *testing.T) {
 		t.Skip("this is not a short test")
 	}
 
-	expectedFeeScCall := "815285920000000"
-	t.Run("sc call", testFixRelayedMoveBalanceWithChainSimulatorScCall(expectedFeeScCall, expectedFeeScCall))
+	expectedFeeScCallBefore := "815285920000000"
+	expectedFeeScCallAfter := "873695920000000"
+	t.Run("sc call", testFixRelayedMoveBalanceWithChainSimulatorScCall(expectedFeeScCallBefore, expectedFeeScCallAfter))
 
 	expectedFeeMoveBalanceBefore := "797500000000000" // 498 * 1500 + 50000 + 5000
 	expectedFeeMoveBalanceAfter := "847000000000000"  // 498 * 1500 + 50000 + 50000
@@ -285,7 +286,7 @@ func testFixRelayedMoveBalanceWithChainSimulatorScCall(
 
 		providedActivationEpoch := uint32(7)
 		alterConfigsFunc := func(cfg *config.Configs) {
-			cfg.EpochConfig.EnableEpochs.FixRelayedMoveBalanceEnableEpoch = providedActivationEpoch
+			cfg.EpochConfig.EnableEpochs.FixRelayedBaseCostEnableEpoch = providedActivationEpoch
 		}
 
 		cs := startChainSimulator(t, alterConfigsFunc)
@@ -386,7 +387,7 @@ func testFixRelayedMoveBalanceWithChainSimulatorMoveBalance(
 
 		providedActivationEpoch := uint32(5)
 		alterConfigsFunc := func(cfg *config.Configs) {
-			cfg.EpochConfig.EnableEpochs.FixRelayedMoveBalanceEnableEpoch = providedActivationEpoch
+			cfg.EpochConfig.EnableEpochs.FixRelayedBaseCostEnableEpoch = providedActivationEpoch
 		}
 
 		cs := startChainSimulator(t, alterConfigsFunc)

--- a/integrationTests/multiShard/relayedTx/common.go
+++ b/integrationTests/multiShard/relayedTx/common.go
@@ -20,7 +20,7 @@ func CreateGeneralSetupForRelayTxTest(relayedV3Test bool) ([]*integrationTests.T
 	epochsConfig := integrationTests.GetDefaultEnableEpochsConfig()
 	if !relayedV3Test {
 		epochsConfig.RelayedTransactionsV3EnableEpoch = integrationTests.UnreachableEpoch
-		epochsConfig.FixRelayedMoveBalanceEnableEpoch = integrationTests.UnreachableEpoch
+		epochsConfig.FixRelayedBaseCostEnableEpoch = integrationTests.UnreachableEpoch
 	}
 	nodes, idxProposers := createAndMintNodes(initialVal, epochsConfig)
 

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -3274,7 +3274,7 @@ func CreateEnableEpochsConfig() config.EnableEpochs {
 		RefactorPeersMiniBlocksEnableEpoch:                UnreachableEpoch,
 		SCProcessorV2EnableEpoch:                          UnreachableEpoch,
 		RelayedTransactionsV3EnableEpoch:                  UnreachableEpoch,
-		FixRelayedMoveBalanceEnableEpoch:                  UnreachableEpoch,
+		FixRelayedBaseCostEnableEpoch:                     UnreachableEpoch,
 	}
 }
 

--- a/integrationTests/vm/txsFee/multiShard/relayedMoveBalance_test.go
+++ b/integrationTests/vm/txsFee/multiShard/relayedMoveBalance_test.go
@@ -145,13 +145,13 @@ func TestRelayedMoveBalanceExecuteOnSourceAndDestination(t *testing.T) {
 func testRelayedMoveBalanceExecuteOnSourceAndDestination(relayedFixActivationEpoch uint32) func(t *testing.T) {
 	return func(t *testing.T) {
 		testContextSource, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(0, config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContextSource.Close()
 
 		testContextDst, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(1, config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContextDst.Close()
@@ -226,13 +226,13 @@ func TestRelayedMoveBalanceExecuteOnSourceAndDestinationRelayerAndInnerTxSenderS
 func testRelayedMoveBalanceExecuteOnSourceAndDestinationRelayerAndInnerTxSenderShard0InnerTxReceiverShard1ShouldWork(relayedFixActivationEpoch uint32) func(t *testing.T) {
 	return func(t *testing.T) {
 		testContextSource, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(0, config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContextSource.Close()
 
 		testContextDst, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(1, config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContextDst.Close()
@@ -303,13 +303,13 @@ func TestRelayedMoveBalanceRelayerAndInnerTxReceiverShard0SenderShard1(t *testin
 func testRelayedMoveBalanceRelayerAndInnerTxReceiverShard0SenderShard1(relayedFixActivationEpoch uint32) func(t *testing.T) {
 	return func(t *testing.T) {
 		testContextSource, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(0, config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContextSource.Close()
 
 		testContextDst, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(1, config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContextDst.Close()
@@ -392,19 +392,19 @@ func TestMoveBalanceRelayerShard0InnerTxSenderShard1InnerTxReceiverShard2ShouldW
 func testMoveBalanceRelayerShard0InnerTxSenderShard1InnerTxReceiverShard2ShouldWork(relayedFixActivationEpoch uint32) func(t *testing.T) {
 	return func(t *testing.T) {
 		testContextRelayer, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(0, config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContextRelayer.Close()
 
 		testContextInnerSource, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(1, config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContextInnerSource.Close()
 
 		testContextDst, err := vm.CreatePreparedTxProcessorWithVMsMultiShard(2, config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContextDst.Close()

--- a/integrationTests/vm/txsFee/relayedBuiltInFunctions_test.go
+++ b/integrationTests/vm/txsFee/relayedBuiltInFunctions_test.go
@@ -28,8 +28,8 @@ func testRelayedBuildInFunctionChangeOwnerCallShouldWork(relayedFixActivationEpo
 	return func(t *testing.T) {
 		testContext, err := vm.CreatePreparedTxProcessorWithVMs(
 			config.EnableEpochs{
-				PenalizedTooMuchGasEnableEpoch:   integrationTests.UnreachableEpoch,
-				FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+				PenalizedTooMuchGasEnableEpoch: integrationTests.UnreachableEpoch,
+				FixRelayedBaseCostEnableEpoch:  relayedFixActivationEpoch,
 			})
 		require.Nil(t, err)
 		defer testContext.Close()
@@ -63,8 +63,8 @@ func testRelayedBuildInFunctionChangeOwnerCallShouldWork(relayedFixActivationEpo
 		expectedBalanceRelayer := big.NewInt(16610)
 		vm.TestAccount(t, testContext.Accounts, relayerAddr, 1, expectedBalanceRelayer)
 
-	expectedBalance := big.NewInt(9988100)
-	vm.TestAccount(t, testContext.Accounts, owner, 2, expectedBalance)
+		expectedBalance := big.NewInt(9988100)
+		vm.TestAccount(t, testContext.Accounts, owner, 2, expectedBalance)
 
 		// check accumulated fees
 		accumulatedFees := testContext.TxFeeHandler.GetAccumulatedFees()
@@ -87,7 +87,7 @@ func TestRelayedBuildInFunctionChangeOwnerCallWrongOwnerShouldConsumeGas(t *test
 func testRelayedBuildInFunctionChangeOwnerCallWrongOwnerShouldConsumeGas(relayedFixActivationEpoch uint32) func(t *testing.T) {
 	return func(t *testing.T) {
 		testContext, err := vm.CreatePreparedTxProcessorWithVMs(config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContext.Close()
@@ -190,15 +190,15 @@ func TestRelayedBuildInFunctionChangeOwnerCallInsufficientGasLimitShouldConsumeG
 	t.Run("nonce fix is disabled, should increase the sender's nonce", func(t *testing.T) {
 		testRelayedBuildInFunctionChangeOwnerCallInsufficientGasLimitShouldConsumeGas(t,
 			config.EnableEpochs{
-				RelayedNonceFixEnableEpoch:       1000,
-				FixRelayedMoveBalanceEnableEpoch: 1000,
+				RelayedNonceFixEnableEpoch:    1000,
+				FixRelayedBaseCostEnableEpoch: 1000,
 			})
 	})
 	t.Run("nonce fix is enabled, should still increase the sender's nonce", func(t *testing.T) {
 		testRelayedBuildInFunctionChangeOwnerCallInsufficientGasLimitShouldConsumeGas(t,
 			config.EnableEpochs{
-				RelayedNonceFixEnableEpoch:       0,
-				FixRelayedMoveBalanceEnableEpoch: 1000,
+				RelayedNonceFixEnableEpoch:    0,
+				FixRelayedBaseCostEnableEpoch: 1000,
 			})
 	})
 }

--- a/integrationTests/vm/txsFee/relayedESDT_test.go
+++ b/integrationTests/vm/txsFee/relayedESDT_test.go
@@ -24,7 +24,7 @@ func TestRelayedESDTTransferShouldWork(t *testing.T) {
 func testRelayedESDTTransferShouldWork(relayedFixActivationEpoch uint32) func(t *testing.T) {
 	return func(t *testing.T) {
 		testContext, err := vm.CreatePreparedTxProcessorWithVMs(config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContext.Close()
@@ -82,7 +82,7 @@ func TestRelayedESTTransferNotEnoughESTValueShouldConsumeGas(t *testing.T) {
 func testRelayedESTTransferNotEnoughESTValueShouldConsumeGas(relayedFixActivationEpoch uint32) func(t *testing.T) {
 	return func(t *testing.T) {
 		testContext, err := vm.CreatePreparedTxProcessorWithVMs(config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContext.Close()

--- a/integrationTests/vm/txsFee/relayedScCalls_test.go
+++ b/integrationTests/vm/txsFee/relayedScCalls_test.go
@@ -27,7 +27,7 @@ func testRelayedScCallShouldWork(relayedFixActivationEpoch uint32) func(t *testi
 	return func(t *testing.T) {
 		testContext, err := vm.CreatePreparedTxProcessorWithVMs(config.EnableEpochs{
 			DynamicGasCostForDataTrieStorageLoadEnableEpoch: integrationTests.UnreachableEpoch,
-			FixRelayedMoveBalanceEnableEpoch:                relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch:                   relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContext.Close()
@@ -82,7 +82,7 @@ func TestRelayedScCallContractNotFoundShouldConsumeGas(t *testing.T) {
 func testRelayedScCallContractNotFoundShouldConsumeGas(relayedFixActivationEpoch uint32) func(t *testing.T) {
 	return func(t *testing.T) {
 		testContext, err := vm.CreatePreparedTxProcessorWithVMs(config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContext.Close()
@@ -186,7 +186,7 @@ func TestRelayedScCallInsufficientGasLimitShouldConsumeGas(t *testing.T) {
 func testRelayedScCallInsufficientGasLimitShouldConsumeGas(relayedFixActivationEpoch uint32, expectedBalance *big.Int, expectedAccumulatedFees *big.Int) func(t *testing.T) {
 	return func(t *testing.T) {
 		testContext, err := vm.CreatePreparedTxProcessorWithVMs(config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContext.Close()

--- a/integrationTests/vm/txsFee/relayedScDeploy_test.go
+++ b/integrationTests/vm/txsFee/relayedScDeploy_test.go
@@ -24,7 +24,7 @@ func TestRelayedScDeployShouldWork(t *testing.T) {
 func testRelayedScDeployShouldWork(relayedFixActivationEpoch uint32) func(t *testing.T) {
 	return func(t *testing.T) {
 		testContext, err := vm.CreatePreparedTxProcessorWithVMs(config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContext.Close()
@@ -77,7 +77,7 @@ func TestRelayedScDeployInvalidCodeShouldConsumeGas(t *testing.T) {
 func testRelayedScDeployInvalidCodeShouldConsumeGas(relayedFixActivationEpoch uint32, expectedBalance *big.Int, expectedAccumulatedFees *big.Int) func(t *testing.T) {
 	return func(t *testing.T) {
 		testContext, err := vm.CreatePreparedTxProcessorWithVMs(config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContext.Close()
@@ -130,7 +130,7 @@ func TestRelayedScDeployInsufficientGasLimitShouldConsumeGas(t *testing.T) {
 func testRelayedScDeployInsufficientGasLimitShouldConsumeGas(relayedFixActivationEpoch uint32, expectedBalance *big.Int, expectedAccumulatedFees *big.Int) func(t *testing.T) {
 	return func(t *testing.T) {
 		testContext, err := vm.CreatePreparedTxProcessorWithVMs(config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContext.Close()
@@ -182,7 +182,7 @@ func TestRelayedScDeployOutOfGasShouldConsumeGas(t *testing.T) {
 func testRelayedScDeployOutOfGasShouldConsumeGas(relayedFixActivationEpoch uint32, expectedBalance *big.Int, expectedAccumulatedFees *big.Int) func(t *testing.T) {
 	return func(t *testing.T) {
 		testContext, err := vm.CreatePreparedTxProcessorWithVMs(config.EnableEpochs{
-			FixRelayedMoveBalanceEnableEpoch: relayedFixActivationEpoch,
+			FixRelayedBaseCostEnableEpoch: relayedFixActivationEpoch,
 		})
 		require.Nil(t, err)
 		defer testContext.Close()

--- a/node/metrics/metrics.go
+++ b/node/metrics/metrics.go
@@ -122,7 +122,7 @@ func InitConfigMetrics(
 	appStatusHandler.SetUInt64Value(common.MetricSenderInOutTransferEnableEpoch, uint64(enableEpochs.SenderInOutTransferEnableEpoch))
 	appStatusHandler.SetUInt64Value(common.MetricRelayedTransactionsV2EnableEpoch, uint64(enableEpochs.RelayedTransactionsV2EnableEpoch))
 	appStatusHandler.SetUInt64Value(common.MetricRelayedTransactionsV3EnableEpoch, uint64(enableEpochs.RelayedTransactionsV3EnableEpoch))
-	appStatusHandler.SetUInt64Value(common.MetricFixRelayedMoveBalanceEnableEpoch, uint64(enableEpochs.FixRelayedMoveBalanceEnableEpoch))
+	appStatusHandler.SetUInt64Value(common.MetricFixRelayedBaseCostEnableEpoch, uint64(enableEpochs.FixRelayedBaseCostEnableEpoch))
 	appStatusHandler.SetUInt64Value(common.MetricUnbondTokensV2EnableEpoch, uint64(enableEpochs.UnbondTokensV2EnableEpoch))
 	appStatusHandler.SetUInt64Value(common.MetricSaveJailedAlwaysEnableEpoch, uint64(enableEpochs.SaveJailedAlwaysEnableEpoch))
 	appStatusHandler.SetUInt64Value(common.MetricValidatorToDelegationEnableEpoch, uint64(enableEpochs.ValidatorToDelegationEnableEpoch))

--- a/node/metrics/metrics_test.go
+++ b/node/metrics/metrics_test.go
@@ -208,8 +208,8 @@ func TestInitConfigMetrics(t *testing.T) {
 			EGLDInMultiTransferEnableEpoch:                           101,
 			CryptoOpcodesV2EnableEpoch:                               102,
 			ScToScLogEventEnableEpoch:                                103,
-			RelayedTransactionsV3EnableEpoch:            			  104,
-			FixRelayedMoveBalanceEnableEpoch:            			  105,
+			RelayedTransactionsV3EnableEpoch:                         104,
+			FixRelayedBaseCostEnableEpoch:                            105,
 			MaxNodesChangeEnableEpoch: []config.MaxNodesChangeConfig{
 				{
 					EpochEnable:            0,
@@ -328,8 +328,8 @@ func TestInitConfigMetrics(t *testing.T) {
 		"erd_egld_in_multi_transfer_enable_epoch":                              uint32(101),
 		"erd_crypto_opcodes_v2_enable_epoch":                                   uint32(102),
 		"erd_set_sc_to_sc_log_event_enable_epoch":                              uint32(103),
-		"erd_relayed_transactions_v3_enable_epoch":                      		uint32(104),
-		"erd_fix_relayed_move_balance_enable_epoch":                     		uint32(105),
+		"erd_relayed_transactions_v3_enable_epoch":                             uint32(104),
+		"erd_fix_relayed_base_cost_enable_epoch":                               uint32(105),
 		"erd_max_nodes_change_enable_epoch":                                    nil,
 		"erd_total_supply":                                                     "12345",
 		"erd_hysteresis":                                                       "0.100000",

--- a/process/transaction/baseProcess.go
+++ b/process/transaction/baseProcess.go
@@ -147,7 +147,7 @@ func (txProc *baseTxProcessor) checkTxValues(
 			return process.ErrNotEnoughGasInUserTx
 		}
 
-		txFee = txProc.computeTxFee(tx)
+		txFee = txProc.computeTxFeeForRelayedTx(tx)
 	} else {
 		txFee = txProc.economicsFee.ComputeTxFee(tx)
 	}
@@ -174,7 +174,7 @@ func (txProc *baseTxProcessor) checkTxValues(
 	return nil
 }
 
-func (txProc *baseTxProcessor) computeTxFee(tx *transaction.Transaction) *big.Int {
+func (txProc *baseTxProcessor) computeTxFeeForRelayedTx(tx *transaction.Transaction) *big.Int {
 	if txProc.enableEpochsHandler.IsFlagEnabled(common.FixRelayedBaseCostFlag) {
 		return txProc.computeTxFeeAfterBaseCostFix(tx)
 	}

--- a/process/transaction/baseProcess.go
+++ b/process/transaction/baseProcess.go
@@ -147,9 +147,7 @@ func (txProc *baseTxProcessor) checkTxValues(
 			return process.ErrNotEnoughGasInUserTx
 		}
 
-		_, dstShardTxType := txProc.txTypeHandler.ComputeTransactionType(tx)
-		isMoveBalance := dstShardTxType == process.MoveBalance
-		txFee = txProc.computeTxFee(tx, isMoveBalance)
+		txFee = txProc.computeTxFee(tx)
 	} else {
 		txFee = txProc.economicsFee.ComputeTxFee(tx)
 	}
@@ -176,15 +174,15 @@ func (txProc *baseTxProcessor) checkTxValues(
 	return nil
 }
 
-func (txProc *baseTxProcessor) computeTxFee(tx *transaction.Transaction, isInnerTxMoveBalance bool) *big.Int {
-	if txProc.enableEpochsHandler.IsFlagEnabled(common.FixRelayedMoveBalanceFlag) && isInnerTxMoveBalance {
-		return txProc.computeTxFeeAfterMoveBalanceFix(tx)
+func (txProc *baseTxProcessor) computeTxFee(tx *transaction.Transaction) *big.Int {
+	if txProc.enableEpochsHandler.IsFlagEnabled(common.FixRelayedBaseCostFlag) {
+		return txProc.computeTxFeeAfterBaseCostFix(tx)
 	}
 
 	return txProc.economicsFee.ComputeFeeForProcessing(tx, tx.GasLimit)
 }
 
-func (txProc *baseTxProcessor) computeTxFeeAfterMoveBalanceFix(tx *transaction.Transaction) *big.Int {
+func (txProc *baseTxProcessor) computeTxFeeAfterBaseCostFix(tx *transaction.Transaction) *big.Int {
 	moveBalanceGasLimit := txProc.economicsFee.ComputeGasLimit(tx)
 	gasToUse := tx.GetGasLimit() - moveBalanceGasLimit
 	moveBalanceUserFee := txProc.economicsFee.ComputeMoveBalanceFee(tx)

--- a/process/transaction/metaProcess.go
+++ b/process/transaction/metaProcess.go
@@ -65,7 +65,7 @@ func NewMetaTxProcessor(args ArgsNewMetaTxProcessor) (*metaTxProcessor, error) {
 	err := core.CheckHandlerCompatibility(args.EnableEpochsHandler, []core.EnableEpochFlag{
 		common.PenalizedTooMuchGasFlag,
 		common.ESDTFlag,
-		common.FixRelayedMoveBalanceFlag,
+		common.FixRelayedBaseCostFlag,
 	})
 	if err != nil {
 		return nil, err

--- a/process/transaction/shardProcess.go
+++ b/process/transaction/shardProcess.go
@@ -1154,20 +1154,18 @@ func (txProc *txProcessor) executeFailedRelayedUserTx(
 		return err
 	}
 
-	_, dstShardTxType := txProc.txTypeHandler.ComputeTransactionType(userTx)
-	isMoveBalance := dstShardTxType == process.MoveBalance
 	totalFee := txProc.economicsFee.ComputeFeeForProcessing(userTx, userTx.GasLimit)
 	moveBalanceGasLimit := txProc.economicsFee.ComputeGasLimit(userTx)
 	gasToUse := userTx.GetGasLimit() - moveBalanceGasLimit
 	processingUserFee := txProc.economicsFee.ComputeFeeForProcessing(userTx, gasToUse)
-	if txProc.enableEpochsHandler.IsFlagEnabled(common.FixRelayedBaseCostFlag) && isMoveBalance {
+	if txProc.enableEpochsHandler.IsFlagEnabled(common.FixRelayedBaseCostFlag) {
 		moveBalanceUserFee := txProc.economicsFee.ComputeMoveBalanceFee(userTx)
 		totalFee = big.NewInt(0).Add(moveBalanceUserFee, processingUserFee)
 	}
 
 	senderShardID := txProc.shardCoordinator.ComputeId(userTx.SndAddr)
 	if senderShardID != txProc.shardCoordinator.SelfId() {
-		if txProc.enableEpochsHandler.IsFlagEnabled(common.FixRelayedBaseCostFlag) && isMoveBalance {
+		if txProc.enableEpochsHandler.IsFlagEnabled(common.FixRelayedBaseCostFlag) {
 			totalFee.Sub(totalFee, processingUserFee)
 		} else {
 			moveBalanceUserFee := txProc.economicsFee.ComputeFeeForProcessing(userTx, moveBalanceGasLimit)

--- a/process/transaction/shardProcess.go
+++ b/process/transaction/shardProcess.go
@@ -400,7 +400,7 @@ func (txProc *txProcessor) processTxFee(
 	}
 
 	if isUserTxOfRelayed {
-		totalCost := txProc.computeTxFee(tx)
+		totalCost := txProc.computeTxFeeForRelayedTx(tx)
 
 		err := acntSnd.SubFromBalance(totalCost)
 		if err != nil {
@@ -743,7 +743,7 @@ func (txProc *txProcessor) processInnerTx(
 	originalTxHash []byte,
 ) (*big.Int, vmcommon.ReturnCode, error) {
 
-	txFee := txProc.computeTxFee(innerTx)
+	txFee := txProc.computeTxFeeForRelayedTx(innerTx)
 
 	acntSnd, err := txProc.getAccountFromAddress(innerTx.SndAddr)
 	if err != nil {
@@ -897,7 +897,7 @@ func (txProc *txProcessor) removeValueAndConsumedFeeFromUser(
 		return err
 	}
 
-	consumedFee := txProc.computeTxFee(userTx)
+	consumedFee := txProc.computeTxFeeForRelayedTx(userTx)
 
 	err = userAcnt.SubFromBalance(consumedFee)
 	if err != nil {

--- a/process/transaction/shardProcess_test.go
+++ b/process/transaction/shardProcess_test.go
@@ -92,7 +92,7 @@ func createArgsForTxProcessor() txproc.ArgsNewTxProcessor {
 		BadTxForwarder:          &mock.IntermediateTransactionHandlerMock{},
 		ArgsParser:              &mock.ArgumentParserMock{},
 		ScrForwarder:            &mock.IntermediateTransactionHandlerMock{},
-		EnableEpochsHandler:     enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.PenalizedTooMuchGasFlag, common.FixRelayedMoveBalanceFlag),
+		EnableEpochsHandler:     enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.PenalizedTooMuchGasFlag, common.FixRelayedBaseCostFlag),
 		GuardianChecker:         &guardianMocks.GuardedAccountHandlerStub{},
 		TxVersionChecker:        &testscommon.TxVersionCheckerStub{},
 		TxLogsProcessor:         &mock.TxLogsProcessorStub{},
@@ -2238,7 +2238,7 @@ func TestTxProcessor_ProcessRelayedTransactionV3(t *testing.T) {
 		args.TxTypeHandler = txTypeHandler
 		args.PubkeyConv = pubKeyConverter
 		args.ArgsParser = smartContract.NewArgumentParser()
-		args.EnableEpochsHandler = enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.RelayedTransactionsV3Flag, common.FixRelayedMoveBalanceFlag)
+		args.EnableEpochsHandler = enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.RelayedTransactionsV3Flag, common.FixRelayedBaseCostFlag)
 		args.EconomicsFee = &economicsmocks.EconomicsHandlerStub{
 			ComputeMoveBalanceFeeCalled: func(tx data.TransactionWithFeeHandler) *big.Int {
 				return big.NewInt(1)
@@ -2361,7 +2361,7 @@ func TestTxProcessor_ProcessRelayedTransactionV3(t *testing.T) {
 		args.TxTypeHandler = txTypeHandler
 		args.PubkeyConv = pubKeyConverter
 		args.ArgsParser = smartContract.NewArgumentParser()
-		args.EnableEpochsHandler = enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.RelayedTransactionsV3Flag, common.FixRelayedMoveBalanceFlag)
+		args.EnableEpochsHandler = enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.RelayedTransactionsV3Flag, common.FixRelayedBaseCostFlag)
 		args.EconomicsFee = &economicsmocks.EconomicsHandlerStub{
 			ComputeMoveBalanceFeeCalled: func(tx data.TransactionWithFeeHandler) *big.Int {
 				return big.NewInt(int64(tx.GetGasPrice() * tx.GetGasLimit()))
@@ -2448,7 +2448,7 @@ func TestTxProcessor_ProcessRelayedTransactionV3(t *testing.T) {
 		args.TxTypeHandler = txTypeHandler
 		args.PubkeyConv = pubKeyConverter
 		args.ArgsParser = smartContract.NewArgumentParser()
-		args.EnableEpochsHandler = enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.RelayedTransactionsV3Flag, common.FixRelayedMoveBalanceFlag)
+		args.EnableEpochsHandler = enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.RelayedTransactionsV3Flag, common.FixRelayedBaseCostFlag)
 		increasingFee := big.NewInt(0)
 		args.EconomicsFee = &economicsmocks.EconomicsHandlerStub{
 			ComputeMoveBalanceFeeCalled: func(tx data.TransactionWithFeeHandler) *big.Int {
@@ -2554,7 +2554,7 @@ func testProcessRelayedTransactionV3(
 	args.TxTypeHandler = txTypeHandler
 	args.PubkeyConv = pubKeyConverter
 	args.ArgsParser = smartContract.NewArgumentParser()
-	args.EnableEpochsHandler = enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.RelayedTransactionsV3Flag, common.FixRelayedMoveBalanceFlag)
+	args.EnableEpochsHandler = enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.RelayedTransactionsV3Flag, common.FixRelayedBaseCostFlag)
 	args.EconomicsFee = &economicsmocks.EconomicsHandlerMock{
 		ComputeTxFeeCalled: func(tx data.TransactionWithFeeHandler) *big.Int {
 			return big.NewInt(4)
@@ -3204,6 +3204,7 @@ func TestTxProcessor_ConsumeMoveBalanceWithUserTx(t *testing.T) {
 	t.Parallel()
 
 	args := createArgsForTxProcessor()
+	args.EnableEpochsHandler = enableEpochsHandlerMock.NewEnableEpochsHandlerStub()
 	args.EconomicsFee = &economicsmocks.EconomicsHandlerStub{
 		ComputeTxFeeCalled: func(tx data.TransactionWithFeeHandler) *big.Int {
 			return big.NewInt(150)

--- a/sharding/mock/enableEpochsHandlerMock.go
+++ b/sharding/mock/enableEpochsHandlerMock.go
@@ -53,8 +53,8 @@ func (mock *EnableEpochsHandlerMock) IsRelayedTransactionsV3FlagEnabled() bool {
 	return false
 }
 
-// IsFixRelayedMoveBalanceFlagEnabled -
-func (mock *EnableEpochsHandlerMock) IsFixRelayedMoveBalanceFlagEnabled() bool {
+// IsFixRelayedBaseCostFlagEnabled -
+func (mock *EnableEpochsHandlerMock) IsFixRelayedBaseCostFlagEnabled() bool {
 	return false
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request
- the fix for move balance should actually be fix for base cost
  
## Proposed changes
- updated the fix to also cover other inner txs than move balance

## Testing procedure
- will be verified on feat branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
