### PR TITLE
elasticsearch indices update at startup

### DIFF
--- a/scripts/testnet/include/config.sh
+++ b/scripts/testnet/include/config.sh
@@ -94,7 +94,6 @@ prepareElasticsearch() {
     ES_CONTAINER_ID=$(docker start $ES_CONTAINER)
   else
     ES_CONTAINER_ID=$(docker run -d --network host --volume=$ELASTICSEARCH_VOLUME:/usr/share/elasticsearch/data -e "discovery.type=single-node" --name=$ES_CONTAINER docker.elastic.co/elasticsearch/elasticsearch:7.10.2)
-    sleep 20
     updateElasticsearchIndices
   fi
   echo $ES_CONTAINER_ID > $TESTNETDIR/es_container_id.txt

--- a/scripts/testnet/include/config.sh
+++ b/scripts/testnet/include/config.sh
@@ -94,8 +94,17 @@ prepareElasticsearch() {
     ES_CONTAINER_ID=$(docker start $ES_CONTAINER)
   else
     ES_CONTAINER_ID=$(docker run -d --network host --volume=$ELASTICSEARCH_VOLUME:/usr/share/elasticsearch/data -e "discovery.type=single-node" --name=$ES_CONTAINER docker.elastic.co/elasticsearch/elasticsearch:7.10.2)
+    sleep 20
+    updateElasticsearchIndices
   fi
   echo $ES_CONTAINER_ID > $TESTNETDIR/es_container_id.txt
+}
+
+updateElasticsearchIndices() {
+  echo "Updating Elasticsearch indices..."
+  pushd $(dirname $MULTIVERSXDIR)/mx-chain-tools-go/elasticreindexer/cmd/indices-creator
+  ./indices-creator
+  popd
 }
 
 copyNodeConfig() {

--- a/scripts/testnet/prerequisites.sh
+++ b/scripts/testnet/prerequisites.sh
@@ -68,13 +68,22 @@ if [ "$SOVEREIGN_DEPLOY" -eq 1 ]; then
     popd
 
     pushd .
-
     git clone git@github.com:multiversx/mx-chain-sovereign-bridge-go.git
     cd mx-chain-sovereign-bridge-go
     cd cert/cmd/cert
     go build
     ./cert
+    popd
 
+    pushd .
+    git clone --no-checkout https://github.com/multiversx/mx-chain-tools-go.git
+    cd mx-chain-tools-go
+    git sparse-checkout init --cone
+    git sparse-checkout set elasticreindexer
+    git checkout main
+    cd elasticreindexer
+    cd cmd/indices-creator/
+    go build
     popd
 fi
 

--- a/scripts/testnet/sovereignBridge/config/common.snippets.sh
+++ b/scripts/testnet/sovereignBridge/config/common.snippets.sh
@@ -62,5 +62,10 @@ gitPullAllChanges()
     git pull
     cd ..
 
+    echo -e "Pulling changes for mx-chain-tools-go..."
+    cd mx-chain-tools-go
+    git pull
+    cd ..
+
     popd
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- `NFTs` tab in explorer was not working
- 
- 
  
## Proposed changes
- Need to run the tool to update indices at startup, if elasticsearch is enabled
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
