### PR TITLE
[sovereign] Save validators info shard data epoch change

### DIFF
--- a/epochStart/metachain/sovereignValidatorInfoCreatorFactory.go
+++ b/epochStart/metachain/sovereignValidatorInfoCreatorFactory.go
@@ -1,0 +1,26 @@
+package metachain
+
+import "github.com/multiversx/mx-chain-go/process"
+
+type sovereignValidatorInfoCreatorFactory struct {
+}
+
+// NewSovereignValidatorInfoCreatorFactory creates a validator info creator factory for sovereign run type chain
+func NewSovereignValidatorInfoCreatorFactory() *sovereignValidatorInfoCreatorFactory {
+	return &sovereignValidatorInfoCreatorFactory{}
+}
+
+// CreateValidatorInfoCreator creates a validator info creator for sovereign run type chain
+func (f *sovereignValidatorInfoCreatorFactory) CreateValidatorInfoCreator(args ArgsNewValidatorInfoCreator) (process.EpochStartValidatorInfoCreator, error) {
+	vic, err := NewValidatorInfoCreator(args)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSovereignValidatorInfoCreator(vic)
+}
+
+// IsInterfaceNil checks if the underlying pointer is nil
+func (f *sovereignValidatorInfoCreatorFactory) IsInterfaceNil() bool {
+	return f == nil
+}

--- a/epochStart/metachain/sovereignValidatorInfoCreatorFactory_test.go
+++ b/epochStart/metachain/sovereignValidatorInfoCreatorFactory_test.go
@@ -1,0 +1,20 @@
+package metachain
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSovereignValidatorInfoCreatorFactory_CreateValidatorInfoCreator(t *testing.T) {
+	t.Parallel()
+
+	factory := NewSovereignValidatorInfoCreatorFactory()
+	require.False(t, factory.IsInterfaceNil())
+
+	args := createMockEpochValidatorInfoCreatorsArguments()
+	vic, err := factory.CreateValidatorInfoCreator(args)
+	require.Nil(t, err)
+	require.Equal(t, "*metachain.sovereignValidatorInfoCreator", fmt.Sprintf("%T", vic))
+}

--- a/epochStart/metachain/sovereignValidators.go
+++ b/epochStart/metachain/sovereignValidators.go
@@ -62,8 +62,10 @@ func (svic *sovereignValidatorInfoCreator) getMarshalledValidatorInfoTxs(miniBlo
 			continue
 		}
 
+		// add data directly to pool for sovereign chain, we don't need to broadcast and intercept it
 		strCache := process.ShardCacherIdentifier(core.SovereignChainShardId, core.SovereignChainShardId)
 		svic.dataPool.ValidatorsInfo().AddData(txHash, validatorInfoTx, validatorInfoTx.Size(), strCache)
+
 		marshalledValidatorInfoTxs = append(marshalledValidatorInfoTxs, marshalledData)
 	}
 

--- a/epochStart/metachain/sovereignValidators.go
+++ b/epochStart/metachain/sovereignValidators.go
@@ -12,6 +12,7 @@ type sovereignValidatorInfoCreator struct {
 	*validatorInfoCreator
 }
 
+// NewSovereignValidatorInfoCreator creates a sovereign validator info creator
 func NewSovereignValidatorInfoCreator(vic *validatorInfoCreator) (*sovereignValidatorInfoCreator, error) {
 	if check.IfNil(vic) {
 		return nil, process.ErrNilEpochStartValidatorInfoCreator
@@ -37,6 +38,7 @@ func (svic *sovereignValidatorInfoCreator) CreateMarshalledData(body *block.Body
 		marshalledValidatorInfoTxs = append(marshalledValidatorInfoTxs, svic.getMarshalledValidatorInfoTxs(miniBlock)...)
 	}
 
+	// create broadcast txs as in normal run type processing for now
 	mapMarshalledValidatorInfoTxs := make(map[string][][]byte)
 	if len(marshalledValidatorInfoTxs) > 0 {
 		mapMarshalledValidatorInfoTxs[common.ValidatorInfoTopic] = marshalledValidatorInfoTxs
@@ -70,4 +72,9 @@ func (svic *sovereignValidatorInfoCreator) getMarshalledValidatorInfoTxs(miniBlo
 	}
 
 	return marshalledValidatorInfoTxs
+}
+
+// IsInterfaceNil checks if the underlying pointer is nil
+func (svic *sovereignValidatorInfoCreator) IsInterfaceNil() bool {
+	return svic == nil
 }

--- a/epochStart/metachain/sovereignValidators.go
+++ b/epochStart/metachain/sovereignValidators.go
@@ -1,0 +1,71 @@
+package metachain
+
+import (
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/process"
+)
+
+type sovereignValidatorInfoCreator struct {
+	*validatorInfoCreator
+}
+
+func NewSovereignValidatorInfoCreator(vic *validatorInfoCreator) (*sovereignValidatorInfoCreator, error) {
+	if check.IfNil(vic) {
+		return nil, process.ErrNilEpochStartValidatorInfoCreator
+	}
+
+	return &sovereignValidatorInfoCreator{
+		vic,
+	}, nil
+}
+
+// CreateMarshalledData creates the marshalled data to be sent to shards
+func (svic *sovereignValidatorInfoCreator) CreateMarshalledData(body *block.Body) map[string][][]byte {
+	if check.IfNil(body) {
+		return nil
+	}
+
+	marshalledValidatorInfoTxs := make([][]byte, 0)
+	for _, miniBlock := range body.MiniBlocks {
+		if miniBlock.Type != block.PeerBlock {
+			continue
+		}
+
+		marshalledValidatorInfoTxs = append(marshalledValidatorInfoTxs, svic.getMarshalledValidatorInfoTxs(miniBlock)...)
+	}
+
+	mapMarshalledValidatorInfoTxs := make(map[string][][]byte)
+	if len(marshalledValidatorInfoTxs) > 0 {
+		mapMarshalledValidatorInfoTxs[common.ValidatorInfoTopic] = marshalledValidatorInfoTxs
+	}
+
+	return mapMarshalledValidatorInfoTxs
+}
+
+func (svic *sovereignValidatorInfoCreator) getMarshalledValidatorInfoTxs(miniBlock *block.MiniBlock) [][]byte {
+	validatorInfoCacher := svic.dataPool.CurrentEpochValidatorInfo()
+
+	marshalledValidatorInfoTxs := make([][]byte, 0)
+	for _, txHash := range miniBlock.TxHashes {
+		validatorInfoTx, err := validatorInfoCacher.GetValidatorInfo(txHash)
+		if err != nil {
+			log.Error("validatorInfoCreator.getMarshalledValidatorInfoTxs.GetValidatorInfo", "hash", txHash, "error", err)
+			continue
+		}
+
+		marshalledData, err := svic.marshalizer.Marshal(validatorInfoTx)
+		if err != nil {
+			log.Error("validatorInfoCreator.getMarshalledValidatorInfoTxs.Marshal", "hash", txHash, "error", err)
+			continue
+		}
+
+		strCache := process.ShardCacherIdentifier(core.SovereignChainShardId, core.SovereignChainShardId)
+		svic.dataPool.ValidatorsInfo().AddData(txHash, validatorInfoTx, validatorInfoTx.Size(), strCache)
+		marshalledValidatorInfoTxs = append(marshalledValidatorInfoTxs, marshalledData)
+	}
+
+	return marshalledValidatorInfoTxs
+}

--- a/epochStart/metachain/sovereignValidators_test.go
+++ b/epochStart/metachain/sovereignValidators_test.go
@@ -1,0 +1,81 @@
+package metachain
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/dataRetriever"
+	"github.com/multiversx/mx-chain-go/state"
+	"github.com/multiversx/mx-chain-go/testscommon"
+	dataRetrieverMock "github.com/multiversx/mx-chain-go/testscommon/dataRetriever"
+	vics "github.com/multiversx/mx-chain-go/testscommon/validatorInfoCacher"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSovereignValidatorInfoCreator_CreateMarshalledData(t *testing.T) {
+	t.Parallel()
+
+	arguments := createMockEpochValidatorInfoCreatorsArguments()
+
+	svi1 := &state.ShardValidatorInfo{PublicKey: []byte("x")}
+	marshalledSVI1, _ := arguments.Marshalizer.Marshal(svi1)
+
+	svi2 := &state.ShardValidatorInfo{PublicKey: []byte("y")}
+	marshalledSVI2, _ := arguments.Marshalizer.Marshal(svi2)
+
+	txHash1 := []byte("txHash1")
+	txHash2 := []byte("txHash2")
+	shardDataCacher := testscommon.NewShardedDataCacheNotifierMock()
+	arguments.DataPool = &dataRetrieverMock.PoolsHolderStub{
+		CurrEpochValidatorInfoCalled: func() dataRetriever.ValidatorInfoCacher {
+			return &vics.ValidatorInfoCacherStub{
+				GetValidatorInfoCalled: func(validatorInfoHash []byte) (*state.ShardValidatorInfo, error) {
+					if bytes.Equal(validatorInfoHash, txHash1) {
+						return svi1, nil
+					}
+					if bytes.Equal(validatorInfoHash, txHash2) {
+						return svi2, nil
+					}
+
+					require.Fail(t, "should not call get for another validator")
+					return nil, nil
+				},
+			}
+		},
+		ValidatorsInfoCalled: func() dataRetriever.ShardedDataCacherNotifier {
+			return shardDataCacher
+		},
+	}
+	vic, _ := NewValidatorInfoCreator(arguments)
+	svic, _ := NewSovereignValidatorInfoCreator(vic)
+
+	body := &block.Body{
+		MiniBlocks: []*block.MiniBlock{
+			{
+				SenderShardID:   core.SovereignChainShardId,
+				ReceiverShardID: core.SovereignChainShardId,
+				Type:            block.PeerBlock,
+				TxHashes: [][]byte{
+					txHash1,
+					txHash2,
+				},
+			},
+		},
+	}
+	marshalledData := svic.CreateMarshalledData(body)
+	require.Equal(t, 1, len(marshalledData))
+	require.Equal(t, 2, len(marshalledData[common.ValidatorInfoTopic]))
+	require.Equal(t, marshalledSVI1, marshalledData[common.ValidatorInfoTopic][0])
+	require.Equal(t, marshalledSVI2, marshalledData[common.ValidatorInfoTopic][1])
+
+	cachedData1, found := shardDataCacher.SearchFirstData(txHash1)
+	require.True(t, found)
+	require.Equal(t, svi1, cachedData1)
+
+	cachedData2, found := shardDataCacher.SearchFirstData(txHash2)
+	require.True(t, found)
+	require.Equal(t, svi2, cachedData2)
+}

--- a/epochStart/metachain/sovereignValidators_test.go
+++ b/epochStart/metachain/sovereignValidators_test.go
@@ -2,18 +2,35 @@ package metachain
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
+	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/testscommon"
 	dataRetrieverMock "github.com/multiversx/mx-chain-go/testscommon/dataRetriever"
 	vics "github.com/multiversx/mx-chain-go/testscommon/validatorInfoCacher"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewSovereignValidatorInfoCreator(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil input, should return error", func(t *testing.T) {
+		svic, err := NewSovereignValidatorInfoCreator(nil)
+		require.Equal(t, process.ErrNilEpochStartValidatorInfoCreator, err)
+		require.Nil(t, svic)
+	})
+	t.Run("should work", func(t *testing.T) {
+		svic, err := NewSovereignValidatorInfoCreator(&validatorInfoCreator{})
+		require.Nil(t, err)
+		require.False(t, svic.IsInterfaceNil())
+	})
+}
 
 func TestSovereignValidatorInfoCreator_CreateMarshalledData(t *testing.T) {
 	t.Parallel()
@@ -63,6 +80,14 @@ func TestSovereignValidatorInfoCreator_CreateMarshalledData(t *testing.T) {
 					txHash2,
 				},
 			},
+			{
+				SenderShardID:   core.SovereignChainShardId,
+				ReceiverShardID: core.SovereignChainShardId,
+				Type:            block.StateBlock,
+				TxHashes: [][]byte{
+					[]byte("txHash3"),
+				},
+			},
 		},
 	}
 	marshalledData := svic.CreateMarshalledData(body)
@@ -78,4 +103,89 @@ func TestSovereignValidatorInfoCreator_CreateMarshalledData(t *testing.T) {
 	cachedData2, found := shardDataCacher.SearchFirstData(txHash2)
 	require.True(t, found)
 	require.Equal(t, svi2, cachedData2)
+}
+
+func TestSovereignValidatorInfoCreator_CreateMarshalledDataErrorCases(t *testing.T) {
+
+	t.Run("CreateMarshalledData should return nil body is nil", func(t *testing.T) {
+		t.Parallel()
+
+		arguments := createMockEpochValidatorInfoCreatorsArguments()
+		vic, _ := NewValidatorInfoCreator(arguments)
+		svic, _ := NewSovereignValidatorInfoCreator(vic)
+
+		marshalledData := svic.CreateMarshalledData(nil)
+		require.Nil(t, marshalledData)
+	})
+
+	t.Run("CreateMarshalledData should return empty slice when tx hash does not exist in validator info cacher", func(t *testing.T) {
+		t.Parallel()
+
+		arguments := createMockEpochValidatorInfoCreatorsArguments()
+		localErr := errors.New("local error")
+		arguments.DataPool = &dataRetrieverMock.PoolsHolderStub{
+			CurrEpochValidatorInfoCalled: func() dataRetriever.ValidatorInfoCacher {
+				return &vics.ValidatorInfoCacherStub{
+					GetValidatorInfoCalled: func(validatorInfoHash []byte) (*state.ShardValidatorInfo, error) {
+						return nil, localErr
+					},
+				}
+			},
+		}
+		wasMarshallCalled := false
+		arguments.Marshalizer = &testscommon.MarshallerStub{
+			MarshalCalled: func(obj interface{}) ([]byte, error) {
+				wasMarshallCalled = true
+				return nil, nil
+			},
+		}
+
+		vic, _ := NewValidatorInfoCreator(arguments)
+		svic, _ := NewSovereignValidatorInfoCreator(vic)
+
+		body := createMockBlockBody(core.SovereignChainShardId, core.SovereignChainShardId, block.PeerBlock)
+		marshalledData := svic.CreateMarshalledData(body)
+		require.Empty(t, marshalledData)
+		require.False(t, wasMarshallCalled)
+	})
+
+	t.Run("CreateMarshalledData should return empty slice when marhsall fails", func(t *testing.T) {
+		t.Parallel()
+
+		arguments := createMockEpochValidatorInfoCreatorsArguments()
+		arguments.DataPool = &dataRetrieverMock.PoolsHolderStub{
+			CurrEpochValidatorInfoCalled: func() dataRetriever.ValidatorInfoCacher {
+				return &vics.ValidatorInfoCacherStub{
+					GetValidatorInfoCalled: func(validatorInfoHash []byte) (*state.ShardValidatorInfo, error) {
+						return &state.ShardValidatorInfo{}, nil
+					},
+				}
+			},
+		}
+		localErr := errors.New("local error")
+
+		arguments.Marshalizer = &testscommon.MarshallerStub{
+			MarshalCalled: func(obj interface{}) ([]byte, error) {
+
+				return nil, localErr
+			},
+		}
+		shardDataCacher := testscommon.NewShardedDataCacheNotifierMock()
+		arguments.DataPool = &dataRetrieverMock.PoolsHolderStub{
+			ValidatorsInfoCalled: func() dataRetriever.ShardedDataCacherNotifier {
+				return shardDataCacher
+			},
+			CurrEpochValidatorInfoCalled: func() dataRetriever.ValidatorInfoCacher {
+				return &vics.ValidatorInfoCacherStub{}
+			},
+		}
+
+		vic, _ := NewValidatorInfoCreator(arguments)
+		svic, _ := NewSovereignValidatorInfoCreator(vic)
+
+		body := createMockBlockBody(core.SovereignChainShardId, core.SovereignChainShardId, block.PeerBlock)
+		marshalledData := svic.CreateMarshalledData(body)
+		require.Empty(t, marshalledData)
+		require.Empty(t, shardDataCacher.Keys())
+	})
 }

--- a/epochStart/metachain/validatorInfoCreatorFactory.go
+++ b/epochStart/metachain/validatorInfoCreatorFactory.go
@@ -1,0 +1,21 @@
+package metachain
+
+import "github.com/multiversx/mx-chain-go/process"
+
+type validatorInfoCreatorFactory struct {
+}
+
+// NewValidatorInfoCreatorFactory creates a validator info creator factory for normal run type chain
+func NewValidatorInfoCreatorFactory() *validatorInfoCreatorFactory {
+	return &validatorInfoCreatorFactory{}
+}
+
+// CreateValidatorInfoCreator creates a validator info creator for normal run type chain
+func (f *validatorInfoCreatorFactory) CreateValidatorInfoCreator(args ArgsNewValidatorInfoCreator) (process.EpochStartValidatorInfoCreator, error) {
+	return NewValidatorInfoCreator(args)
+}
+
+// IsInterfaceNil checks if the underlying pointer is nil
+func (f *validatorInfoCreatorFactory) IsInterfaceNil() bool {
+	return f == nil
+}

--- a/epochStart/metachain/validatorInfoCreatorFactory_test.go
+++ b/epochStart/metachain/validatorInfoCreatorFactory_test.go
@@ -1,0 +1,20 @@
+package metachain
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatorInfoCreatorFactory_CreateValidatorInfoCreator(t *testing.T) {
+	t.Parallel()
+
+	factory := NewValidatorInfoCreatorFactory()
+	require.False(t, factory.IsInterfaceNil())
+
+	args := createMockEpochValidatorInfoCreatorsArguments()
+	vic, err := factory.CreateValidatorInfoCreator(args)
+	require.Nil(t, err)
+	require.Equal(t, "*metachain.validatorInfoCreator", fmt.Sprintf("%T", vic))
+}

--- a/epochStart/metachain/validators.go
+++ b/epochStart/metachain/validators.go
@@ -374,7 +374,6 @@ func (vic *validatorInfoCreator) getMarshalledValidatorInfoTxs(miniBlock *block.
 
 	marshalledValidatorInfoTxs := make([][]byte, 0)
 	for _, txHash := range miniBlock.TxHashes {
-		// todo: maybe save here directly for sovereign ???
 		validatorInfoTx, err := validatorInfoCacher.GetValidatorInfo(txHash)
 		if err != nil {
 			log.Error("validatorInfoCreator.getMarshalledValidatorInfoTxs.GetValidatorInfo", "hash", txHash, "error", err)

--- a/epochStart/metachain/validators.go
+++ b/epochStart/metachain/validators.go
@@ -352,6 +352,11 @@ func (vic *validatorInfoCreator) CreateMarshalledData(body *block.Body) map[stri
 		if miniBlock.Type != block.PeerBlock {
 			continue
 		}
+		isCrossMiniBlockFromMe := miniBlock.SenderShardID == vic.shardCoordinator.SelfId() &&
+			miniBlock.ReceiverShardID != vic.shardCoordinator.SelfId()
+		if !isCrossMiniBlockFromMe {
+			continue
+		}
 
 		marshalledValidatorInfoTxs = append(marshalledValidatorInfoTxs, vic.getMarshalledValidatorInfoTxs(miniBlock)...)
 	}

--- a/epochStart/metachain/validators.go
+++ b/epochStart/metachain/validators.go
@@ -352,11 +352,6 @@ func (vic *validatorInfoCreator) CreateMarshalledData(body *block.Body) map[stri
 		if miniBlock.Type != block.PeerBlock {
 			continue
 		}
-		isCrossMiniBlockFromMe := miniBlock.SenderShardID == vic.shardCoordinator.SelfId() &&
-			miniBlock.ReceiverShardID != vic.shardCoordinator.SelfId()
-		if !isCrossMiniBlockFromMe {
-			continue
-		}
 
 		marshalledValidatorInfoTxs = append(marshalledValidatorInfoTxs, vic.getMarshalledValidatorInfoTxs(miniBlock)...)
 	}
@@ -374,6 +369,7 @@ func (vic *validatorInfoCreator) getMarshalledValidatorInfoTxs(miniBlock *block.
 
 	marshalledValidatorInfoTxs := make([][]byte, 0)
 	for _, txHash := range miniBlock.TxHashes {
+		// todo: maybe save here directly for sovereign ???
 		validatorInfoTx, err := validatorInfoCacher.GetValidatorInfo(txHash)
 		if err != nil {
 			log.Error("validatorInfoCreator.getMarshalledValidatorInfoTxs.GetValidatorInfo", "hash", txHash, "error", err)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -820,3 +820,6 @@ var ErrNilEpochStartTriggerFactory = errors.New("nil epoch start trigger factory
 
 // ErrNilStakingToPeerFactory signals that a nil staking to peer factory has been provided
 var ErrNilStakingToPeerFactory = errors.New("nil staking to peer factory has been provided")
+
+// ErrNilValidatorInfoCreatorFactory signals that a nil validator info creator factory has been provided
+var ErrNilValidatorInfoCreatorFactory = errors.New("nil validator info creator factory has been provided")

--- a/factory/interface.go
+++ b/factory/interface.go
@@ -18,6 +18,7 @@ import (
 	"github.com/multiversx/mx-chain-go/dblookupext"
 	"github.com/multiversx/mx-chain-go/epochStart"
 	"github.com/multiversx/mx-chain-go/epochStart/bootstrap"
+	"github.com/multiversx/mx-chain-go/epochStart/metachain"
 	factoryVm "github.com/multiversx/mx-chain-go/factory/vm"
 	"github.com/multiversx/mx-chain-go/genesis"
 	"github.com/multiversx/mx-chain-go/genesis/checking"
@@ -624,10 +625,17 @@ type RunTypeComponentsHolder interface {
 	EpochStartTriggerFactory() EpochStartTriggerFactoryHandler
 	LatestDataProviderFactory() latestData.LatestDataProviderFactory
 	StakingToPeerFactory() scToProtocol.StakingToPeerFactoryHandler
+	ValidatorInfoCreatorFactory() ValidatorInfoCreatorFactory
 	Create() error
 	Close() error
 	CheckSubcomponents() error
 	String() string
+	IsInterfaceNil() bool
+}
+
+// ValidatorInfoCreatorFactory defines a validator info creator factory
+type ValidatorInfoCreatorFactory interface {
+	CreateValidatorInfoCreator(args metachain.ArgsNewValidatorInfoCreator) (process.EpochStartValidatorInfoCreator, error)
 	IsInterfaceNil() bool
 }
 

--- a/factory/processing/blockProcessorCreator.go
+++ b/factory/processing/blockProcessorCreator.go
@@ -1139,7 +1139,7 @@ func (pcf *processComponentsFactory) createExtraMetaBlockProcessorArgs(
 			DataPool:             pcf.data.Datapool(),
 			EnableEpochsHandler:  pcf.coreData.EnableEpochsHandler(),
 		}
-		validatorInfoCreator, err := metachainEpochStart.NewValidatorInfoCreator(argsEpochValidatorInfo)
+		validatorInfoCreator, err := pcf.runTypeComponents.ValidatorInfoCreatorFactory().CreateValidatorInfoCreator(argsEpochValidatorInfo)
 		if err != nil {
 			return nil, err
 		}

--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -2069,6 +2069,9 @@ func checkProcessComponentsArgs(args ProcessComponentsFactoryArgs) error {
 	if check.IfNil(args.RunTypeComponents.StakingToPeerFactory()) {
 		return fmt.Errorf("%s: %w", baseErrMessage, errorsMx.ErrNilStakingToPeerFactory)
 	}
+	if check.IfNil(args.RunTypeComponents.ValidatorInfoCreatorFactory()) {
+		return fmt.Errorf("%s: %w", baseErrMessage, errorsMx.ErrNilValidatorInfoCreatorFactory)
+	}
 
 	return nil
 }

--- a/factory/processing/processComponents_test.go
+++ b/factory/processing/processComponents_test.go
@@ -970,6 +970,17 @@ func TestNewProcessComponentsFactory(t *testing.T) {
 		require.True(t, errors.Is(err, errorsMx.ErrNilStakingToPeerFactory))
 		require.Nil(t, pcf)
 	})
+	t.Run("nil ValidatorInfoCreatorFactory should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockProcessComponentsFactoryArgs()
+		rtMock := getRunTypeComponentsMock()
+		rtMock.ValidatorInfoCreatorFactoryField = nil
+		args.RunTypeComponents = rtMock
+		pcf, err := processComp.NewProcessComponentsFactory(args)
+		require.True(t, errors.Is(err, errorsMx.ErrNilValidatorInfoCreatorFactory))
+		require.Nil(t, pcf)
+	})
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 

--- a/factory/processing/processComponents_test.go
+++ b/factory/processing/processComponents_test.go
@@ -1025,6 +1025,7 @@ func getRunTypeComponents(rt runType.RunTypeComponentsHolder) *mainFactoryMocks.
 		EpochStartTriggerFactoryField:       rt.EpochStartTriggerFactory(),
 		LatestDataProviderFactoryField:      rt.LatestDataProviderFactory(),
 		StakingToPeerFactoryField:           rt.StakingToPeerFactory(),
+		ValidatorInfoCreatorFactoryField:    rt.ValidatorInfoCreatorFactory(),
 	}
 }
 

--- a/factory/runType/runTypeComponents.go
+++ b/factory/runType/runTypeComponents.go
@@ -12,6 +12,7 @@ import (
 	"github.com/multiversx/mx-chain-go/dataRetriever/factory/resolverscontainer"
 	"github.com/multiversx/mx-chain-go/dataRetriever/requestHandlers"
 	"github.com/multiversx/mx-chain-go/epochStart/bootstrap"
+	"github.com/multiversx/mx-chain-go/epochStart/metachain"
 	"github.com/multiversx/mx-chain-go/errors"
 	mainFactory "github.com/multiversx/mx-chain-go/factory"
 	"github.com/multiversx/mx-chain-go/factory/epochStartTrigger"
@@ -101,6 +102,7 @@ type runTypeComponents struct {
 	epochStartTriggerFactory                mainFactory.EpochStartTriggerFactoryHandler
 	latestDataProviderFactory               latestData.LatestDataProviderFactory
 	scToProtocolFactory                     scToProtocol.StakingToPeerFactoryHandler
+	validatorInfoCreatorFactory             mainFactory.ValidatorInfoCreatorFactory
 }
 
 // NewRunTypeComponentsFactory will return a new instance of runTypeComponentsFactory
@@ -267,6 +269,7 @@ func (rcf *runTypeComponentsFactory) Create() (*runTypeComponents, error) {
 		epochStartTriggerFactory:                epochStartTrigger.NewEpochStartTriggerFactory(),
 		latestDataProviderFactory:               latestData.NewLatestDataProviderFactory(),
 		scToProtocolFactory:                     scToProtocol.NewStakingToPeerFactory(),
+		validatorInfoCreatorFactory:             metachain.NewValidatorInfoCreatorFactory(),
 	}, nil
 }
 

--- a/factory/runType/runTypeComponentsHandler.go
+++ b/factory/runType/runTypeComponentsHandler.go
@@ -206,6 +206,9 @@ func (mrc *managedRunTypeComponents) CheckSubcomponents() error {
 	if check.IfNil(mrc.scToProtocolFactory) {
 		return errors.ErrNilStakingToPeerFactory
 	}
+	if check.IfNil(mrc.validatorInfoCreatorFactory) {
+		return errors.ErrNilValidatorInfoCreatorFactory
+	}
 	return nil
 }
 

--- a/factory/runType/runTypeComponentsHandler.go
+++ b/factory/runType/runTypeComponentsHandler.go
@@ -653,6 +653,18 @@ func (mrc *managedRunTypeComponents) StakingToPeerFactory() scToProtocol.Staking
 	return mrc.runTypeComponents.scToProtocolFactory
 }
 
+// ValidatorInfoCreatorFactory returns the validator info creator factory
+func (mrc *managedRunTypeComponents) ValidatorInfoCreatorFactory() factory.ValidatorInfoCreatorFactory {
+	mrc.mutRunTypeComponents.RLock()
+	defer mrc.mutRunTypeComponents.RUnlock()
+
+	if check.IfNil(mrc.runTypeComponents) {
+		return nil
+	}
+
+	return mrc.runTypeComponents.validatorInfoCreatorFactory
+}
+
 // IsInterfaceNil returns true if the interface is nil
 func (mrc *managedRunTypeComponents) IsInterfaceNil() bool {
 	return mrc == nil

--- a/factory/runType/runTypeComponentsHandler_test.go
+++ b/factory/runType/runTypeComponentsHandler_test.go
@@ -91,6 +91,7 @@ func TestManagedRunTypeComponents_Create(t *testing.T) {
 		require.Nil(t, managedRunTypeComponents.EpochStartTriggerFactory())
 		require.Nil(t, managedRunTypeComponents.LatestDataProviderFactory())
 		require.Nil(t, managedRunTypeComponents.StakingToPeerFactory())
+		require.Nil(t, managedRunTypeComponents.ValidatorInfoCreatorFactory())
 
 		err = managedRunTypeComponents.Create()
 		require.NoError(t, err)
@@ -131,6 +132,7 @@ func TestManagedRunTypeComponents_Create(t *testing.T) {
 		require.NotNil(t, managedRunTypeComponents.EpochStartTriggerFactory())
 		require.NotNil(t, managedRunTypeComponents.LatestDataProviderFactory())
 		require.NotNil(t, managedRunTypeComponents.StakingToPeerFactory())
+		require.NotNil(t, managedRunTypeComponents.ValidatorInfoCreatorFactory())
 
 		require.Equal(t, factory.RunTypeComponentsName, managedRunTypeComponents.String())
 		require.NoError(t, managedRunTypeComponents.Close())

--- a/factory/runType/sovereignRunTypeComponents.go
+++ b/factory/runType/sovereignRunTypeComponents.go
@@ -12,6 +12,7 @@ import (
 	"github.com/multiversx/mx-chain-go/dataRetriever/factory/resolverscontainer"
 	"github.com/multiversx/mx-chain-go/dataRetriever/requestHandlers"
 	"github.com/multiversx/mx-chain-go/epochStart/bootstrap"
+	"github.com/multiversx/mx-chain-go/epochStart/metachain"
 	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/factory/epochStartTrigger"
 	factoryVm "github.com/multiversx/mx-chain-go/factory/vm"
@@ -253,5 +254,6 @@ func (rcf *sovereignRunTypeComponentsFactory) Create() (*runTypeComponents, erro
 		epochStartTriggerFactory:                epochStartTrigger.NewSovereignEpochStartTriggerFactory(),
 		latestDataProviderFactory:               latestData.NewSovereignLatestDataProviderFactory(),
 		scToProtocolFactory:                     scToProtocol.NewSovereignStakingToPeerFactory(),
+		validatorInfoCreatorFactory:             metachain.NewSovereignValidatorInfoCreatorFactory(),
 	}, nil
 }

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -2432,7 +2432,7 @@ func (tpn *TestProcessorNode) createMetaBlockProcessorArgs(argumentsBase block.A
 		DataPool:             tpn.DataPool,
 		EnableEpochsHandler:  tpn.EnableEpochsHandler,
 	}
-	epochStartValidatorInfo, _ := metachain.NewValidatorInfoCreator(argsEpochValidatorInfo)
+	epochStartValidatorInfo, _ := tpn.RunTypeComponents.ValidatorInfoCreatorFactory().CreateValidatorInfoCreator(argsEpochValidatorInfo)
 
 	maxNodesChangeConfigProvider, _ := notifier.NewNodesConfigProvider(
 		tpn.EpochNotifier,

--- a/process/block/preprocess/validatorInfoPreProcessor.go
+++ b/process/block/preprocess/validatorInfoPreProcessor.go
@@ -188,7 +188,6 @@ func (vip *validatorInfoPreprocessor) SaveTxsToStorage(body *block.Body) error {
 func (vip *validatorInfoPreprocessor) saveValidatorInfoToStorage(miniBlock *block.MiniBlock) {
 	for _, txHash := range miniBlock.TxHashes {
 		val, ok := vip.validatorsInfoPool.SearchFirstData(txHash)
-		// TODO: MX-15652 fix adding data in validators info pool for interceptor topic validatorsInfo
 		if !ok {
 			log.Debug("validatorInfoPreprocessor.saveValidatorInfoToStorage: SearchFirstData: tx not found in validator info pool", "txHash", txHash)
 			continue

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -1379,8 +1379,9 @@ func (scbp *sovereignChainBlockProcessor) commitEpochStart(header data.HeaderHan
 }
 
 func (scbp *sovereignChainBlockProcessor) createEpochStartData(body *block.Body) {
-	_ = scbp.epochRewardsCreator.CreateMarshalledData(body)
+	// this will create validators info data and save it to pool
 	_ = scbp.validatorInfoCreator.CreateMarshalledData(body)
+	_ = scbp.epochRewardsCreator.CreateMarshalledData(body)
 }
 
 // getOrderedProcessedExtendedShardHeadersFromHeader returns all the extended shard headers fully processed

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -1075,6 +1075,7 @@ func GetRunTypeComponentsStub(rt factory.RunTypeComponentsHandler) *mainFactoryM
 		EpochStartTriggerFactoryField:       rt.EpochStartTriggerFactory(),
 		LatestDataProviderFactoryField:      rt.LatestDataProviderFactory(),
 		StakingToPeerFactoryField:           rt.StakingToPeerFactory(),
+		ValidatorInfoCreatorFactoryField:    rt.ValidatorInfoCreatorFactory(),
 	}
 }
 

--- a/testscommon/factory/validatorInfoCreatorFactoryMock.go
+++ b/testscommon/factory/validatorInfoCreatorFactoryMock.go
@@ -1,0 +1,26 @@
+package factory
+
+import (
+	"github.com/multiversx/mx-chain-go/epochStart/metachain"
+	"github.com/multiversx/mx-chain-go/process"
+	"github.com/multiversx/mx-chain-go/testscommon"
+)
+
+// ValidatorInfoCreatorFactoryMock -
+type ValidatorInfoCreatorFactoryMock struct {
+	CreateValidatorInfoCreatorCalled func(args metachain.ArgsNewValidatorInfoCreator) (process.EpochStartValidatorInfoCreator, error)
+}
+
+// CreateValidatorInfoCreator -
+func (mock *ValidatorInfoCreatorFactoryMock) CreateValidatorInfoCreator(args metachain.ArgsNewValidatorInfoCreator) (process.EpochStartValidatorInfoCreator, error) {
+	if mock.CreateValidatorInfoCreatorCalled != nil {
+		return mock.CreateValidatorInfoCreatorCalled(args)
+	}
+
+	return &testscommon.EpochValidatorInfoCreatorStub{}, nil
+}
+
+// IsInterfaceNil -
+func (mock *ValidatorInfoCreatorFactoryMock) IsInterfaceNil() bool {
+	return mock == nil
+}

--- a/testscommon/mainFactoryMocks/runTypeComponentStub.go
+++ b/testscommon/mainFactoryMocks/runTypeComponentStub.go
@@ -7,6 +7,7 @@ import (
 	"github.com/multiversx/mx-chain-go/dataRetriever/factory/resolverscontainer"
 	"github.com/multiversx/mx-chain-go/dataRetriever/requestHandlers"
 	"github.com/multiversx/mx-chain-go/epochStart/bootstrap"
+	"github.com/multiversx/mx-chain-go/epochStart/metachain"
 	"github.com/multiversx/mx-chain-go/factory"
 	factoryVm "github.com/multiversx/mx-chain-go/factory/vm"
 	"github.com/multiversx/mx-chain-go/genesis"
@@ -79,6 +80,7 @@ type RunTypeComponentsStub struct {
 	EpochStartTriggerFactoryField       factory.EpochStartTriggerFactoryHandler
 	LatestDataProviderFactoryField      latestData.LatestDataProviderFactory
 	StakingToPeerFactoryField           scToProtocol.StakingToPeerFactoryHandler
+	ValidatorInfoCreatorFactoryField    factory.ValidatorInfoCreatorFactory
 }
 
 // NewRunTypeComponentsStub -
@@ -121,6 +123,7 @@ func NewRunTypeComponentsStub() *RunTypeComponentsStub {
 		EpochStartTriggerFactoryField:       &testFactory.EpochStartTriggerFactoryMock{},
 		LatestDataProviderFactoryField:      latestData.NewLatestDataProviderFactory(),
 		StakingToPeerFactoryField:           &testFactory.StakingToPeerFactoryMock{},
+		ValidatorInfoCreatorFactoryField:    metachain.NewValidatorInfoCreatorFactory(),
 	}
 }
 
@@ -327,6 +330,11 @@ func (r *RunTypeComponentsStub) LatestDataProviderFactory() latestData.LatestDat
 // StakingToPeerFactory -
 func (r *RunTypeComponentsStub) StakingToPeerFactory() scToProtocol.StakingToPeerFactoryHandler {
 	return r.StakingToPeerFactoryField
+}
+
+// ValidatorInfoCreatorFactory -
+func (r *RunTypeComponentsStub) ValidatorInfoCreatorFactory() factory.ValidatorInfoCreatorFactory {
+	return r.ValidatorInfoCreatorFactoryField
 }
 
 // IsInterfaceNil -

--- a/testscommon/mainFactoryMocks/runTypeComponentStub.go
+++ b/testscommon/mainFactoryMocks/runTypeComponentStub.go
@@ -7,7 +7,6 @@ import (
 	"github.com/multiversx/mx-chain-go/dataRetriever/factory/resolverscontainer"
 	"github.com/multiversx/mx-chain-go/dataRetriever/requestHandlers"
 	"github.com/multiversx/mx-chain-go/epochStart/bootstrap"
-	"github.com/multiversx/mx-chain-go/epochStart/metachain"
 	"github.com/multiversx/mx-chain-go/factory"
 	factoryVm "github.com/multiversx/mx-chain-go/factory/vm"
 	"github.com/multiversx/mx-chain-go/genesis"
@@ -123,7 +122,7 @@ func NewRunTypeComponentsStub() *RunTypeComponentsStub {
 		EpochStartTriggerFactoryField:       &testFactory.EpochStartTriggerFactoryMock{},
 		LatestDataProviderFactoryField:      latestData.NewLatestDataProviderFactory(),
 		StakingToPeerFactoryField:           &testFactory.StakingToPeerFactoryMock{},
-		ValidatorInfoCreatorFactoryField:    metachain.NewValidatorInfoCreatorFactory(),
+		ValidatorInfoCreatorFactoryField:    &testFactory.ValidatorInfoCreatorFactoryMock{},
 	}
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request
- Save validator info data for peer miniblocks in sovereign chain block processing part
  
## Proposed changes
- No need to broadcast data for epoch start peer mbs and intercept it to be added in pool
- When creating validator infos, we will save them directly in pool inside `sovereignValidatorInfoCreator`, which will be called at processing epoch start block level in `sovereignChainBlock`

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
