### PR TITLE
Optimize "DisplayProcessTxDetails": Early exit if log level is not TRACE

### DIFF
--- a/process/common.go
+++ b/process/common.go
@@ -680,6 +680,10 @@ func DisplayProcessTxDetails(
 	txHash []byte,
 	addressPubkeyConverter core.PubkeyConverter,
 ) {
+	if log.GetLevel() > logger.LogTrace {
+		return
+	}
+
 	if !check.IfNil(accountHandler) {
 		account, ok := accountHandler.(state.UserAccountHandler)
 		if ok {


### PR DESCRIPTION
## Reasoning behind the pull request
- The function `DisplayProcessTxDetails` is called in a few places during transactions processing. Its main concern is to display some data by means of Log.Trace(). In this regard, it performs some computation, which takes some non-negligible time (analyzed with _pprof_).

## Proposed changes
- Skip the computations performed by  `DisplayProcessTxDetails` if it should display nothing, given the current log level.

## Testing procedure
- Standard testing.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
