### PR TITLE
native esdt not printed as issued esdt

### DIFF
--- a/cmd/sovereignnode/chainSimulator/tests/esdt/issue_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/esdt/issue_test.go
@@ -53,6 +53,14 @@ func TestSovereignChainSimulator_IssueFungible(t *testing.T) {
 
 	nodeHandler := cs.GetNodeHandler(core.SovereignChainShardId)
 
+	err = cs.GenerateBlocks(1)
+	require.Nil(t, err)
+
+	issuedESDTs, err := nodeHandler.GetFacadeHandler().GetAllIssuedESDTs("")
+	require.Nil(t, err)
+	require.NotNil(t, issuedESDTs)
+	require.Equal(t, 0, len(issuedESDTs))
+
 	nonce := uint64(0)
 	wallet, err := cs.GenerateAndMintWalletAddress(core.SovereignChainShardId, chainSim.InitialAmount)
 	require.Nil(t, err)
@@ -63,6 +71,11 @@ func TestSovereignChainSimulator_IssueFungible(t *testing.T) {
 	tokenTicker := "SVN"
 	numDecimals := 18
 	tokenIdentifier := chainSim.IssueFungible(t, cs, nodeHandler, wallet.Bytes, &nonce, issueCost, tokenName, tokenTicker, numDecimals, supply)
+
+	issuedESDTs, err = nodeHandler.GetFacadeHandler().GetAllIssuedESDTs("")
+	require.Nil(t, err)
+	require.NotNil(t, issuedESDTs)
+	require.Equal(t, 1, len(issuedESDTs))
 
 	tokens, _, err := nodeHandler.GetFacadeHandler().GetAllESDTTokens(wallet.Bech32, coreAPI.AccountQueryOptions{})
 	require.Nil(t, err)

--- a/node/node.go
+++ b/node/node.go
@@ -23,6 +23,9 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/data/validator"
 	disabledSig "github.com/multiversx/mx-chain-crypto-go/signing/disabled/singlesig"
+	logger "github.com/multiversx/mx-chain-logger-go"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/errChan"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
@@ -41,13 +44,12 @@ import (
 	"github.com/multiversx/mx-chain-go/trie"
 	"github.com/multiversx/mx-chain-go/vm"
 	"github.com/multiversx/mx-chain-go/vm/systemSmartContracts"
-	logger "github.com/multiversx/mx-chain-logger-go"
-	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
 const (
 	// esdtTickerNumChars represents the number of hex-encoded characters of a ticker
 	esdtTickerNumChars = 6
+	baseESDTKeyPrefix  = core.ProtectedKeyPrefix + core.ESDTKeyIdentifier
 )
 
 var log = logger.GetOrCreate("node")
@@ -244,6 +246,10 @@ func (n *Node) baseGetAllIssuedESDTs(tokenType string, ctx context.Context) ([]s
 	for leaf := range chLeaves.LeavesChan {
 		tokenName := string(leaf.Key())
 		if !strings.Contains(tokenName, "-") {
+			continue
+		}
+
+		if strings.HasPrefix(tokenName, baseESDTKeyPrefix) {
 			continue
 		}
 


### PR DESCRIPTION
## Reasoning behind the pull request
- NativeESDT is printed as Issued ESDT
- 
- 
  
## Proposed changes
- Don't print tokens from ESDT SC Address if they contain prefix `ELRONDesdt`
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
