### PR TITLE
fixed missing scrs when multiple inner tx fail with the same error, caused by hash collision

### DIFF
--- a/process/transaction/export_test.go
+++ b/process/transaction/export_test.go
@@ -57,7 +57,13 @@ func (txProc *txProcessor) ProcessUserTx(
 	relayedNonce uint64,
 	originalTxHash []byte,
 ) (vmcommon.ReturnCode, error) {
-	return txProc.processUserTx(originalTx, userTx, relayedTxValue, relayedNonce, originalTxHash)
+	return txProc.processUserTx(
+		originalTx,
+		userTx,
+		relayedTxValue,
+		relayedNonce,
+		originalTxHash,
+		nonRelayedV3UserTxIdx)
 }
 
 // ProcessMoveBalanceCostRelayedUserTx calls the un-exported method processMoveBalanceCostRelayedUserTx
@@ -87,7 +93,8 @@ func (txProc *txProcessor) ExecuteFailedRelayedTransaction(
 		relayedNonce,
 		originalTx,
 		originalTxHash,
-		errorMsg)
+		errorMsg,
+		nonRelayedV3UserTxIdx)
 }
 
 // CheckMaxGasPrice calls the un-exported method checkMaxGasPrice

--- a/process/transaction/shardProcess.go
+++ b/process/transaction/shardProcess.go
@@ -31,6 +31,8 @@ var _ process.TransactionProcessor = (*txProcessor)(nil)
 // for move balance transactions that provide more gas than needed
 const RefundGasMessage = "refundedGas"
 
+const nonRelayedV3UserTxIdx = -1
+
 type relayedFees struct {
 	totalFee, remainingFee, relayerFee *big.Int
 }
@@ -647,12 +649,13 @@ func (txProc *txProcessor) finishExecutionOfRelayedTx(
 			tx.Nonce,
 			tx,
 			originalTxHash,
-			err.Error())
+			err.Error(),
+			nonRelayedV3UserTxIdx)
 	}
 
 	defer txProc.saveFailedLogsIfNeeded(originalTxHash)
 
-	return txProc.processUserTx(tx, userTx, tx.Value, tx.Nonce, originalTxHash)
+	return txProc.processUserTx(tx, userTx, tx.Value, tx.Nonce, originalTxHash, nonRelayedV3UserTxIdx)
 }
 
 func (txProc *txProcessor) processTxAtRelayer(
@@ -743,8 +746,8 @@ func (txProc *txProcessor) processRelayedTxV3(
 	var innerTxFee *big.Int
 	innerTxsTotalFees := big.NewInt(0)
 	executedUserTxs := make([]*transaction.Transaction, 0)
-	for _, innerTx := range innerTxs {
-		innerTxFee, innerTxRetCode, innerTxErr = txProc.processInnerTx(tx, innerTx, originalTxHash)
+	for innerTxIdx, innerTx := range innerTxs {
+		innerTxFee, innerTxRetCode, innerTxErr = txProc.processInnerTx(tx, innerTx, originalTxHash, innerTxIdx)
 		innerTxsTotalFees.Add(innerTxsTotalFees, innerTxFee)
 		if innerTxErr != nil || innerTxRetCode != vmcommon.Ok {
 			continue
@@ -781,6 +784,7 @@ func (txProc *txProcessor) processInnerTx(
 	tx *transaction.Transaction,
 	innerTx *transaction.Transaction,
 	originalTxHash []byte,
+	innerTxIdx int,
 ) (*big.Int, vmcommon.ReturnCode, error) {
 
 	txFee := txProc.computeInnerTxFee(innerTx)
@@ -794,7 +798,8 @@ func (txProc *txProcessor) processInnerTx(
 			tx.Nonce,
 			tx,
 			originalTxHash,
-			err.Error())
+			err.Error(),
+			innerTxIdx)
 	}
 
 	if check.IfNil(acntSnd) {
@@ -805,7 +810,8 @@ func (txProc *txProcessor) processInnerTx(
 			tx.Nonce,
 			tx,
 			originalTxHash,
-			process.ErrRelayedTxV3SenderShardMismatch.Error())
+			process.ErrRelayedTxV3SenderShardMismatch.Error(),
+			innerTxIdx)
 	}
 
 	// TODO: remove adding and then removing the fee at the sender
@@ -818,10 +824,11 @@ func (txProc *txProcessor) processInnerTx(
 			tx.Nonce,
 			tx,
 			originalTxHash,
-			err.Error())
+			err.Error(),
+			innerTxIdx)
 	}
 
-	result, err := txProc.processUserTx(tx, innerTx, tx.Value, tx.Nonce, originalTxHash)
+	result, err := txProc.processUserTx(tx, innerTx, tx.Value, tx.Nonce, originalTxHash, innerTxIdx)
 	return txFee, result, err
 }
 
@@ -1002,6 +1009,7 @@ func (txProc *txProcessor) processUserTx(
 	relayedTxValue *big.Int,
 	relayedNonce uint64,
 	originalTxHash []byte,
+	innerTxIdx int,
 ) (vmcommon.ReturnCode, error) {
 
 	relayerAdr := originalTx.SndAddr
@@ -1018,7 +1026,8 @@ func (txProc *txProcessor) processUserTx(
 			relayedNonce,
 			originalTx,
 			originalTxHash,
-			err.Error())
+			err.Error(),
+			innerTxIdx)
 	}
 
 	txType, dstShardTxType := txProc.txTypeHandler.ComputeTransactionType(userTx)
@@ -1035,7 +1044,8 @@ func (txProc *txProcessor) processUserTx(
 			relayedNonce,
 			originalTx,
 			originalTxHash,
-			err.Error())
+			err.Error(),
+			innerTxIdx)
 	}
 
 	scrFromTx, err := txProc.makeSCRFromUserTx(userTx, relayerAdr, relayedTxValue, originalTxHash)
@@ -1085,7 +1095,8 @@ func (txProc *txProcessor) processUserTx(
 			relayedNonce,
 			originalTx,
 			originalTxHash,
-			err.Error())
+			err.Error(),
+			innerTxIdx)
 	}
 
 	if errors.Is(err, process.ErrInvalidMetaTransaction) || errors.Is(err, process.ErrAccountNotPayable) {
@@ -1096,7 +1107,8 @@ func (txProc *txProcessor) processUserTx(
 			relayedNonce,
 			originalTx,
 			originalTxHash,
-			err.Error())
+			err.Error(),
+			innerTxIdx)
 	}
 
 	if errors.Is(err, process.ErrFailedTransaction) {
@@ -1174,7 +1186,14 @@ func (txProc *txProcessor) executeFailedRelayedUserTx(
 	originalTx *transaction.Transaction,
 	originalTxHash []byte,
 	errorMsg string,
+	innerTxIdx int,
 ) error {
+
+	returnMessage := []byte(errorMsg)
+	isUserTxOfRelayedV3 := innerTxIdx != nonRelayedV3UserTxIdx
+	if isUserTxOfRelayedV3 {
+		returnMessage = []byte(fmt.Sprintf("%s while executing inner tx at index %d", errorMsg, innerTxIdx))
+	}
 	scrForRelayer := &smartContractResult.SmartContractResult{
 		Nonce:          relayedNonce,
 		Value:          big.NewInt(0).Set(relayedTxValue),
@@ -1182,7 +1201,7 @@ func (txProc *txProcessor) executeFailedRelayedUserTx(
 		SndAddr:        userTx.SndAddr,
 		PrevTxHash:     originalTxHash,
 		OriginalTxHash: originalTxHash,
-		ReturnMessage:  []byte(errorMsg),
+		ReturnMessage:  returnMessage,
 	}
 
 	relayerAcnt, err := txProc.getAccountFromAddress(relayerAdr)


### PR DESCRIPTION
## Reasoning behind the pull request
- when multiple inner txs fail with the same error(non executable), only one scr will be generated due to all scrs having the same hash
  
## Proposed changes
- improved return message on scr in order to reflect which inner tx failed, resulting in different hashes each time

## Testing procedure
- standard system test + test relayed v3 with multiple inner txs from the same sender with higher/lower nonce

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
