### PR TITLE
New p2p network messenger for the light clients and suppliers.

### DIFF
--- a/cmd/node/CLI.md
+++ b/cmd/node/CLI.md
@@ -15,7 +15,7 @@ AUTHOR:
    The MultiversX Team <contact@multiversx.com>
    
 GLOBAL OPTIONS:
-    --genesis-file [path]                     The [path] for the genesis file. This JSON file contains initial data to bootstrap from, such as initial balances for accounts. (default: "./config/genesis.json")
+   --genesis-file [path]                     The [path] for the genesis file. This JSON file contains initial data to bootstrap from, such as initial balances for accounts. (default: "./config/genesis.json")
    --smart-contracts-file [path]             The [path] for the initial smart contracts file. This JSON file contains data used to deploy initial smart contracts such as delegation smart contracts (default: "./config/genesisSmartContracts.json")
    --nodes-setup-file [path]                 The [path] for the nodes setup. This JSON file contains initial nodes info, such as consensus group size, round duration, validators public keys and so on. (default: "./config/nodesSetup.json")
    --config [path]                           The [path] for the main configuration file. This TOML file contain the main configurations such as storage setups, epoch duration and so on. (default: "./config/config.toml")

--- a/cmd/node/CLI.md
+++ b/cmd/node/CLI.md
@@ -15,7 +15,7 @@ AUTHOR:
    The MultiversX Team <contact@multiversx.com>
    
 GLOBAL OPTIONS:
-   --genesis-file [path]                     The [path] for the genesis file. This JSON file contains initial data to bootstrap from, such as initial balances for accounts. (default: "./config/genesis.json")
+    --genesis-file [path]                     The [path] for the genesis file. This JSON file contains initial data to bootstrap from, such as initial balances for accounts. (default: "./config/genesis.json")
    --smart-contracts-file [path]             The [path] for the initial smart contracts file. This JSON file contains data used to deploy initial smart contracts such as delegation smart contracts (default: "./config/genesisSmartContracts.json")
    --nodes-setup-file [path]                 The [path] for the nodes setup. This JSON file contains initial nodes info, such as consensus group size, round duration, validators public keys and so on. (default: "./config/nodesSetup.json")
    --config [path]                           The [path] for the main configuration file. This TOML file contain the main configurations such as storage setups, epoch duration and so on. (default: "./config/config.toml")
@@ -27,6 +27,7 @@ GLOBAL OPTIONS:
    --config-external [path]                  The [path] for the external configuration file. This TOML file contains external configurations such as ElasticSearch's URL and login information (default: "./config/external.toml")
    --p2p-config [path]                       The [path] for the p2p configuration file. This TOML file contains peer-to-peer configurations such as port, target peer count or KadDHT settings (default: "./config/p2p.toml")
    --full-archive-p2p-config [path]          The [path] for the p2p configuration file for the full archive network. This TOML file contains peer-to-peer configurations such as port, target peer count or KadDHT settings (default: "./config/fullArchiveP2P.toml")
+   --light-client-p2p-config [path]          The [path] for the p2p configuration file for the light client network. This TOML file contains peer-to-peer configurations such as port, target peer count or KadDHT settings (default: "./config/lightClientP2P.toml")
    --epoch-config [path]                     The [path] for the epoch configuration file. This TOML file contains activation epochs configurations (default: "./config/enableEpochs.toml")
    --round-config [path]                     The [path] for the round configuration file. This TOML file contains activation round configurations (default: "./config/enableRounds.toml")
    --gas-costs-config [path]                 The [path] for the gas costs configuration directory. (default: "./config/gasSchedules")
@@ -60,6 +61,7 @@ GLOBAL OPTIONS:
    --import-db-save-epoch-root-hash          This flag, if set, will export the trie snapshots at every new epoch
    --redundancy-level value                  This flag specifies the level of redundancy used by the current instance for the node (-1 = disabled, 0 = main instance (default), 1 = first backup, 2 = second backup, etc.) (default: 0)
    --full-archive                            Boolean option for settings an observer as full archive, which will sync the entire database of its shard
+   --light-client-supplier                   Boolean option for setting an observer as light client
    --mem-ballast value                       Flag that specifies the number of MegaBytes to be used as a memory ballast for Garbage Collector optimization. If set to 0 (or not set at all), the feature will be disabled. This flag should be used only for well-monitored nodes and by advanced users, as a too high memory ballast could lead to Out Of Memory panics. The memory ballast should not be higher than 20-25% of the machine's available RAM (default: 0)
    --memory-usage-to-create-profiles value   Integer value to be used to set the memory usage thresholds (in bytes) (default: 2415919104)
    --force-start-from-network                Flag that will force the start from network bootstrap process

--- a/cmd/node/CLI.md
+++ b/cmd/node/CLI.md
@@ -61,7 +61,8 @@ GLOBAL OPTIONS:
    --import-db-save-epoch-root-hash          This flag, if set, will export the trie snapshots at every new epoch
    --redundancy-level value                  This flag specifies the level of redundancy used by the current instance for the node (-1 = disabled, 0 = main instance (default), 1 = first backup, 2 = second backup, etc.) (default: 0)
    --full-archive                            Boolean option for settings an observer as full archive, which will sync the entire database of its shard
-   --light-client-supplier                   Boolean option for setting an observer as light client
+   --light-client                            Boolean option for setting an observer as light client
+   --light-client-supplier                   Boolean option for setting an observer as light client supplier
    --mem-ballast value                       Flag that specifies the number of MegaBytes to be used as a memory ballast for Garbage Collector optimization. If set to 0 (or not set at all), the feature will be disabled. This flag should be used only for well-monitored nodes and by advanced users, as a too high memory ballast could lead to Out Of Memory panics. The memory ballast should not be higher than 20-25% of the machine's available RAM (default: 0)
    --memory-usage-to-create-profiles value   Integer value to be used to set the memory usage thresholds (in bytes) (default: 2415919104)
    --force-start-from-network                Flag that will force the start from network bootstrap process

--- a/cmd/node/config/lightClientP2P.toml
+++ b/cmd/node/config/lightClientP2P.toml
@@ -1,0 +1,90 @@
+# FullArchiveP2P config file
+
+# NodeConfig holds the P2P settings
+[Node]
+    # Port is the port that will be opened by the node on all interfaces so other peers can connect to it
+    # If the port = 0, the node will search for a free port on the machine and use it
+    Port = "37373-38383"
+
+    # ThresholdMinConnectedPeers represents the minimum number of connections a node should have before it can start
+    # the sync and consensus mechanisms
+    ThresholdMinConnectedPeers = 3
+
+    # MinNumPeersToWaitForOnBootstrap is the minimum number of peers to wait on bootstrap or the node will wait the default
+    # time which is now set to ~20 seconds (the const defined in the common package named TimeToWaitForP2PBootstrap)
+    MinNumPeersToWaitForOnBootstrap = 10
+
+    # available transports. All defined addresses contains a single '%d' markup that is mandatory and will
+    # be replaced at runtime with the actual port value
+    [Node.Transports]
+        QUICAddress = "" # optional QUIC address. If this transport should be activated, should be in this format: /ip4/0.0.0.0/udp/%d/quic-v1
+        WebSocketAddress = "" # optional WebSocket address. If this transport should be activated, should be in this format: /ip4/0.0.0.0/tcp/%d/ws
+        WebTransportAddress = "" # optional WebTransport address. If this transport should be activated, should be in this format: /ip4/0.0.0.0/udp/%d/quic-v1/webtransport
+        [Node.Transports.TCP]
+            ListenAddress = "/ip4/0.0.0.0/tcp/%d" # TCP listen address
+            PreventPortReuse = false
+
+    [Node.ResourceLimiter]
+        Type = "default autoscale" #available options "default autoscale", "infinite", "default with manual scale".
+        ManualSystemMemoryInMB = 0 # not taken into account if the type is not "default with manual scale"
+        ManualMaximumFD = 0 # not taken into account if the type is not "default with manual scale"
+
+# P2P peer discovery section
+
+# The following sections correspond to the way new peers will be discovered
+# If all config types are disabled then the peer will run in single mode (will not try to find other peers)
+# If more than one peer discovery mechanism is enabled, the application will output an error and will not start
+
+[KadDhtPeerDiscovery]
+    # Enabled: true/false to enable/disable this discovery mechanism
+    Enabled = true
+
+    # Type represents the kad-dht glue code implementation.
+    # "legacy" will define the first implementation.
+    # "optimized" represents the new variant able to connect to multiple seeders at once. This implementation also has
+    # a built-in timer that will try to automatically reconnect to the seeders (in case the seeders recover after a
+    # premature shutdown)
+    Type = "optimized"
+
+    # RefreshIntervalInSec represents the time in seconds between querying for new peers
+    RefreshIntervalInSec = 10
+
+    # ProtocolIDs represents the protocols that this node will advertise to other peers
+    # To connect to other nodes, those nodes should have at least one common protocol string
+    ProtocolIDs = [
+        "/erd/kad/1.0.0",
+        "mvx-full-archive",
+    ]
+
+    # InitialPeerList represents the list of strings of some known nodes that will bootstrap this node
+    # The address will be in a self-describing addressing format.
+    # More can be found here: https://github.com/libp2p/specs/blob/master/3-requirements.md#34-transport-agnostic
+    # Example:
+    #    /ip6/fe80::8823:6dff:fee7:f172/tcp/4001/p2p/QmYJyUMAcXEw1b5bFfbBbzYu5wyyjLMRHXGUkCXpag74Fu
+    #    /ip4/162.246.145.218/udp/4001/utp/ipfs/QmYJyUMAcXEw1b5bFfbBbzYu5wyyjLMRHXGUkCXpag74Fu
+    #
+    # If the initial peers list is left empty, the node will not try to connect to other peers during initial bootstrap
+    # phase but will accept connections and will do the network discovery if another peer connects to it
+    InitialPeerList = ["/ip4/127.0.0.1/tcp/9999/p2p/16Uiu2HAkw5SNNtSvH1zJiQ6Gc3WoGNSxiyNueRKe6fuAuh57G3Bk"]
+
+    # kademlia's routing table bucket size
+    BucketSize = 100
+
+    # RoutingTableRefreshIntervalInSec defines how many seconds should pass between 2 kad routing table auto refresh calls
+    RoutingTableRefreshIntervalInSec = 300
+
+[Sharding]
+    # The targeted number of peer connections
+    TargetPeerCount = 41
+    MaxIntraShardValidators = 7
+    MaxCrossShardValidators = 15
+    MaxIntraShardObservers = 7
+    MaxCrossShardObservers = 3
+    MaxSeeders = 2
+
+    # available options:
+    #   `ListsSharder` will split the peers based on the shard membership (intra, cross or unknown)
+    #   `OneListSharder` will do just the connection triming (upto TargetPeerCount value) not taking into account
+    #               the shard membership of the connected peers
+    #   `NilListSharder` will disable conection trimming (sharder is off)
+    Type = "ListsSharder"

--- a/cmd/node/config/lightClientP2P.toml
+++ b/cmd/node/config/lightClientP2P.toml
@@ -52,8 +52,7 @@
     # ProtocolIDs represents the protocols that this node will advertise to other peers
     # To connect to other nodes, those nodes should have at least one common protocol string
     ProtocolIDs = [
-        "/erd/kad/1.0.0",
-        "mvx-full-archive",
+        "mvx-light-client",
     ]
 
     # InitialPeerList represents the list of strings of some known nodes that will bootstrap this node

--- a/cmd/node/config/lightClientP2P.toml
+++ b/cmd/node/config/lightClientP2P.toml
@@ -52,7 +52,7 @@
     # ProtocolIDs represents the protocols that this node will advertise to other peers
     # To connect to other nodes, those nodes should have at least one common protocol string
     ProtocolIDs = [
-        "mvx-light-client",
+        "/mvx/mainnet-light/v1.0.0",
     ]
 
     # InitialPeerList represents the list of strings of some known nodes that will bootstrap this node

--- a/cmd/node/config/lightClientP2P.toml
+++ b/cmd/node/config/lightClientP2P.toml
@@ -1,4 +1,4 @@
-# FullArchiveP2P config file
+# LightClientP2P config file
 
 # NodeConfig holds the P2P settings
 [Node]

--- a/cmd/node/config/lightClientP2P.toml
+++ b/cmd/node/config/lightClientP2P.toml
@@ -52,7 +52,7 @@
     # ProtocolIDs represents the protocols that this node will advertise to other peers
     # To connect to other nodes, those nodes should have at least one common protocol string
     ProtocolIDs = [
-        "/mvx/mainnet-light/v1.0.0",
+        "/mvx/light/1.0.0",
     ]
 
     # InitialPeerList represents the list of strings of some known nodes that will bootstrap this node

--- a/cmd/node/config/prefs.toml
+++ b/cmd/node/config/prefs.toml
@@ -20,7 +20,8 @@
    # It is highly recommended to enable this flag on an observer (not on a validator node)
    FullArchive = false
 
-   # TODO: add comment
+   # LightClient, if enabled, will make the node able to connect on the light client supplier network.
+   # It is highly recommended to enable this flag on an observer (not on a validator node)
    LightClient = false
 
    # PreferredConnections holds an array containing valid ips or peer ids from nodes to connect with (in top of other connections)

--- a/cmd/node/config/prefs.toml
+++ b/cmd/node/config/prefs.toml
@@ -20,6 +20,9 @@
    # It is highly recommended to enable this flag on an observer (not on a validator node)
    FullArchive = false
 
+   # TODO: add comment
+   LightClient = false
+
    # PreferredConnections holds an array containing valid ips or peer ids from nodes to connect with (in top of other connections)
    # Example:
    # PreferredConnections = [

--- a/cmd/node/config/prefs.toml
+++ b/cmd/node/config/prefs.toml
@@ -20,9 +20,13 @@
    # It is highly recommended to enable this flag on an observer (not on a validator node)
    FullArchive = false
 
-   # LightClient, if enabled, will make the node able to connect on the light client supplier network.
+   # LightClient, if enabled, will make the node able to connect on the light client network.
    # It is highly recommended to enable this flag on an observer (not on a validator node)
    LightClient = false
+
+   # LightClientSupplier, if enabled, will make the node able to connect on the light client network as a supplier.
+   # It is highly recommended to enable this flag on an observer (not on a validator node)
+   LightClientSupplier = false
 
    # PreferredConnections holds an array containing valid ips or peer ids from nodes to connect with (in top of other connections)
    # Example:

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -355,7 +355,7 @@ var (
 		Name:  "light-client",
 		Usage: "Boolean option for setting an observer as light client",
 	}
-	// lightClientSupplier defines a flag that, if set, will make the node act like a light client
+	// lightClientSupplier defines a flag that, if set, will make the node act like a light client supplier
 	lightClientSupplier = cli.BoolFlag{
 		Name:  "light-client-supplier",
 		Usage: "Boolean option for setting an observer as light client supplier",

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -470,6 +470,7 @@ func getFlags() []cli.Flag {
 		importDbSaveEpochRootHash,
 		redundancyLevel,
 		fullArchive,
+		lightClient,
 		memBallast,
 		memoryUsageToCreateProfiles,
 		forceStartFromNetwork,

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -477,6 +477,7 @@ func getFlags() []cli.Flag {
 		redundancyLevel,
 		fullArchive,
 		lightClient,
+		lightClientSupplier,
 		memBallast,
 		memoryUsageToCreateProfiles,
 		forceStartFromNetwork,

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -6,12 +6,13 @@ import (
 	"os"
 	"runtime"
 
+	logger "github.com/multiversx/mx-chain-logger-go"
+	"github.com/urfave/cli"
+
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/operationmodes"
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/facade"
-	logger "github.com/multiversx/mx-chain-logger-go"
-	"github.com/urfave/cli"
 )
 
 var (
@@ -97,6 +98,12 @@ var (
 		Usage: "The `" + filePathPlaceholder + "` for the p2p configuration file for the full archive network. This TOML file contains peer-to-peer " +
 			"configurations such as port, target peer count or KadDHT settings",
 		Value: "./config/fullArchiveP2P.toml",
+	}
+	lightClientP2PConfigurationFile = cli.StringFlag{
+		Name: "light-client-p2p-config",
+		Usage: "The `" + filePathPlaceholder + "` for the p2p configuration file for the light client network. This TOML file contains peer-to-peer " +
+			"configurations such as port, target peer count or KadDHT settings",
+		Value: "./config/lightClientP2P.toml",
 	}
 	// epochConfigurationFile defines a flag for the path to the toml file containing the epoch configuration
 	epochConfigurationFile = cli.StringFlag{
@@ -342,6 +349,11 @@ var (
 		Name:  "full-archive",
 		Usage: "Boolean option for settings an observer as full archive, which will sync the entire database of its shard",
 	}
+	// lightClient defines a flag that, if set, will make the node act like a light client
+	lightClient = cli.BoolFlag{
+		Name:  "light-client-supplier",
+		Usage: "Boolean option for setting an observer as light client",
+	}
 	// memBallast defines a flag that specifies the number of MegaBytes to be used as a memory ballast for Garbage Collector optimization
 	// if set to 0, the memory ballast won't be used
 	memBallast = cli.Uint64Flag{
@@ -424,6 +436,7 @@ func getFlags() []cli.Flag {
 		externalConfigFile,
 		p2pConfigurationFile,
 		fullArchiveP2PConfigurationFile,
+		lightClientP2PConfigurationFile,
 		epochConfigurationFile,
 		roundConfigurationFile,
 		gasScheduleConfigurationDirectory,
@@ -534,6 +547,9 @@ func applyFlags(ctx *cli.Context, cfgs *config.Configs, flagsConfig *config.Cont
 	}
 	if ctx.IsSet(fullArchive.Name) {
 		cfgs.PreferencesConfig.Preferences.FullArchive = ctx.GlobalBool(fullArchive.Name)
+	}
+	if ctx.IsSet(lightClient.Name) {
+		cfgs.PreferencesConfig.Preferences.LightClient = ctx.GlobalBool(lightClient.Name)
 	}
 	if ctx.IsSet(memoryUsageToCreateProfiles.Name) {
 		cfgs.GeneralConfig.Health.MemoryUsageToCreateProfiles = int(ctx.GlobalUint64(memoryUsageToCreateProfiles.Name))

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -9,14 +9,15 @@ import (
 	"github.com/klauspost/cpuid/v2"
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
+	logger "github.com/multiversx/mx-chain-logger-go"
+	"github.com/multiversx/mx-chain-logger-go/file"
+	"github.com/urfave/cli"
+
 	"github.com/multiversx/mx-chain-go/cmd/node/factory"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/config/overridableConfig"
 	"github.com/multiversx/mx-chain-go/node"
-	logger "github.com/multiversx/mx-chain-logger-go"
-	"github.com/multiversx/mx-chain-logger-go/file"
-	"github.com/urfave/cli"
 	// test point 1 for custom profiler
 )
 
@@ -224,6 +225,13 @@ func readConfigs(ctx *cli.Context, log logger.Logger) (*config.Configs, error) {
 	}
 	log.Debug("config", "file", configurationPaths.FullArchiveP2p)
 
+	configurationPaths.LightClientP2p = ctx.GlobalString(lightClientP2PConfigurationFile.Name)
+	lightClientP2PConfig, err := common.LoadP2PConfig(configurationPaths.LightClientP2p)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug("config", "file", configurationPaths.LightClientP2p)
+
 	configurationPaths.Epoch = ctx.GlobalString(epochConfigurationFile.Name)
 	epochConfig, err := common.LoadEpochConfig(configurationPaths.Epoch)
 	if err != nil {
@@ -264,6 +272,7 @@ func readConfigs(ctx *cli.Context, log logger.Logger) (*config.Configs, error) {
 		ExternalConfig:           externalConfig,
 		MainP2pConfig:            mainP2PConfig,
 		FullArchiveP2pConfig:     fullArchiveP2PConfig,
+		LightClientP2pConfig:     lightClientP2PConfig,
 		ConfigurationPathsHolder: configurationPaths,
 		EpochConfig:              epochConfig,
 		RoundConfig:              roundConfig,

--- a/common/constants.go
+++ b/common/constants.go
@@ -16,14 +16,11 @@ const NormalOperation NodeOperation = "normal operation"
 // FullArchiveMode defines the node operation as a full archive mode
 const FullArchiveMode NodeOperation = "full archive mode"
 
-// LightClient defines the p2p light client interaction.
-type LightClient string
-
 // LightClientMode defines the node operation as a light client
-const LightClientMode LightClient = "light client mode"
+const LightClientMode NodeOperation = "light client mode"
 
-// LightClientSupplierMode defines the light client
-const LightClientSupplierMode LightClient = "light client supplier mode"
+// LightClientSupplierMode defines the node operation light client supplier
+const LightClientSupplierMode NodeOperation = "light client supplier mode"
 
 // PeerType represents the type of peer
 type PeerType string

--- a/common/constants.go
+++ b/common/constants.go
@@ -16,8 +16,14 @@ const NormalOperation NodeOperation = "normal operation"
 // FullArchiveMode defines the node operation as a full archive mode
 const FullArchiveMode NodeOperation = "full archive mode"
 
+// LightClient defines the p2p light client interaction.
+type LightClient string
+
 // LightClientMode defines the node operation as a light client
-const LightClientMode NodeOperation = "light client mode"
+const LightClientMode LightClient = "light client mode"
+
+// LightClientSupplierMode defines the light client
+const LightClientSupplierMode LightClient = "light client supplier mode"
 
 // PeerType represents the type of peer
 type PeerType string

--- a/common/constants.go
+++ b/common/constants.go
@@ -16,6 +16,9 @@ const NormalOperation NodeOperation = "normal operation"
 // FullArchiveMode defines the node operation as a full archive mode
 const FullArchiveMode NodeOperation = "full archive mode"
 
+// LightClientMode defines the node operation as a light client
+const LightClientMode NodeOperation = "light client mode"
+
 // PeerType represents the type of peer
 type PeerType string
 

--- a/common/generics.go
+++ b/common/generics.go
@@ -1,10 +1,12 @@
 package common
 
 // Contains returns true if the specified value is contained in a slice.
-func Contains[T comparable](s []T, e T) bool {
+func Contains[T comparable](s []T, e ...T) bool {
 	for _, v := range s {
-		if v == e {
-			return true
+		for _, v2 := range e {
+			if v == v2 {
+				return true
+			}
 		}
 	}
 	return false

--- a/common/generics.go
+++ b/common/generics.go
@@ -1,0 +1,11 @@
+package common
+
+// Contains returns true if the specified value is contained in a slice.
+func Contains[T comparable](s []T, e T) bool {
+	for _, v := range s {
+		if v == e {
+			return true
+		}
+	}
+	return false
+}

--- a/config/config.go
+++ b/config/config.go
@@ -588,6 +588,7 @@ type Configs struct {
 	ExternalConfig           *ExternalConfig
 	MainP2pConfig            *p2pConfig.P2PConfig
 	FullArchiveP2pConfig     *p2pConfig.P2PConfig
+	LightClientP2pConfig     *p2pConfig.P2PConfig
 	FlagsConfig              *ContextFlagsConfig
 	ImportDbConfig           *ImportDbConfig
 	ConfigurationPathsHolder *ConfigurationPathsHolder
@@ -606,6 +607,7 @@ type ConfigurationPathsHolder struct {
 	External                 string
 	MainP2p                  string
 	FullArchiveP2p           string
+	LightClientP2p           string
 	GasScheduleDirectoryName string
 	Nodes                    string
 	Genesis                  string

--- a/config/prefsConfig.go
+++ b/config/prefsConfig.go
@@ -18,6 +18,7 @@ type PreferencesConfig struct {
 	OverridableConfigTomlValues []OverridableConfig
 	FullArchive                 bool
 	LightClient                 bool
+	LightClientSupplier         bool
 }
 
 // OverridableConfig holds the path and the new value to be updated in the configuration

--- a/config/prefsConfig.go
+++ b/config/prefsConfig.go
@@ -17,6 +17,7 @@ type PreferencesConfig struct {
 	ConnectionWatcherType       string
 	OverridableConfigTomlValues []OverridableConfig
 	FullArchive                 bool
+	LightClient                 bool
 }
 
 // OverridableConfig holds the path and the new value to be updated in the configuration

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -590,8 +590,14 @@ var ErrNilBLSPublicKey = errors.New("bls public key is nil")
 // ErrEmptyAddress defines the error when trying to work with an empty address
 var ErrEmptyAddress = errors.New("empty Address")
 
-// ErrInvalidNodeOperationMode signals that an invalid node operation mode has been provided
-var ErrInvalidNodeOperationMode = errors.New("invalid node operation mode")
+// ErrInvalidOperationMode signals that the operation mode is invalid
+var ErrInvalidOperationMode = errors.New("invalid operation mode")
+
+// ErrInvalidMainNodeOperationMode signals that an invalid node operation mode has been provided
+var ErrInvalidMainNodeOperationMode = errors.New("node operation modes does not contain Normal or FullArchive")
+
+// ErrInvalidNodeOperationModeCombo signals that an invalid node operation mode combination has been provided
+var ErrInvalidNodeOperationModeCombo = errors.New("invalid node operation mode combo")
 
 // ErrNilSentSignatureTracker defines the error for setting a nil SentSignatureTracker
 var ErrNilSentSignatureTracker = errors.New("nil sent signature tracker")

--- a/factory/network/networkComponents.go
+++ b/factory/network/networkComponents.go
@@ -33,6 +33,7 @@ import (
 type NetworkComponentsFactoryArgs struct {
 	MainP2pConfig         p2pConfig.P2PConfig
 	FullArchiveP2pConfig  p2pConfig.P2PConfig
+	LightClientP2pConfig  p2pConfig.P2PConfig
 	MainConfig            config.Config
 	RatingsConfig         config.RatingsConfig
 	StatusHandler         core.AppStatusHandler
@@ -102,13 +103,16 @@ func NewNetworkComponentsFactory(
 	if check.IfNil(args.CryptoComponents) {
 		return nil, errors.ErrNilCryptoComponentsHolder
 	}
-	if args.NodeOperationMode != common.NormalOperation && args.NodeOperationMode != common.FullArchiveMode {
+	if args.NodeOperationMode != common.NormalOperation &&
+		args.NodeOperationMode != common.FullArchiveMode &&
+		args.NodeOperationMode != common.LightClientMode {
 		return nil, errors.ErrInvalidNodeOperationMode
 	}
 
 	return &networkComponentsFactory{
 		mainP2PConfig:         args.MainP2pConfig,
 		fullArchiveP2PConfig:  args.FullArchiveP2pConfig,
+		lightClientP2PConfig:  args.LightClientP2pConfig,
 		ratingsConfig:         args.RatingsConfig,
 		marshalizer:           args.Marshalizer,
 		mainConfig:            args.MainConfig,

--- a/factory/network/networkComponents.go
+++ b/factory/network/networkComponents.go
@@ -42,6 +42,7 @@ type NetworkComponentsFactoryArgs struct {
 	PreferredPeersSlices  []string
 	BootstrapWaitTime     time.Duration
 	NodeOperationMode     common.NodeOperation
+	LightClientMode       common.LightClient
 	ConnectionWatcherType string
 	CryptoComponents      factory.CryptoComponentsHolder
 }
@@ -58,6 +59,7 @@ type networkComponentsFactory struct {
 	preferredPeersSlices  []string
 	bootstrapWaitTime     time.Duration
 	nodeOperationMode     common.NodeOperation
+	lightClientMode       common.LightClient
 	connectionWatcherType string
 	cryptoComponents      factory.CryptoComponentsHolder
 }
@@ -104,8 +106,7 @@ func NewNetworkComponentsFactory(
 		return nil, errors.ErrNilCryptoComponentsHolder
 	}
 	if args.NodeOperationMode != common.NormalOperation &&
-		args.NodeOperationMode != common.FullArchiveMode &&
-		args.NodeOperationMode != common.LightClientMode {
+		args.NodeOperationMode != common.FullArchiveMode {
 		return nil, errors.ErrInvalidNodeOperationMode
 	}
 
@@ -121,6 +122,7 @@ func NewNetworkComponentsFactory(
 		bootstrapWaitTime:     args.BootstrapWaitTime,
 		preferredPeersSlices:  args.PreferredPeersSlices,
 		nodeOperationMode:     args.NodeOperationMode,
+		lightClientMode:       args.LightClientMode,
 		connectionWatcherType: args.ConnectionWatcherType,
 		cryptoComponents:      args.CryptoComponents,
 	}, nil
@@ -310,7 +312,7 @@ func (ncf *networkComponentsFactory) createFullArchiveNetworkHolder(peersRatingH
 }
 
 func (ncf *networkComponentsFactory) createLightClientNetworkHolder(peersRatingHandler p2p.PeersRatingHandler) (networkComponentsHolder, error) {
-	if ncf.nodeOperationMode != common.LightClientMode {
+	if ncf.lightClientMode == "" {
 		return networkComponentsHolder{
 			netMessenger:         p2pDisabled.NewNetworkMessenger(),
 			preferredPeersHolder: disabled.NewPreferredPeersHolder(),

--- a/factory/network/networkComponents.go
+++ b/factory/network/networkComponents.go
@@ -382,5 +382,11 @@ func (nc *networkComponents) Close() error {
 		log.LogIfError(fullArchiveNetMessenger.Close())
 	}
 
+	lightClientMessenger := nc.lightClientNetworkHolder.netMessenger
+	if !check.IfNil(lightClientMessenger) {
+		log.Debug("calling close on the light client network messenger instance...")
+		log.LogIfError(lightClientMessenger.Close())
+	}
+
 	return nil
 }

--- a/factory/network/networkComponentsHandler.go
+++ b/factory/network/networkComponentsHandler.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
+
 	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/factory"
 	"github.com/multiversx/mx-chain-go/p2p"
@@ -18,6 +19,7 @@ var _ factory.NetworkComponentsHandler = (*managedNetworkComponents)(nil)
 const (
 	errorOnMainNetworkString        = "on main network"
 	errorOnFullArchiveNetworkString = "on full archive network"
+	errorOnLightClientNetworkString = "on light client network"
 )
 
 // managedNetworkComponents creates the data components handler that can create, close and access the data components
@@ -91,6 +93,10 @@ func (mnc *managedNetworkComponents) CheckSubcomponents() error {
 
 	if check.IfNil(mnc.fullArchiveNetworkHolder.netMessenger) {
 		return fmt.Errorf("%w %s", errors.ErrNilMessenger, errorOnFullArchiveNetworkString)
+	}
+
+	if check.IfNil(mnc.lightClientNetworkHolder.netMessenger) {
+		return fmt.Errorf("%w %s", errors.ErrNilMessenger, errorOnLightClientNetworkString)
 	}
 
 	if check.IfNil(mnc.inputAntifloodHandler) {

--- a/factory/network/networkComponents_test.go
+++ b/factory/network/networkComponents_test.go
@@ -2,12 +2,15 @@ package network_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/multiversx/mx-chain-go/common"
 	errorsMx "github.com/multiversx/mx-chain-go/errors"
 	networkComp "github.com/multiversx/mx-chain-go/factory/network"
 	componentsMock "github.com/multiversx/mx-chain-go/testscommon/components"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewNetworkComponentsFactory(t *testing.T) {
@@ -49,16 +52,32 @@ func TestNewNetworkComponentsFactory(t *testing.T) {
 		require.Nil(t, ncf)
 		require.Equal(t, errorsMx.ErrNilCryptoComponentsHolder, err)
 	})
-	t.Run("invalid node operation mode should error", func(t *testing.T) {
+	t.Run("invalid node operation modes should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := componentsMock.GetNetworkFactoryArgs()
-		args.NodeOperationMode = "invalid"
+		t.Run("invalid mode", func(t *testing.T) {
+			t.Parallel()
 
-		ncf, err := networkComp.NewNetworkComponentsFactory(args)
-		require.Equal(t, errorsMx.ErrInvalidNodeOperationMode, err)
-		require.Nil(t, ncf)
+			args := componentsMock.GetNetworkFactoryArgs()
+			args.NodeOperationModes = []common.NodeOperation{"invalid"}
+
+			ncf, err := networkComp.NewNetworkComponentsFactory(args)
+			require.Equal(t, errorsMx.ErrInvalidNodeOperationMode, err)
+			require.Nil(t, ncf)
+		})
+
+		t.Run("invalid length", func(t *testing.T) {
+			args := componentsMock.GetNetworkFactoryArgs()
+			args.NodeOperationModes = []common.NodeOperation{"full archive", "light client", "light client supplier"}
+
+			ncf, err := networkComp.NewNetworkComponentsFactory(args)
+			require.Equal(t, fmt.Errorf("cannot have more than 2 node operation modes, got %d modes instead",
+				len(args.NodeOperationModes)), err)
+			require.Nil(t, ncf)
+		})
+
 	})
+	//t.Run("invalid node operation modes should ")
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 

--- a/factory/network/networkComponents_test.go
+++ b/factory/network/networkComponents_test.go
@@ -62,13 +62,16 @@ func TestNewNetworkComponentsFactory(t *testing.T) {
 			args.NodeOperationModes = []common.NodeOperation{"invalid"}
 
 			ncf, err := networkComp.NewNetworkComponentsFactory(args)
-			require.Equal(t, errorsMx.ErrInvalidNodeOperationMode, err)
+			require.Equal(t, errorsMx.ErrInvalidOperationMode, err)
 			require.Nil(t, ncf)
 		})
 
 		t.Run("invalid length", func(t *testing.T) {
+			t.Parallel()
+
 			args := componentsMock.GetNetworkFactoryArgs()
-			args.NodeOperationModes = []common.NodeOperation{"full archive", "light client", "light client supplier"}
+			args.NodeOperationModes = []common.NodeOperation{common.FullArchiveMode, common.LightClientMode,
+				common.LightClientSupplierMode}
 
 			ncf, err := networkComp.NewNetworkComponentsFactory(args)
 			require.Equal(t, fmt.Errorf("cannot have more than 2 node operation modes, got %d modes instead",
@@ -76,15 +79,61 @@ func TestNewNetworkComponentsFactory(t *testing.T) {
 			require.Nil(t, ncf)
 		})
 
-	})
-	//t.Run("invalid node operation modes should ")
-	t.Run("should work", func(t *testing.T) {
-		t.Parallel()
+		t.Run("invalid main mode", func(t *testing.T) {
+			t.Parallel()
+			args := componentsMock.GetNetworkFactoryArgs()
+			args.NodeOperationModes = []common.NodeOperation{common.LightClientSupplierMode, common.LightClientMode}
+			ncf, err := networkComp.NewNetworkComponentsFactory(args)
+			require.Equal(t, errorsMx.ErrInvalidMainNodeOperationMode, err)
+			require.Nil(t, ncf)
+		})
 
-		args := componentsMock.GetNetworkFactoryArgs()
-		ncf, err := networkComp.NewNetworkComponentsFactory(args)
-		require.NoError(t, err)
-		require.NotNil(t, ncf)
+		t.Run("invalid combo", func(t *testing.T) {
+			t.Parallel()
+
+			args := componentsMock.GetNetworkFactoryArgs()
+			args.NodeOperationModes = []common.NodeOperation{common.NormalOperation, common.FullArchiveMode}
+
+			ncf, err := networkComp.NewNetworkComponentsFactory(args)
+			require.Equal(t, errorsMx.ErrInvalidNodeOperationModeCombo, err)
+			require.Nil(t, ncf)
+		})
+
+		t.Run("valid combo", func(t *testing.T) {
+			t.Parallel()
+
+			args := componentsMock.GetNetworkFactoryArgs()
+			args.NodeOperationModes = []common.NodeOperation{common.NormalOperation}
+			ncf, err := networkComp.NewNetworkComponentsFactory(args)
+			require.Nil(t, err)
+			require.NotNil(t, ncf)
+
+			args.NodeOperationModes = []common.NodeOperation{common.FullArchiveMode}
+			ncf, err = networkComp.NewNetworkComponentsFactory(args)
+			require.Nil(t, err)
+			require.NotNil(t, ncf)
+
+			args.NodeOperationModes = []common.NodeOperation{common.NormalOperation, common.LightClientMode}
+			ncf, err = networkComp.NewNetworkComponentsFactory(args)
+			require.Nil(t, err)
+			require.NotNil(t, ncf)
+
+			args.NodeOperationModes = []common.NodeOperation{common.NormalOperation, common.LightClientSupplierMode}
+			ncf, err = networkComp.NewNetworkComponentsFactory(args)
+			require.Nil(t, err)
+			require.NotNil(t, ncf)
+
+			args.NodeOperationModes = []common.NodeOperation{common.FullArchiveMode, common.LightClientMode}
+			ncf, err = networkComp.NewNetworkComponentsFactory(args)
+			require.Nil(t, err)
+			require.NotNil(t, ncf)
+
+			args.NodeOperationModes = []common.NodeOperation{common.FullArchiveMode, common.LightClientSupplierMode}
+			ncf, err = networkComp.NewNetworkComponentsFactory(args)
+			require.Nil(t, err)
+			require.NotNil(t, ncf)
+		})
+
 	})
 }
 

--- a/integrationTests/factory/componentsHelper.go
+++ b/integrationTests/factory/componentsHelper.go
@@ -89,6 +89,7 @@ func createConfigurationsPathsHolder() *config.ConfigurationPathsHolder {
 		External:                 concatPath(ExternalPath),
 		MainP2p:                  concatPath(MainP2pPath),
 		FullArchiveP2p:           concatPath(FullArchiveP2pPath),
+		LightClientP2p:           concatPath(LightClientP2pPath),
 		Epoch:                    concatPath(EpochPath),
 		SystemSC:                 concatPath(SystemSCConfigPath),
 		GasScheduleDirectoryName: concatPath(GasSchedule),

--- a/integrationTests/factory/componentsHelper.go
+++ b/integrationTests/factory/componentsHelper.go
@@ -7,10 +7,11 @@ import (
 	"runtime/pprof"
 	"testing"
 
+	logger "github.com/multiversx/mx-chain-logger-go"
+
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/p2p"
-	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
 var log = logger.GetOrCreate("integrationtests")
@@ -36,6 +37,7 @@ func CreateDefaultConfig(tb testing.TB) *config.Configs {
 	prefsConfig, _ := common.LoadPreferencesConfig(configPathsHolder.Preferences)
 	mainP2PConfig, _ := common.LoadP2PConfig(configPathsHolder.MainP2p)
 	fullArchiveP2PConfig, _ := common.LoadP2PConfig(configPathsHolder.FullArchiveP2p)
+	lightClientP2PConfig, _ := common.LoadP2PConfig(configPathsHolder.LightClientP2p)
 	externalConfig, _ := common.LoadExternalConfig(configPathsHolder.External)
 	systemSCConfig, _ := common.LoadSystemSmartContractsConfig(configPathsHolder.SystemSC)
 	epochConfig, _ := common.LoadEpochConfig(configPathsHolder.Epoch)
@@ -53,6 +55,7 @@ func CreateDefaultConfig(tb testing.TB) *config.Configs {
 	configs.PreferencesConfig = prefsConfig
 	configs.MainP2pConfig = mainP2PConfig
 	configs.FullArchiveP2pConfig = fullArchiveP2PConfig
+	configs.LightClientP2pConfig = lightClientP2PConfig
 	configs.ExternalConfig = externalConfig
 	configs.EpochConfig = epochConfig
 	configs.RoundConfig = roundConfig

--- a/integrationTests/factory/constants.go
+++ b/integrationTests/factory/constants.go
@@ -10,6 +10,7 @@ const (
 	ExternalPath          = "external.toml"
 	MainP2pPath           = "p2p.toml"
 	FullArchiveP2pPath    = "fullArchiveP2P.toml"
+	LightClientP2pPath    = "lightClientP2P.toml"
 	EpochPath             = "enableEpochs.toml"
 	SystemSCConfigPath    = "systemSmartContractsConfig.toml"
 	GasSchedule           = "gasSchedules"

--- a/integrationTests/realcomponents/processorRunner.go
+++ b/integrationTests/realcomponents/processorRunner.go
@@ -13,6 +13,8 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/endProcess"
 	"github.com/multiversx/mx-chain-core-go/data/esdt"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/stretchr/testify/require"
+
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/forking"
 	"github.com/multiversx/mx-chain-go/common/ordering"
@@ -40,7 +42,6 @@ import (
 	storageFactory "github.com/multiversx/mx-chain-go/storage/factory"
 	"github.com/multiversx/mx-chain-go/storage/storageunit"
 	"github.com/multiversx/mx-chain-go/update/trigger"
-	"github.com/stretchr/testify/require"
 )
 
 // ProcessorRunner is a test emulation to the nodeRunner component
@@ -175,7 +176,7 @@ func (pr *ProcessorRunner) createNetworkComponents(tb testing.TB) {
 		Syncer:                pr.CoreComponents.SyncTimer(),
 		PreferredPeersSlices:  make([]string, 0),
 		BootstrapWaitTime:     1,
-		NodeOperationMode:     common.NormalOperation,
+		NodeOperationModes:    []common.NodeOperation{common.NormalOperation},
 		ConnectionWatcherType: "",
 		CryptoComponents:      pr.CryptoComponents,
 	}

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -20,6 +20,8 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/throttler"
 	"github.com/multiversx/mx-chain-core-go/data/endProcess"
 	outportCore "github.com/multiversx/mx-chain-core-go/data/outport"
+	logger "github.com/multiversx/mx-chain-logger-go"
+
 	"github.com/multiversx/mx-chain-go/api/gin"
 	"github.com/multiversx/mx-chain-go/api/shared"
 	"github.com/multiversx/mx-chain-go/common"
@@ -61,7 +63,6 @@ import (
 	"github.com/multiversx/mx-chain-go/storage/storageunit"
 	trieStatistics "github.com/multiversx/mx-chain-go/trie/statistics"
 	"github.com/multiversx/mx-chain-go/update/trigger"
-	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
 type nextOperationForNode int

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -1426,7 +1426,7 @@ func (nr *nodeRunner) CreateManagedNetworkComponents(
 		Syncer:                coreComponents.SyncTimer(),
 		PreferredPeersSlices:  nr.configs.PreferencesConfig.Preferences.PreferredConnections,
 		BootstrapWaitTime:     common.TimeToWaitForP2PBootstrap,
-		NodeOperationMode:     common.NormalOperation,
+		NodeOperationModes:    []common.NodeOperation{common.NormalOperation},
 		ConnectionWatcherType: nr.configs.PreferencesConfig.Preferences.ConnectionWatcherType,
 		CryptoComponents:      cryptoComponents,
 	}
@@ -1434,13 +1434,13 @@ func (nr *nodeRunner) CreateManagedNetworkComponents(
 		networkComponentsFactoryArgs.BootstrapWaitTime = 0
 	}
 	if nr.configs.PreferencesConfig.Preferences.FullArchive {
-		networkComponentsFactoryArgs.NodeOperationMode = common.FullArchiveMode
+		networkComponentsFactoryArgs.NodeOperationModes = []common.NodeOperation{common.FullArchiveMode}
 	}
 	if nr.configs.PreferencesConfig.Preferences.LightClient {
-		networkComponentsFactoryArgs.LightClientMode = common.LightClientMode
+		networkComponentsFactoryArgs.NodeOperationModes = append(networkComponentsFactoryArgs.NodeOperationModes, common.LightClientMode)
 	}
 	if nr.configs.PreferencesConfig.Preferences.LightClientSupplier {
-		networkComponentsFactoryArgs.LightClientMode = common.LightClientSupplierMode
+		networkComponentsFactoryArgs.NodeOperationModes = append(networkComponentsFactoryArgs.NodeOperationModes, common.LightClientSupplierMode)
 	}
 
 	networkComponentsFactory, err := networkComp.NewNetworkComponentsFactory(networkComponentsFactoryArgs)

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -1418,6 +1418,7 @@ func (nr *nodeRunner) CreateManagedNetworkComponents(
 	networkComponentsFactoryArgs := networkComp.NetworkComponentsFactoryArgs{
 		MainP2pConfig:         *nr.configs.MainP2pConfig,
 		FullArchiveP2pConfig:  *nr.configs.FullArchiveP2pConfig,
+		LightClientP2pConfig:  *nr.configs.LightClientP2pConfig,
 		MainConfig:            *nr.configs.GeneralConfig,
 		RatingsConfig:         *nr.configs.RatingsConfig,
 		StatusHandler:         statusCoreComponents.AppStatusHandler(),
@@ -1434,6 +1435,9 @@ func (nr *nodeRunner) CreateManagedNetworkComponents(
 	}
 	if nr.configs.PreferencesConfig.Preferences.FullArchive {
 		networkComponentsFactoryArgs.NodeOperationMode = common.FullArchiveMode
+	}
+	if nr.configs.PreferencesConfig.Preferences.LightClient {
+		networkComponentsFactoryArgs.NodeOperationMode = common.LightClientMode
 	}
 
 	networkComponentsFactory, err := networkComp.NewNetworkComponentsFactory(networkComponentsFactoryArgs)

--- a/node/nodeRunner.go
+++ b/node/nodeRunner.go
@@ -1437,7 +1437,10 @@ func (nr *nodeRunner) CreateManagedNetworkComponents(
 		networkComponentsFactoryArgs.NodeOperationMode = common.FullArchiveMode
 	}
 	if nr.configs.PreferencesConfig.Preferences.LightClient {
-		networkComponentsFactoryArgs.NodeOperationMode = common.LightClientMode
+		networkComponentsFactoryArgs.LightClientMode = common.LightClientMode
+	}
+	if nr.configs.PreferencesConfig.Preferences.LightClientSupplier {
+		networkComponentsFactoryArgs.LightClientMode = common.LightClientSupplierMode
 	}
 
 	networkComponentsFactory, err := networkComp.NewNetworkComponentsFactory(networkComponentsFactoryArgs)

--- a/p2p/constants.go
+++ b/p2p/constants.go
@@ -13,6 +13,9 @@ const MainNetwork NetworkType = "main"
 // FullArchiveNetwork defines the full archive network
 const FullArchiveNetwork NetworkType = "full archive"
 
+// LightClientNetwork defines the light clients network
+const LightClientNetwork NetworkType = "light client"
+
 // ListsSharder is the variant that uses lists
 const ListsSharder = p2p.ListsSharder
 

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -8,6 +8,10 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/endProcess"
 	"github.com/multiversx/mx-chain-core-go/data/outport"
+	logger "github.com/multiversx/mx-chain-logger-go"
+	wasmConfig "github.com/multiversx/mx-chain-vm-go/config"
+	"github.com/stretchr/testify/require"
+
 	"github.com/multiversx/mx-chain-go/common"
 	commonFactory "github.com/multiversx/mx-chain-go/common/factory"
 	"github.com/multiversx/mx-chain-go/config"
@@ -41,9 +45,6 @@ import (
 	statusHandlerMock "github.com/multiversx/mx-chain-go/testscommon/statusHandler"
 	"github.com/multiversx/mx-chain-go/testscommon/storage"
 	"github.com/multiversx/mx-chain-go/trie"
-	logger "github.com/multiversx/mx-chain-logger-go"
-	wasmConfig "github.com/multiversx/mx-chain-vm-go/config"
-	"github.com/stretchr/testify/require"
 )
 
 var log = logger.GetOrCreate("componentsMock")
@@ -308,11 +309,11 @@ func GetNetworkFactoryArgs() networkComp.NetworkComponentsFactoryArgs {
 	cryptoCompMock := GetDefaultCryptoComponents()
 
 	return networkComp.NetworkComponentsFactoryArgs{
-		MainP2pConfig:     p2pCfg,
-		NodeOperationMode: common.NormalOperation,
-		MainConfig:        mainConfig,
-		StatusHandler:     appStatusHandler,
-		Marshalizer:       &mock.MarshalizerMock{},
+		MainP2pConfig:      p2pCfg,
+		NodeOperationModes: []common.NodeOperation{common.NormalOperation},
+		MainConfig:         mainConfig,
+		StatusHandler:      appStatusHandler,
+		Marshalizer:        &mock.MarshalizerMock{},
 		RatingsConfig: config.RatingsConfig{
 			General:    config.General{},
 			ShardChain: config.ShardChain{},


### PR DESCRIPTION
## Reasoning behind the pull request
- Light clients will connect on this additional network messenger.
  
## Proposed changes
- Similar to the full archive network, another one has been added for the light client suppliers to connect to.

## Testing procedure
- Start a seednode with mvx-light-client protocol ID.
- Start a node with the InitialPeerList in lightClientP2P.toml set from the seednode you just started.
- Connection should work, add more nodes if needed. 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
