### PR TITLE
Fixed fee field for guardian operations

### DIFF
--- a/common/forking/gasSchedule.go
+++ b/common/forking/gasSchedule.go
@@ -163,6 +163,26 @@ func (g *gasScheduleNotifier) LatestGasSchedule() map[string]map[string]uint64 {
 	return g.lastGasSchedule
 }
 
+// GasScheduleForEpoch returns the gas schedule for the specific epoch
+func (g *gasScheduleNotifier) GasScheduleForEpoch(epoch uint32) (map[string]map[string]uint64, error) {
+	g.mutNotifier.RLock()
+	defer g.mutNotifier.RUnlock()
+
+	currentVersion := g.getMatchingVersion(g.currentEpoch)
+	requestedVersion := g.getMatchingVersion(epoch)
+	if currentVersion == requestedVersion {
+		return g.lastGasSchedule, nil
+	}
+
+	gasSchedule, err := common.LoadGasScheduleConfig(filepath.Join(g.configDir, requestedVersion.FileName))
+	if err != nil {
+		log.Error("could not load the gas schedule", "epoch", requestedVersion.StartEpoch)
+		return nil, err
+	}
+
+	return gasSchedule, nil
+}
+
 // LatestGasScheduleCopy returns a copy of the latest gas schedule
 func (g *gasScheduleNotifier) LatestGasScheduleCopy() map[string]map[string]uint64 {
 	g.mutNotifier.RLock()

--- a/factory/api/apiResolverFactory.go
+++ b/factory/api/apiResolverFactory.go
@@ -244,6 +244,7 @@ func CreateApiResolver(args *ApiResolverArgs) (facade.ApiResolver, error) {
 		TxTypeHandler:            txTypeHandler,
 		LogsFacade:               logsFacade,
 		DataFieldParser:          dataFieldParser,
+		GasScheduleNotifier:      args.GasScheduleNotifier,
 	}
 	apiTransactionProcessor, err := transactionAPI.NewAPITransactionProcessor(argsAPITransactionProc)
 	if err != nil {

--- a/genesis/process/disabled/feeHandler.go
+++ b/genesis/process/disabled/feeHandler.go
@@ -87,6 +87,11 @@ func (fh *FeeHandler) ComputeMoveBalanceFee(_ data.TransactionWithFeeHandler) *b
 	return big.NewInt(0)
 }
 
+// ComputeMoveBalanceFeeInEpoch returns 0
+func (fh *FeeHandler) ComputeMoveBalanceFeeInEpoch(_ data.TransactionWithFeeHandler, _ uint32) *big.Int {
+	return big.NewInt(0)
+}
+
 // ComputeFeeForProcessing returns 0
 func (fh *FeeHandler) ComputeFeeForProcessing(_ data.TransactionWithFeeHandler, _ uint64) *big.Int {
 	return big.NewInt(0)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.5
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiversx/mx-chain-communication-go v1.0.15-0.20240725071304-ebce652ff65d
-	github.com/multiversx/mx-chain-core-go v1.2.21-0.20240725065431-6e9bfee5a4c6
+	github.com/multiversx/mx-chain-core-go v1.2.21-0.20240726123734-d2e801ceb0bc
 	github.com/multiversx/mx-chain-crypto-go v1.2.12-0.20240725071000-c3212540166f
 	github.com/multiversx/mx-chain-es-indexer-go v1.7.3-0.20240725073933-b3457c5308ca
 	github.com/multiversx/mx-chain-logger-go v1.0.15-0.20240725065747-176bd697c775

--- a/go.sum
+++ b/go.sum
@@ -387,8 +387,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.0.15-0.20240725071304-ebce652ff65d h1:grQCJW4DCvvIQ6q84sy23oAp8XQ8Dxr3Js8aoh+m99M=
 github.com/multiversx/mx-chain-communication-go v1.0.15-0.20240725071304-ebce652ff65d/go.mod h1:hFGM+O7rt+gWXSHFoRjC3/oN0OJfPfeFAxqXIac5UdQ=
-github.com/multiversx/mx-chain-core-go v1.2.21-0.20240725065431-6e9bfee5a4c6 h1:Q7uUjTYTrt8Mw9oq5JWPv+WHhpxHTv6lhZZlhPuNcoQ=
-github.com/multiversx/mx-chain-core-go v1.2.21-0.20240725065431-6e9bfee5a4c6/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
+github.com/multiversx/mx-chain-core-go v1.2.21-0.20240726123734-d2e801ceb0bc h1:COQlZ7wmOz15F40woVfRb6sl5CLQCKcRv13e9s/2PT0=
+github.com/multiversx/mx-chain-core-go v1.2.21-0.20240726123734-d2e801ceb0bc/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
 github.com/multiversx/mx-chain-crypto-go v1.2.12-0.20240725071000-c3212540166f h1:jydjrmVFvSllBOTppveOAkLITpOYKk0kma5z0bfDImI=
 github.com/multiversx/mx-chain-crypto-go v1.2.12-0.20240725071000-c3212540166f/go.mod h1:9aSp//uBSvqFdzh4gvYISraoruhr1FCTXgPQalQ687k=
 github.com/multiversx/mx-chain-es-indexer-go v1.7.3-0.20240725073933-b3457c5308ca h1:9b2yFAarWDG/jTYePv0UqNWQ9gxeSZy9mGxtd8dFj2Y=

--- a/integrationTests/mock/gasScheduleNotifierMock.go
+++ b/integrationTests/mock/gasScheduleNotifierMock.go
@@ -28,6 +28,11 @@ func (g *GasScheduleNotifierMock) LatestGasSchedule() map[string]map[string]uint
 	return g.GasSchedule
 }
 
+// GasScheduleForEpoch -
+func (g *GasScheduleNotifierMock) GasScheduleForEpoch(_ uint32) (map[string]map[string]uint64, error) {
+	return g.GasSchedule, nil
+}
+
 // UnRegisterAll -
 func (g *GasScheduleNotifierMock) UnRegisterAll() {
 }

--- a/integrationTests/testProcessorNodeWithTestWebServer.go
+++ b/integrationTests/testProcessorNodeWithTestWebServer.go
@@ -236,6 +236,7 @@ func createFacadeComponents(tpn *TestProcessorNode) nodeFacade.ApiResolver {
 		TxTypeHandler:            txTypeHandler,
 		LogsFacade:               logsFacade,
 		DataFieldParser:          dataFieldParser,
+		GasScheduleNotifier:      gasScheduleNotifier,
 	}
 	apiTransactionHandler, err := transactionAPI.NewAPITransactionProcessor(argsApiTransactionProc)
 	log.LogIfError(err)

--- a/node/external/timemachine/fee/feeComputer.go
+++ b/node/external/timemachine/fee/feeComputer.go
@@ -42,12 +42,18 @@ func (computer *feeComputer) ComputeTxFeeBasedOnGasUsed(tx *transaction.ApiTrans
 
 // ComputeGasLimit computes a transaction gas limit, at a given epoch
 func (computer *feeComputer) ComputeGasLimit(tx *transaction.ApiTransactionResult) uint64 {
+	computer.economicsInstance.MaxGasPriceSetGuardian()
 	return computer.economicsInstance.ComputeGasLimitInEpoch(tx.Tx, tx.Epoch)
 }
 
 // ComputeTransactionFee computes a transaction fee, at a given epoch
 func (computer *feeComputer) ComputeTransactionFee(tx *transaction.ApiTransactionResult) *big.Int {
 	return computer.economicsInstance.ComputeTxFeeInEpoch(tx.Tx, tx.Epoch)
+}
+
+// ComputeMoveBalanceFee computes a transaction's move balance fee, at a given epoch
+func (computer *feeComputer) ComputeMoveBalanceFee(tx *transaction.ApiTransactionResult) *big.Int {
+	return computer.economicsInstance.ComputeMoveBalanceFeeInEpoch(tx.Tx, tx.Epoch)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/node/external/transactionAPI/apiTransactionArgs.go
+++ b/node/external/transactionAPI/apiTransactionArgs.go
@@ -27,4 +27,5 @@ type ArgAPITransactionProcessor struct {
 	TxTypeHandler            process.TxTypeHandler
 	LogsFacade               LogsFacade
 	DataFieldParser          DataFieldParser
+	GasScheduleNotifier      core.GasScheduleNotifier
 }

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -65,7 +65,7 @@ func NewAPITransactionProcessor(args *ArgAPITransactionProcessor) (*apiTransacti
 	)
 
 	refundDetectorInstance := NewRefundDetector()
-	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(args.FeeComputer, args.AddressPubKeyConverter)
+	gasUsedAndFeeProc := newGasUsedAndFeeProcessor(args.FeeComputer, args.GasScheduleNotifier, args.AddressPubKeyConverter)
 
 	return &apiTransactionProcessor{
 		roundDuration:               args.RoundDuration,

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -59,6 +59,7 @@ func createMockArgAPITransactionProcessor() *ArgAPITransactionProcessor {
 				return &datafield.ResponseParseData{}
 			},
 		},
+		GasScheduleNotifier: &testscommon.GasScheduleNotifierMock{},
 	}
 }
 
@@ -459,6 +460,7 @@ func TestNode_GetTransactionWithResultsFromStorage(t *testing.T) {
 				return &datafield.ResponseParseData{}
 			},
 		},
+		GasScheduleNotifier: &testscommon.GasScheduleNotifierMock{},
 	}
 	apiTransactionProc, _ := NewAPITransactionProcessor(args)
 
@@ -1027,6 +1029,7 @@ func createAPITransactionProc(t *testing.T, epoch uint32, withDbLookupExt bool) 
 		TxTypeHandler:            &testscommon.TxTypeHandlerMock{},
 		LogsFacade:               &testscommon.LogsFacadeStub{},
 		DataFieldParser:          dataFieldParser,
+		GasScheduleNotifier:      &testscommon.GasScheduleNotifierMock{},
 	}
 	apiTransactionProc, err := NewAPITransactionProcessor(args)
 	require.Nil(t, err)

--- a/node/external/transactionAPI/check.go
+++ b/node/external/transactionAPI/check.go
@@ -42,6 +42,9 @@ func checkNilArgs(arg *ArgAPITransactionProcessor) error {
 	if check.IfNilReflect(arg.DataFieldParser) {
 		return ErrNilDataFieldParser
 	}
+	if check.IfNilReflect(arg.GasScheduleNotifier) {
+		return process.ErrNilGasSchedule
+	}
 
 	return nil
 }

--- a/node/external/transactionAPI/interface.go
+++ b/node/external/transactionAPI/interface.go
@@ -12,6 +12,7 @@ type feeComputer interface {
 	ComputeTxFeeBasedOnGasUsed(tx *transaction.ApiTransactionResult, gasUsed uint64) *big.Int
 	ComputeGasLimit(tx *transaction.ApiTransactionResult) uint64
 	ComputeTransactionFee(tx *transaction.ApiTransactionResult) *big.Int
+	ComputeMoveBalanceFee(tx *transaction.ApiTransactionResult) *big.Int
 	IsInterfaceNil() bool
 }
 

--- a/process/interface.go
+++ b/process/interface.go
@@ -680,6 +680,7 @@ type feeHandler interface {
 	MaxGasLimitPerTx() uint64
 	ComputeGasLimit(tx data.TransactionWithFeeHandler) uint64
 	ComputeMoveBalanceFee(tx data.TransactionWithFeeHandler) *big.Int
+	ComputeMoveBalanceFeeInEpoch(tx data.TransactionWithFeeHandler, epoch uint32) *big.Int
 	ComputeTxFee(tx data.TransactionWithFeeHandler) *big.Int
 	CheckValidityTxValues(tx data.TransactionWithFeeHandler) error
 	ComputeFeeForProcessing(tx data.TransactionWithFeeHandler, gasToUse uint64) *big.Int

--- a/testscommon/economicsmocks/economicsDataHandlerStub.go
+++ b/testscommon/economicsmocks/economicsDataHandlerStub.go
@@ -49,6 +49,7 @@ type EconomicsHandlerStub struct {
 	ComputeTxFeeBasedOnGasUsedInEpochCalled             func(tx data.TransactionWithFeeHandler, gasUsed uint64, epoch uint32) *big.Int
 	ComputeRelayedTxFeesCalled                          func(tx data.TransactionWithFeeHandler) (*big.Int, *big.Int, error)
 	SetTxTypeHandlerCalled                              func(txTypeHandler process.TxTypeHandler) error
+	ComputeMoveBalanceFeeInEpochCalled                  func(tx data.TransactionWithFeeHandler, epoch uint32) *big.Int
 }
 
 // ComputeFeeForProcessing -
@@ -224,6 +225,14 @@ func (e *EconomicsHandlerStub) ComputeGasLimit(tx data.TransactionWithFeeHandler
 func (e *EconomicsHandlerStub) ComputeMoveBalanceFee(tx data.TransactionWithFeeHandler) *big.Int {
 	if e.ComputeMoveBalanceFeeCalled != nil {
 		return e.ComputeMoveBalanceFeeCalled(tx)
+	}
+	return big.NewInt(0)
+}
+
+// ComputeMoveBalanceFeeInEpoch -
+func (e *EconomicsHandlerStub) ComputeMoveBalanceFeeInEpoch(tx data.TransactionWithFeeHandler, epoch uint32) *big.Int {
+	if e.ComputeMoveBalanceFeeInEpochCalled != nil {
+		return e.ComputeMoveBalanceFeeInEpochCalled(tx, epoch)
 	}
 	return big.NewInt(0)
 }

--- a/testscommon/economicsmocks/economicsHandlerMock.go
+++ b/testscommon/economicsmocks/economicsHandlerMock.go
@@ -27,6 +27,7 @@ type EconomicsHandlerMock struct {
 	ComputeFeeCalled                                    func(tx data.TransactionWithFeeHandler) *big.Int
 	CheckValidityTxValuesCalled                         func(tx data.TransactionWithFeeHandler) error
 	ComputeMoveBalanceFeeCalled                         func(tx data.TransactionWithFeeHandler) *big.Int
+	ComputeMoveBalanceFeeInEpochCalled                  func(tx data.TransactionWithFeeHandler, epoch uint32) *big.Int
 	ComputeTxFeeCalled                                  func(tx data.TransactionWithFeeHandler) *big.Int
 	DeveloperPercentageCalled                           func() float64
 	MinGasPriceCalled                                   func() uint64
@@ -199,7 +200,14 @@ func (ehm *EconomicsHandlerMock) ComputeMoveBalanceFee(tx data.TransactionWithFe
 		return ehm.ComputeMoveBalanceFeeCalled(tx)
 	}
 	return big.NewInt(0)
+}
 
+// ComputeMoveBalanceFeeInEpoch -
+func (ehm *EconomicsHandlerMock) ComputeMoveBalanceFeeInEpoch(tx data.TransactionWithFeeHandler, epoch uint32) *big.Int {
+	if ehm.ComputeMoveBalanceFeeInEpochCalled != nil {
+		return ehm.ComputeMoveBalanceFeeInEpochCalled(tx, epoch)
+	}
+	return big.NewInt(0)
 }
 
 // ComputeGasLimitBasedOnBalance -

--- a/testscommon/feeComputerStub.go
+++ b/testscommon/feeComputerStub.go
@@ -12,6 +12,7 @@ type FeeComputerStub struct {
 	ComputeGasUsedAndFeeBasedOnRefundValueCalled func(tx *transaction.ApiTransactionResult, refundValue *big.Int) (uint64, *big.Int)
 	ComputeTxFeeBasedOnGasUsedCalled             func(tx *transaction.ApiTransactionResult, gasUsed uint64) *big.Int
 	ComputeGasLimitCalled                        func(tx *transaction.ApiTransactionResult) uint64
+	ComputeMoveBalanceFeeCalled                  func(tx *transaction.ApiTransactionResult) *big.Int
 }
 
 // ComputeTransactionFee -
@@ -47,6 +48,15 @@ func (stub *FeeComputerStub) ComputeGasLimit(tx *transaction.ApiTransactionResul
 	}
 
 	return 0
+}
+
+// ComputeMoveBalanceFee -
+func (stub *FeeComputerStub) ComputeMoveBalanceFee(tx *transaction.ApiTransactionResult) *big.Int {
+	if stub.ComputeMoveBalanceFeeCalled != nil {
+		return stub.ComputeMoveBalanceFeeCalled(tx)
+	}
+
+	return big.NewInt(0)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/testscommon/gasScheduleNotifierMock.go
+++ b/testscommon/gasScheduleNotifierMock.go
@@ -8,6 +8,7 @@ type GasScheduleNotifierMock struct {
 	RegisterNotifyHandlerCalled func(handler core.GasScheduleSubscribeHandler)
 	LatestGasScheduleCalled     func() map[string]map[string]uint64
 	LatestGasScheduleCopyCalled func() map[string]map[string]uint64
+	GasScheduleForEpochCalled   func(epoch uint32) (map[string]map[string]uint64, error)
 }
 
 // NewGasScheduleNotifierMock -
@@ -48,6 +49,15 @@ func (g *GasScheduleNotifierMock) LatestGasScheduleCopy() map[string]map[string]
 
 // UnRegisterAll -
 func (g *GasScheduleNotifierMock) UnRegisterAll() {
+}
+
+// GasScheduleForEpoch -
+func (g *GasScheduleNotifierMock) GasScheduleForEpoch(epoch uint32) (map[string]map[string]uint64, error) {
+	if g.GasScheduleForEpochCalled != nil {
+		return g.GasScheduleForEpochCalled(epoch)
+	}
+
+	return g.GasSchedule, nil
 }
 
 // IsInterfaceNil -


### PR DESCRIPTION
## Reasoning behind the pull request
- fee field does not keep track of the builtin cost of guardian operations
  
## Proposed changes
- fix displayed fee for guardian operations

## Testing procedure
- check fee, gasUsed, initiallyPaidFee on transaction withResults=true for any guardian operation(SetGuardian, GuardAccount, UnGuardAccount)

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
