### PR TITLE
Keygen workflow remove pull request action trigger

### DIFF
--- a/.github/workflows/docker-keygenerator.yaml
+++ b/.github/workflows/docker-keygenerator.yaml
@@ -2,7 +2,6 @@ name: Build & push keygenerator docker image
 
 on:
   workflow_dispatch:
-  pull_request:
 
 jobs:
   build-docker-image:
@@ -19,7 +18,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log into Docker Hub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -32,5 +30,5 @@ jobs:
           context: .
           file: ./docker/keygenerator/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: multiversx/chain-keygenerator:latest


### PR DESCRIPTION
## Reasoning behind the pull request
- Building the Docker image for keygenerator on each pull request is not necessary.
  
## Proposed changes
- Removed the pull request trigger from the GitHub Actions workflow, leaving only the manual workflow_dispatch trigger active.

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
