### PR TITLE
update trie on goroutines

### DIFF
--- a/common/interface.go
+++ b/common/interface.go
@@ -394,3 +394,13 @@ type BatchHandler interface {
 	MarkForRemoval(key []byte)
 	Get(key []byte) ([]byte, bool)
 }
+
+// TrieGoroutinesManager defines the methods needed for managing the trie goroutines
+type TrieGoroutinesManager interface {
+	ShouldContinueProcessing() bool
+	CanStartGoRoutine() bool
+	EndGoRoutineProcessing()
+	SetError(err error)
+	GetError() error
+	IsInterfaceNil() bool
+}

--- a/common/interface.go
+++ b/common/interface.go
@@ -410,5 +410,4 @@ type TrieGoroutinesManager interface {
 type AtomicBytesSlice interface {
 	Append(data [][]byte)
 	Get() [][]byte
-	Reset()
 }

--- a/common/interface.go
+++ b/common/interface.go
@@ -400,6 +400,7 @@ type TrieGoroutinesManager interface {
 	ShouldContinueProcessing() bool
 	CanStartGoRoutine() bool
 	EndGoRoutineProcessing()
+	SetNewErrorChannel(BufferedErrChan) error
 	SetError(err error)
 	GetError() error
 	IsInterfaceNil() bool

--- a/common/interface.go
+++ b/common/interface.go
@@ -404,3 +404,10 @@ type TrieGoroutinesManager interface {
 	GetError() error
 	IsInterfaceNil() bool
 }
+
+// AtomicBytesSlice defines the methods needed for an atomic bytes slice
+type AtomicBytesSlice interface {
+	Append(data [][]byte)
+	Get() [][]byte
+	Reset()
+}

--- a/common/modifiedHashes.go
+++ b/common/modifiedHashes.go
@@ -22,9 +22,9 @@ type modifiedHashesSlice struct {
 }
 
 // NewModifiedHashesSlice is used to create a new instance of modifiedHashesSlice
-func NewModifiedHashesSlice() *modifiedHashesSlice {
+func NewModifiedHashesSlice(initialCapacity int) *modifiedHashesSlice {
 	return &modifiedHashesSlice{
-		hashes: make([][]byte, 0),
+		hashes: make([][]byte, 0, initialCapacity),
 	}
 }
 

--- a/common/modifiedHashes.go
+++ b/common/modifiedHashes.go
@@ -45,11 +45,3 @@ func (mhs *modifiedHashesSlice) Get() [][]byte {
 	copy(hashes, mhs.hashes)
 	return hashes
 }
-
-// Reset is used to reset the slice
-func (mhs *modifiedHashesSlice) Reset() {
-	mhs.Lock()
-	defer mhs.Unlock()
-
-	mhs.hashes = nil
-}

--- a/common/modifiedHashes.go
+++ b/common/modifiedHashes.go
@@ -1,5 +1,7 @@
 package common
 
+import "sync"
+
 // ModifiedHashes is used to memorize all old hashes and new hashes from when a trie is committed
 type ModifiedHashes map[string]struct{}
 
@@ -11,4 +13,43 @@ func (mh ModifiedHashes) Clone() ModifiedHashes {
 	}
 
 	return newMap
+}
+
+// ModifiedHashesSlice is used to memorize all old hashes and new hashes from when a trie is committed
+type modifiedHashesSlice struct {
+	hashes [][]byte
+	sync.RWMutex
+}
+
+// NewModifiedHashesSlice is used to create a new instance of modifiedHashesSlice
+func NewModifiedHashesSlice() *modifiedHashesSlice {
+	return &modifiedHashesSlice{
+		hashes: make([][]byte, 0),
+	}
+}
+
+// Append is used to add new hashes to the slice
+func (mhs *modifiedHashesSlice) Append(hashes [][]byte) {
+	mhs.Lock()
+	defer mhs.Unlock()
+
+	mhs.hashes = append(mhs.hashes, hashes...)
+}
+
+// Get is used to get the hashes from the slice
+func (mhs *modifiedHashesSlice) Get() [][]byte {
+	mhs.RLock()
+	defer mhs.RUnlock()
+
+	hashes := make([][]byte, len(mhs.hashes))
+	copy(hashes, mhs.hashes)
+	return hashes
+}
+
+// Reset is used to reset the slice
+func (mhs *modifiedHashesSlice) Reset() {
+	mhs.Lock()
+	defer mhs.Unlock()
+
+	mhs.hashes = nil
 }

--- a/common/modifiedHashes_test.go
+++ b/common/modifiedHashes_test.go
@@ -70,14 +70,3 @@ func TestModifiedHashesSlice_Get(t *testing.T) {
 	newRetrievedHashes := mhs.Get()
 	assert.NotEqual(t, retrievedHashes, newRetrievedHashes)
 }
-
-func TestModifiedHashesSlice_Reset(t *testing.T) {
-	t.Parallel()
-
-	hashes := [][]byte{{1}, {2}, {3}}
-	mhs := NewModifiedHashesSlice(len(hashes))
-	mhs.Append(hashes)
-	assert.Equal(t, len(hashes), len(mhs.hashes))
-	mhs.Reset()
-	assert.Equal(t, 0, len(mhs.hashes))
-}

--- a/common/modifiedHashes_test.go
+++ b/common/modifiedHashes_test.go
@@ -30,8 +30,8 @@ func TestModifiedHashes_Clone(t *testing.T) {
 func TestModifiedHashesSlice_Append(t *testing.T) {
 	t.Parallel()
 
-	mhs := NewModifiedHashesSlice()
 	numHashes := 100
+	mhs := NewModifiedHashesSlice(numHashes)
 	hashes := make([][]byte, numHashes)
 	for i := 0; i < numHashes; i++ {
 		hashes[i] = []byte{byte(i)}
@@ -61,8 +61,8 @@ func TestModifiedHashesSlice_Append(t *testing.T) {
 func TestModifiedHashesSlice_Get(t *testing.T) {
 	t.Parallel()
 
-	mhs := NewModifiedHashesSlice()
 	hashes := [][]byte{{1}, {2}, {3}}
+	mhs := NewModifiedHashesSlice(len(hashes))
 	mhs.Append(hashes)
 	retrievedHashes := mhs.Get()
 	assert.Equal(t, hashes, retrievedHashes)
@@ -74,8 +74,8 @@ func TestModifiedHashesSlice_Get(t *testing.T) {
 func TestModifiedHashesSlice_Reset(t *testing.T) {
 	t.Parallel()
 
-	mhs := NewModifiedHashesSlice()
 	hashes := [][]byte{{1}, {2}, {3}}
+	mhs := NewModifiedHashesSlice(len(hashes))
 	mhs.Append(hashes)
 	assert.Equal(t, len(hashes), len(mhs.hashes))
 	mhs.Reset()

--- a/common/modifiedHashes_test.go
+++ b/common/modifiedHashes_test.go
@@ -1,7 +1,9 @@
 package common
 
 import (
+	"bytes"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,4 +25,59 @@ func TestModifiedHashes_Clone(t *testing.T) {
 		assert.True(t, found)
 	}
 
+}
+
+func TestModifiedHashesSlice_Append(t *testing.T) {
+	t.Parallel()
+
+	mhs := NewModifiedHashesSlice()
+	numHashes := 100
+	hashes := make([][]byte, numHashes)
+	for i := 0; i < numHashes; i++ {
+		hashes[i] = []byte{byte(i)}
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(numHashes)
+	for i := 0; i < numHashes; i++ {
+		go func(index int) {
+			mhs.Append([][]byte{hashes[index]})
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < numHashes; i++ {
+		hashFound := false
+		for _, hash := range mhs.hashes {
+			if bytes.Equal(hashes[i], hash) {
+				hashFound = true
+			}
+		}
+		assert.True(t, hashFound)
+	}
+}
+
+func TestModifiedHashesSlice_Get(t *testing.T) {
+	t.Parallel()
+
+	mhs := NewModifiedHashesSlice()
+	hashes := [][]byte{{1}, {2}, {3}}
+	mhs.Append(hashes)
+	retrievedHashes := mhs.Get()
+	assert.Equal(t, hashes, retrievedHashes)
+	retrievedHashes[0] = []byte{4}
+	newRetrievedHashes := mhs.Get()
+	assert.NotEqual(t, retrievedHashes, newRetrievedHashes)
+}
+
+func TestModifiedHashesSlice_Reset(t *testing.T) {
+	t.Parallel()
+
+	mhs := NewModifiedHashesSlice()
+	hashes := [][]byte{{1}, {2}, {3}}
+	mhs.Append(hashes)
+	assert.Equal(t, len(hashes), len(mhs.hashes))
+	mhs.Reset()
+	assert.Equal(t, 0, len(mhs.hashes))
 }

--- a/trie/branchNode.go
+++ b/trie/branchNode.go
@@ -504,6 +504,7 @@ func (bn *branchNode) updateNode(
 		go func(childPos int) {
 			updateFunc(data[childPos], childPos, goRoutinesManager, modifiedHashes, hasBeenModified, db)
 
+			goRoutinesManager.EndGoRoutineProcessing()
 			waitGroup.Done()
 		}(childPos)
 	}

--- a/trie/branchNode.go
+++ b/trie/branchNode.go
@@ -628,6 +628,9 @@ func (bn *branchNode) insertOnExistingChild(
 }
 
 func (bn *branchNode) modifyNodeAfterInsert(modifiedHashes [][]byte, childPos byte, newNode node) ([][]byte, error) {
+	bn.mutex.Lock()
+	defer bn.mutex.Unlock()
+
 	if !bn.dirty {
 		modifiedHashes = append(modifiedHashes, bn.hash)
 	}
@@ -779,6 +782,9 @@ func (bn *branchNode) deleteChild(
 }
 
 func (bn *branchNode) setNewChild(childPos byte, newNode node) error {
+	bn.mutex.Lock()
+	defer bn.mutex.Unlock()
+
 	bn.hash = nil
 	bn.children[childPos] = newNode
 	if check.IfNil(newNode) {

--- a/trie/branchNode.go
+++ b/trie/branchNode.go
@@ -631,6 +631,9 @@ func (bn *branchNode) insertOnExistingChild(
 }
 
 func (bn *branchNode) modifyNodeAfterInsert(modifiedHashes common.AtomicBytesSlice, childPos byte, newNode node) error {
+	bn.mutex.Lock()
+	defer bn.mutex.Unlock()
+
 	if !bn.dirty {
 		modifiedHashes.Append([][]byte{bn.hash})
 	}
@@ -751,6 +754,9 @@ func (bn *branchNode) deleteChild(
 }
 
 func (bn *branchNode) setNewChild(childPos byte, newNode node) error {
+	bn.mutex.Lock()
+	defer bn.mutex.Unlock()
+
 	bn.hash = nil
 	bn.children[childPos] = newNode
 	if check.IfNil(newNode) {

--- a/trie/branchNode_test.go
+++ b/trie/branchNode_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/core/atomic"
 	"github.com/multiversx/mx-chain-core-go/core/throttler"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
@@ -22,6 +23,13 @@ import (
 	"github.com/multiversx/mx-chain-go/trie/trieBatchManager"
 	"github.com/stretchr/testify/assert"
 )
+
+func getTestGoroutinesManager() common.TrieGoroutinesManager {
+	th, _ := throttler.NewNumGoRoutinesThrottler(5)
+	goRoutinesManager, _ := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
+
+	return goRoutinesManager
+}
 
 func getTestMarshalizerAndHasher() (marshal.Marshalizer, hashing.Hasher) {
 	marsh := &marshal.GogoProtoMarshalizer{}
@@ -626,12 +634,10 @@ func TestBranchNode_insert(t *testing.T) {
 	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
 	nodeKey := []byte{0, 2, 3}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
 
-	newBn, _ := bn.insert(data, goRoutinesManager, nil)
+	newBn := bn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.NotNil(t, newBn)
 	assert.Nil(t, goRoutinesManager.GetError())
 
@@ -645,12 +651,10 @@ func TestBranchNode_insertEmptyKey(t *testing.T) {
 
 	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion("", "dogs")}
 
-	newBn, _ := bn.insert(data, goRoutinesManager, nil)
+	newBn := bn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.Equal(t, ErrValueTooShort, goRoutinesManager.GetError())
 	assert.Nil(t, newBn)
 }
@@ -660,12 +664,10 @@ func TestBranchNode_insertChildPosOutOfRange(t *testing.T) {
 
 	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion("dog", "dogs")}
 
-	newBn, _ := bn.insert(data, goRoutinesManager, nil)
+	newBn := bn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.Equal(t, ErrChildPosOutOfRange, goRoutinesManager.GetError())
 	assert.Nil(t, newBn)
 }
@@ -681,12 +683,10 @@ func TestBranchNode_insertCollapsedNode(t *testing.T) {
 	_ = bn.setHash()
 	_ = bn.commitDirty(0, 5, db, db)
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
-	newBn, _ := collapsedBn.insert(data, goRoutinesManager, db)
+	newBn := collapsedBn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), db)
 	assert.NotNil(t, newBn)
 	assert.Nil(t, goRoutinesManager.GetError())
 
@@ -708,15 +708,36 @@ func TestBranchNode_insertInStoredBnOnExistingPos(t *testing.T) {
 	lnHash := ln.getHash()
 	expectedHashes := [][]byte{lnHash, bnHash}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
-	newNode, oldHashes := bn.insert(data, goRoutinesManager, db)
+	modifiedHashes := common.NewModifiedHashesSlice()
+	newNode := bn.insert(data, goRoutinesManager, modifiedHashes, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
-	assert.Equal(t, expectedHashes, oldHashes)
+
+	assert.True(t, slicesContainSameElements(expectedHashes, modifiedHashes.Get()))
+}
+
+func slicesContainSameElements(s1 [][]byte, s2 [][]byte) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+
+	for _, e1 := range s1 {
+		found := false
+		for _, e2 := range s2 {
+			if bytes.Equal(e1, e2) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
 }
 
 func TestBranchNode_insertInStoredBnOnNilPos(t *testing.T) {
@@ -731,15 +752,14 @@ func TestBranchNode_insertInStoredBnOnNilPos(t *testing.T) {
 	bnHash := bn.getHash()
 	expectedHashes := [][]byte{bnHash}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
-	newNode, oldHashes := bn.insert(data, goRoutinesManager, db)
+	modifiedHashes := common.NewModifiedHashesSlice()
+	newNode := bn.insert(data, goRoutinesManager, modifiedHashes, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
-	assert.Equal(t, expectedHashes, oldHashes)
+	assert.True(t, slicesContainSameElements(expectedHashes, modifiedHashes.Get()))
 }
 
 func TestBranchNode_insertInDirtyBnOnNilPos(t *testing.T) {
@@ -749,15 +769,14 @@ func TestBranchNode_insertInDirtyBnOnNilPos(t *testing.T) {
 	nilChildPos := byte(11)
 	key := append([]byte{nilChildPos}, []byte("dog")...)
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
-	newNode, oldHashes := bn.insert(data, goRoutinesManager, nil)
+	modifiedHashes := common.NewModifiedHashesSlice()
+	newNode := bn.insert(data, goRoutinesManager, modifiedHashes, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
-	assert.Equal(t, [][]byte{}, oldHashes)
+	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
 }
 
 func TestBranchNode_insertInDirtyBnOnExistingPos(t *testing.T) {
@@ -767,15 +786,14 @@ func TestBranchNode_insertInDirtyBnOnExistingPos(t *testing.T) {
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
-	newNode, oldHashes := bn.insert(data, goRoutinesManager, nil)
+	modifiedHashes := common.NewModifiedHashesSlice()
+	newNode := bn.insert(data, goRoutinesManager, modifiedHashes, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
-	assert.Equal(t, [][]byte{}, oldHashes)
+	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
 }
 
 func TestBranchNode_insertInNilNode(t *testing.T) {
@@ -783,12 +801,10 @@ func TestBranchNode_insertInNilNode(t *testing.T) {
 
 	var bn *branchNode
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion("key", "dogs")}
 
-	newBn, _ := bn.insert(data, goRoutinesManager, nil)
+	newBn := bn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.True(t, errors.Is(goRoutinesManager.GetError(), ErrNilBranchNode))
 	assert.Nil(t, newBn)
 }
@@ -807,11 +823,8 @@ func TestBranchNode_delete(t *testing.T) {
 	key := append([]byte{childPos}, []byte("dog")...)
 	data := []core.TrieData{{Key: key}}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
-	dirty, newBn, _ := bn.delete(data, goRoutinesManager, nil)
+	goRoutinesManager := getTestGoroutinesManager()
+	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 
@@ -834,15 +847,13 @@ func TestBranchNode_deleteFromStoredBn(t *testing.T) {
 	lnHash := ln.getHash()
 	expectedHashes := [][]byte{lnHash, bnHash}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{{Key: lnKey}}
-	dirty, _, oldHashes := bn.delete(data, goRoutinesManager, db)
+	modifiedHashes := common.NewModifiedHashesSlice()
+	dirty, _ := bn.delete(data, goRoutinesManager, modifiedHashes, db)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
-	assert.Equal(t, expectedHashes, oldHashes)
+	assert.True(t, slicesContainSameElements(expectedHashes, modifiedHashes.Get()))
 }
 
 func TestBranchNode_deleteFromDirtyBn(t *testing.T) {
@@ -853,14 +864,12 @@ func TestBranchNode_deleteFromDirtyBn(t *testing.T) {
 	lnKey := append([]byte{childPos}, []byte("dog")...)
 	data := []core.TrieData{{Key: lnKey}}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
-	dirty, _, oldHashes := bn.delete(data, goRoutinesManager, nil)
+	goRoutinesManager := getTestGoroutinesManager()
+	modifiedHashes := common.NewModifiedHashesSlice()
+	dirty, _ := bn.delete(data, goRoutinesManager, modifiedHashes, nil)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
-	assert.Equal(t, [][]byte{}, oldHashes)
+	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
 }
 
 func TestBranchNode_deleteEmptyNode(t *testing.T) {
@@ -871,11 +880,8 @@ func TestBranchNode_deleteEmptyNode(t *testing.T) {
 	key := append([]byte{childPos}, []byte("dog")...)
 	data := []core.TrieData{{Key: key}}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
-	dirty, newBn, _ := bn.delete(data, goRoutinesManager, nil)
+	goRoutinesManager := getTestGoroutinesManager()
+	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.False(t, dirty)
 	assert.True(t, errors.Is(goRoutinesManager.GetError(), ErrEmptyBranchNode))
 	assert.Nil(t, newBn)
@@ -889,11 +895,8 @@ func TestBranchNode_deleteNilNode(t *testing.T) {
 	key := append([]byte{childPos}, []byte("dog")...)
 	data := []core.TrieData{{Key: key}}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
-	dirty, newBn, _ := bn.delete(data, goRoutinesManager, nil)
+	goRoutinesManager := getTestGoroutinesManager()
+	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.False(t, dirty)
 	assert.True(t, errors.Is(goRoutinesManager.GetError(), ErrNilBranchNode))
 	assert.Nil(t, newBn)
@@ -908,11 +911,8 @@ func TestBranchNode_deleteNonexistentNodeFromChild(t *testing.T) {
 	key := append([]byte{childPos}, []byte("butterfly")...)
 	data := []core.TrieData{{Key: key}}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
-	dirty, newBn, _ := bn.delete(data, goRoutinesManager, nil)
+	goRoutinesManager := getTestGoroutinesManager()
+	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.False(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, bn, newBn)
@@ -924,11 +924,8 @@ func TestBranchNode_deleteEmptykey(t *testing.T) {
 	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
 	data := []core.TrieData{{Key: []byte{}}}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
-	dirty, newBn, _ := bn.delete(data, goRoutinesManager, nil)
+	goRoutinesManager := getTestGoroutinesManager()
+	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.False(t, dirty)
 	assert.Equal(t, ErrValueTooShort, goRoutinesManager.GetError())
 	assert.Nil(t, newBn)
@@ -946,11 +943,8 @@ func TestBranchNode_deleteCollapsedNode(t *testing.T) {
 	key := append([]byte{childPos}, []byte("dog")...)
 	data := []core.TrieData{{Key: key}}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
-	dirty, newBn, _ := collapsedBn.delete(data, goRoutinesManager, db)
+	goRoutinesManager := getTestGoroutinesManager()
+	dirty, newBn := collapsedBn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), db)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 
@@ -976,11 +970,8 @@ func TestBranchNode_deleteAndReduceBn(t *testing.T) {
 	key = append([]byte{secondChildPos}, []byte("doe")...)
 	data := []core.TrieData{{Key: key}}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
-	dirty, newBn, _ := bn.delete(data, goRoutinesManager, nil)
+	goRoutinesManager := getTestGoroutinesManager()
+	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, ln, newBn)
@@ -1553,7 +1544,7 @@ func TestBranchNode_VerifyChildrenVersionIsSetCorrectlyAfterInsertAndDelete(t *t
 			Version: 0,
 		}
 
-		newBn, _ := bn.insert([]core.TrieData{data}, goRoutinesManager, &testscommon.MemDbMock{})
+		newBn := bn.insert([]core.TrieData{data}, goRoutinesManager, common.NewModifiedHashesSlice(), &testscommon.MemDbMock{})
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Nil(t, newBn.(*branchNode).ChildrenVersion)
 	})
@@ -1571,7 +1562,7 @@ func TestBranchNode_VerifyChildrenVersionIsSetCorrectlyAfterInsertAndDelete(t *t
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		_, newBn, _ := bn.delete(data, goRoutinesManager, &testscommon.MemDbMock{})
+		_, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), &testscommon.MemDbMock{})
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Nil(t, newBn.(*branchNode).ChildrenVersion)
 	})
@@ -1768,11 +1759,13 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes, nodeModified := bn.insertOnNilChild(data, 0, goRoutinesManager, nil)
+		modifiedHashes := common.NewModifiedHashesSlice()
+		bnModified := &atomic.Flag{}
+		bn.insertOnNilChild(data, 0, goRoutinesManager, modifiedHashes, bnModified, nil)
 		expectedNumTrieNodesChanged := 0
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		assert.Equal(t, ErrValueTooShort, goRoutinesManager.GetError())
-		assert.False(t, nodeModified)
+		assert.False(t, bnModified.IsSet())
 	})
 	t.Run("insert one child in !dirty node", func(t *testing.T) {
 		t.Parallel()
@@ -1797,15 +1790,17 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes, bnModified := bn.insertOnNilChild(newData, childPos, goRoutinesManager, db)
+		modifiedHashes := common.NewModifiedHashesSlice()
+		bnModified := &atomic.Flag{}
+		bn.insertOnNilChild(newData, childPos, goRoutinesManager, modifiedHashes, bnModified, db)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 1
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
-		assert.Equal(t, originalHash, modifiedHashes[0])
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
+		assert.Equal(t, originalHash, modifiedHashes.Get()[0])
 		assert.True(t, bn.dirty)
 		assert.NotNil(t, bn.children[childPos])
 		assert.Equal(t, byte(core.AutoBalanceEnabled), bn.ChildrenVersion[childPos])
-		assert.True(t, bnModified)
+		assert.True(t, bnModified.IsSet())
 	})
 	t.Run("insert one child in dirty node", func(t *testing.T) {
 		t.Parallel()
@@ -1826,14 +1821,16 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes, bnModified := bn.insertOnNilChild(newData, childPos, goRoutinesManager, db)
+		modifiedHashes := common.NewModifiedHashesSlice()
+		bnModified := &atomic.Flag{}
+		bn.insertOnNilChild(newData, childPos, goRoutinesManager, modifiedHashes, bnModified, db)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 0
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		assert.True(t, bn.dirty)
 		assert.NotNil(t, bn.children[childPos])
 		assert.Equal(t, byte(core.AutoBalanceEnabled), bn.ChildrenVersion[childPos])
-		assert.True(t, bnModified)
+		assert.True(t, bnModified.IsSet())
 	})
 	t.Run("insert multiple children", func(t *testing.T) {
 		t.Parallel()
@@ -1858,16 +1855,18 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes, bnModified := bn.insertOnNilChild(newData, childPos, goRoutinesManager, db)
+		modifiedHashes := common.NewModifiedHashesSlice()
+		bnModified := &atomic.Flag{}
+		bn.insertOnNilChild(newData, childPos, goRoutinesManager, modifiedHashes, bnModified, db)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 0
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		assert.True(t, bn.dirty)
 		assert.NotNil(t, bn.children[childPos])
 		assert.Equal(t, byte(core.AutoBalanceEnabled), bn.ChildrenVersion[childPos])
 		_, ok := bn.children[0].(*extensionNode)
 		assert.True(t, ok)
-		assert.True(t, bnModified)
+		assert.True(t, bnModified.IsSet())
 	})
 }
 
@@ -1909,14 +1908,28 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 		goRoutinesManager, _ := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes, bnModified := bn.insertOnExistingChild(newData, childPos, goRoutinesManager, db)
+		modifiedHashes := common.NewModifiedHashesSlice()
+		bnModified := &atomic.Flag{}
+		bn.insertOnExistingChild(newData, childPos, goRoutinesManager, modifiedHashes, bnModified, db)
 		assert.Nil(t, goRoutinesManager.GetError())
-		assert.True(t, bnModified)
+		assert.True(t, bnModified.IsSet())
 		assert.True(t, bn.dirty)
 		expectedNumTrieNodesChanged := 2
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
-		assert.Equal(t, originalChildHash, modifiedHashes[0])
-		assert.Equal(t, originalHash, modifiedHashes[1])
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
+
+		originalChildHashPresent := false
+		originalHashPresent := false
+		for _, hash := range modifiedHashes.Get() {
+			if bytes.Equal(hash, originalChildHash) {
+				originalChildHashPresent = true
+			}
+			if bytes.Equal(hash, originalHash) {
+				originalHashPresent = true
+			}
+		}
+		assert.True(t, originalChildHashPresent)
+		assert.True(t, originalHashPresent)
+
 		_, ok := bn.children[childPos].(*extensionNode)
 		assert.True(t, ok)
 	})
@@ -1948,12 +1961,14 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes, bnModified := bn.insertOnExistingChild(newData, childPos, goRoutinesManager, db)
+		modifiedHashes := common.NewModifiedHashesSlice()
+		bnModified := &atomic.Flag{}
+		bn.insertOnExistingChild(newData, childPos, goRoutinesManager, modifiedHashes, bnModified, db)
 		assert.Nil(t, goRoutinesManager.GetError())
-		assert.False(t, bnModified)
+		assert.False(t, bnModified.IsSet())
 		assert.False(t, bn.dirty)
 		expectedNumTrieNodesChanged := 0
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		_, ok := bn.children[childPos].(*leafNode)
 		assert.True(t, ok)
 	})
@@ -1996,10 +2011,11 @@ func TestBranchNode_insertBatch(t *testing.T) {
 	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 	assert.Nil(t, err)
 
-	newNode, modifiedHashes := bn.insert(newData, goRoutinesManager, db)
+	modifiedHashes := common.NewModifiedHashesSlice()
+	newNode := bn.insert(newData, goRoutinesManager, modifiedHashes, db)
 	assert.Nil(t, goRoutinesManager.GetError())
 	expectedNumTrieNodesChanged := 2
-	assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+	assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 	assert.True(t, newNode.isDirty())
 
 	bn, ok := newNode.(*branchNode)
@@ -2054,12 +2070,13 @@ func TestBranchNode_deleteBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		dirty, newNode, modifiedHashes := bn.delete(data, goRoutinesManager, testscommon.NewMemDbMock())
+		modifiedHashes := common.NewModifiedHashesSlice()
+		dirty, newNode := bn.delete(data, goRoutinesManager, modifiedHashes, testscommon.NewMemDbMock())
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.True(t, dirty)
 		assert.True(t, newNode.isDirty())
 		expectedNumTrieNodesChanged := 5
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		bn, ok := newNode.(*branchNode)
 		assert.True(t, ok)
 
@@ -2091,12 +2108,13 @@ func TestBranchNode_deleteBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		dirty, newNode, modifiedHashes := bn.delete(data, goRoutinesManager, testscommon.NewMemDbMock())
+		modifiedHashes := common.NewModifiedHashesSlice()
+		dirty, newNode := bn.delete(data, goRoutinesManager, modifiedHashes, testscommon.NewMemDbMock())
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.True(t, dirty)
 		assert.True(t, newNode.isDirty())
 		expectedNumTrieNodesChanged := 6
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		ln, ok := newNode.(*leafNode)
 		assert.True(t, ok)
 		assert.Equal(t, []byte{9, 3, 7, 8, 9}, ln.Key)
@@ -2126,11 +2144,12 @@ func TestBranchNode_deleteBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		dirty, newNode, modifiedHashes := bn.delete(data, goRoutinesManager, testscommon.NewMemDbMock())
+		modifiedHashes := common.NewModifiedHashesSlice()
+		dirty, newNode := bn.delete(data, goRoutinesManager, modifiedHashes, testscommon.NewMemDbMock())
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.True(t, dirty)
 		assert.Nil(t, newNode)
 		expectedNumTrieNodesChanged := 6
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 	})
 }

--- a/trie/errors.go
+++ b/trie/errors.go
@@ -123,3 +123,12 @@ var ErrNilTrieLeafParser = errors.New("nil trie leaf parser")
 
 // ErrInvalidNodeVersion signals that an invalid node version has been provided
 var ErrInvalidNodeVersion = errors.New("invalid node version provided")
+
+// ErrNilThrottler signals that a nil throttler has been provided
+var ErrNilThrottler = errors.New("nil throttler")
+
+// ErrNilBufferedErrChan signals that a nil buffered error channel has been provided
+var ErrNilBufferedErrChan = errors.New("nil buffered error channel")
+
+// ErrNilChanClose signals that a nil chan close has been provided
+var ErrNilChanClose = errors.New("nil chan close")

--- a/trie/extensionNode.go
+++ b/trie/extensionNode.go
@@ -337,18 +337,18 @@ func (en *extensionNode) getNext(key []byte, db common.TrieStorageInteractor) (n
 func (en *extensionNode) insert(
 	newData []core.TrieData,
 	goRoutinesManager common.TrieGoroutinesManager,
+	modifiedHashes common.AtomicBytesSlice,
 	db common.TrieStorageInteractor,
-) (node, [][]byte) {
-	emptyHashes := make([][]byte, 0)
+) node {
 	err := en.isEmptyOrNil()
 	if err != nil {
 		goRoutinesManager.SetError(fmt.Errorf("insert error %w", err))
-		return nil, emptyHashes
+		return nil
 	}
 	err = resolveIfCollapsed(en, 0, db)
 	if err != nil {
 		goRoutinesManager.SetError(err)
-		return nil, emptyHashes
+		return nil
 	}
 
 	keyMatchLen, index := getMinKeyMatchLen(newData, en.Key)
@@ -356,11 +356,11 @@ func (en *extensionNode) insert(
 	// If the whole key matches, keep this extension node as is
 	// and only update the value.
 	if keyMatchLen == len(en.Key) {
-		return en.insertInSameEn(newData, keyMatchLen, goRoutinesManager, db)
+		return en.insertInSameEn(newData, keyMatchLen, goRoutinesManager, modifiedHashes, db)
 	}
 
 	// Otherwise branch out at the index where they differ.
-	return en.insertInNewBn(newData, goRoutinesManager, db, keyMatchLen, index)
+	return en.insertInNewBn(newData, goRoutinesManager, modifiedHashes, db, keyMatchLen, index)
 }
 
 func getMinKeyMatchLen(newData []core.TrieData, enKey []byte) (int, int) {
@@ -395,62 +395,63 @@ func (en *extensionNode) insertInSameEn(
 	newData []core.TrieData,
 	keyMatchLen int,
 	goRoutinesManager common.TrieGoroutinesManager,
+	modifiedHashes common.AtomicBytesSlice,
 	db common.TrieStorageInteractor,
-) (node, [][]byte) {
+) node {
 	for i := range newData {
 		newData[i].Key = newData[i].Key[keyMatchLen:]
 	}
-	newNode, oldHashes := en.child.insert(newData, goRoutinesManager, db)
+	newNode := en.child.insert(newData, goRoutinesManager, modifiedHashes, db)
 	if !goRoutinesManager.ShouldContinueProcessing() {
-		return newNode, oldHashes
+		return newNode
 	}
 
 	if check.IfNil(newNode) {
-		return nil, [][]byte{}
+		return nil
 	}
 
 	if !en.dirty {
-		oldHashes = append(oldHashes, en.hash)
+		modifiedHashes.Append([][]byte{en.hash})
 	}
 
 	newEn, err := newExtensionNode(en.Key, newNode, en.marsh, en.hasher)
 	if err != nil {
 		goRoutinesManager.SetError(err)
-		return nil, [][]byte{}
+		return nil
 	}
 
-	return newEn, oldHashes
+	return newEn
 }
 
 func (en *extensionNode) insertInNewBn(
 	newData []core.TrieData,
 	goRoutinesManager common.TrieGoroutinesManager,
+	modifiedHashes common.AtomicBytesSlice,
 	db common.TrieStorageInteractor,
 	keyMatchLen int,
 	index int,
-) (node, [][]byte) {
-	oldHash := make([][]byte, 0)
+) node {
 	if !en.dirty {
-		oldHash = append(oldHash, en.hash)
+		modifiedHashes.Append([][]byte{en.hash})
 	}
 
 	bn, err := newBranchNode(en.marsh, en.hasher)
 	if err != nil {
 		goRoutinesManager.SetError(err)
-		return nil, [][]byte{}
+		return nil
 	}
 
 	oldChildPos := en.Key[keyMatchLen]
 	newChildPos := newData[index].Key[keyMatchLen]
 	if childPosOutOfRange(oldChildPos) || childPosOutOfRange(newChildPos) {
 		goRoutinesManager.SetError(ErrChildPosOutOfRange)
-		return nil, [][]byte{}
+		return nil
 	}
 
 	err = en.insertOldChildInBn(bn, oldChildPos, keyMatchLen)
 	if err != nil {
 		goRoutinesManager.SetError(err)
-		return nil, [][]byte{}
+		return nil
 	}
 
 	newChild := newData[index]
@@ -459,35 +460,35 @@ func (en *extensionNode) insertInNewBn(
 	err = en.insertNewChildInBn(bn, newChild, newChildPos, keyMatchLen)
 	if err != nil {
 		goRoutinesManager.SetError(err)
-		return nil, [][]byte{}
+		return nil
 	}
 
 	err = removeCommonPrefix(newData, keyMatchLen)
 	if err != nil {
 		goRoutinesManager.SetError(err)
-		return nil, [][]byte{}
+		return nil
 	}
 
 	var newNode node
 	newNode = bn
 	if len(newData) != 0 {
-		newNode, _ = bn.insert(newData, goRoutinesManager, db)
+		newNode = bn.insert(newData, goRoutinesManager, modifiedHashes, db)
 		if !goRoutinesManager.ShouldContinueProcessing() {
-			return nil, [][]byte{}
+			return nil
 		}
 	}
 
 	if keyMatchLen == 0 {
-		return newNode, oldHash
+		return newNode
 	}
 
 	newEn, err := newExtensionNode(en.Key[:keyMatchLen], newNode, en.marsh, en.hasher)
 	if err != nil {
 		goRoutinesManager.SetError(err)
-		return nil, [][]byte{}
+		return nil
 	}
 
-	return newEn, oldHash
+	return newEn
 }
 
 func (en *extensionNode) insertOldChildInBn(bn *branchNode, oldChildPos byte, keyMatchLen int) error {
@@ -540,34 +541,35 @@ func (en *extensionNode) getDataWithMatchingPrefix(data []core.TrieData) []core.
 func (en *extensionNode) delete(
 	data []core.TrieData,
 	goRoutinesManager common.TrieGoroutinesManager,
+	modifiedHashes common.AtomicBytesSlice,
 	db common.TrieStorageInteractor,
-) (bool, node, [][]byte) {
+) (bool, node) {
 	err := en.isEmptyOrNil()
 	if err != nil {
 		goRoutinesManager.SetError(fmt.Errorf("delete error %w", err))
-		return false, nil, [][]byte{}
+		return false, nil
 	}
 
 	dataWithMatchingKey := en.getDataWithMatchingPrefix(data)
 	if len(dataWithMatchingKey) == 0 {
-		return false, en, [][]byte{}
+		return false, en
 	}
 	err = resolveIfCollapsed(en, 0, db)
 	if err != nil {
 		goRoutinesManager.SetError(err)
-		return false, nil, [][]byte{}
+		return false, nil
 	}
 
-	dirty, newNode, oldHashes := en.child.delete(dataWithMatchingKey, goRoutinesManager, db)
+	dirty, newNode := en.child.delete(dataWithMatchingKey, goRoutinesManager, modifiedHashes, db)
 	if !goRoutinesManager.ShouldContinueProcessing() {
-		return false, nil, [][]byte{}
+		return false, nil
 	}
 	if !dirty {
-		return false, en, [][]byte{}
+		return false, en
 	}
 
 	if !en.dirty {
-		oldHashes = append(oldHashes, en.hash)
+		modifiedHashes.Append([][]byte{en.hash})
 	}
 
 	switch newNode := newNode.(type) {
@@ -580,31 +582,31 @@ func (en *extensionNode) delete(
 		n, err := newLeafNode(newLeafData, en.marsh, en.hasher)
 		if err != nil {
 			goRoutinesManager.SetError(err)
-			return false, nil, [][]byte{}
+			return false, nil
 		}
 
-		return true, n, oldHashes
+		return true, n
 	case *extensionNode:
 		n, err := newExtensionNode(concat(en.Key, newNode.Key...), newNode.child, en.marsh, en.hasher)
 		if err != nil {
 			goRoutinesManager.SetError(err)
-			return false, nil, [][]byte{}
+			return false, nil
 		}
 
-		return true, n, oldHashes
+		return true, n
 	case *branchNode:
 		n, err := newExtensionNode(en.Key, newNode, en.marsh, en.hasher)
 		if err != nil {
 			goRoutinesManager.SetError(err)
-			return false, nil, [][]byte{}
+			return false, nil
 		}
 
-		return true, n, oldHashes
+		return true, n
 	case nil:
-		return true, nil, oldHashes
+		return true, nil
 	default:
 		goRoutinesManager.SetError(ErrInvalidNode)
-		return false, nil, oldHashes
+		return false, nil
 	}
 }
 

--- a/trie/extensionNode_test.go
+++ b/trie/extensionNode_test.go
@@ -498,7 +498,7 @@ func TestExtensionNode_insert(t *testing.T) {
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
-	newNode := en.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
+	newNode := en.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 
@@ -519,7 +519,7 @@ func TestExtensionNode_insertCollapsedNode(t *testing.T) {
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
-	newNode := collapsedEn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), db)
+	newNode := collapsedEn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 
@@ -544,7 +544,7 @@ func TestExtensionNode_insertInStoredEnSameKey(t *testing.T) {
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
-	modifiedHashes := common.NewModifiedHashesSlice()
+	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 	newNode := en.insert(data, goRoutinesManager, modifiedHashes, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
@@ -566,7 +566,7 @@ func TestExtensionNode_insertInStoredEnDifferentKey(t *testing.T) {
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
 
-	modifiedHashes := common.NewModifiedHashesSlice()
+	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 	newNode := en.insert(data, goRoutinesManager, modifiedHashes, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
@@ -582,7 +582,7 @@ func TestExtensionNode_insertInDirtyEnSameKey(t *testing.T) {
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
 
-	modifiedHashes := common.NewModifiedHashesSlice()
+	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 	newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
@@ -600,7 +600,7 @@ func TestExtensionNode_insertInDirtyEnDifferentKey(t *testing.T) {
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
 
-	modifiedHashes := common.NewModifiedHashesSlice()
+	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 	newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
@@ -615,7 +615,7 @@ func TestExtensionNode_insertInNilNode(t *testing.T) {
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion("key", "val")}
 
-	newNode := en.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
+	newNode := en.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
 	assert.Nil(t, newNode)
 	assert.True(t, errors.Is(goRoutinesManager.GetError(), ErrNilExtensionNode))
 	assert.Nil(t, newNode)
@@ -638,7 +638,7 @@ func TestExtensionNode_delete(t *testing.T) {
 	data := []core.TrieData{{Key: key}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	dirty, _ := en.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
+	dirty, _ := en.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	val, _, _ = en.tryGet(key, 0, nil)
@@ -664,7 +664,7 @@ func TestExtensionNode_deleteFromStoredEn(t *testing.T) {
 	data := []core.TrieData{{Key: lnPathKey}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	modifiedHashes := common.NewModifiedHashesSlice()
+	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 	dirty, _ := en.delete(data, goRoutinesManager, modifiedHashes, db)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
@@ -679,7 +679,7 @@ func TestExtensionNode_deleteFromDirtyEn(t *testing.T) {
 	data := []core.TrieData{{Key: lnKey}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	modifiedHashes := common.NewModifiedHashesSlice()
+	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 	dirty, _ := en.delete(data, goRoutinesManager, modifiedHashes, nil)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
@@ -693,7 +693,7 @@ func TestExtendedNode_deleteEmptyNode(t *testing.T) {
 	data := []core.TrieData{{Key: []byte("dog")}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	dirty, newNode := en.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
+	dirty, newNode := en.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
 	assert.False(t, dirty)
 	assert.True(t, errors.Is(goRoutinesManager.GetError(), ErrEmptyExtensionNode))
 	assert.Nil(t, newNode)
@@ -706,7 +706,7 @@ func TestExtensionNode_deleteNilNode(t *testing.T) {
 	data := []core.TrieData{{Key: []byte("dog")}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	dirty, newNode := en.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
+	dirty, newNode := en.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
 	assert.False(t, dirty)
 	assert.True(t, errors.Is(goRoutinesManager.GetError(), ErrNilExtensionNode))
 	assert.Nil(t, newNode)
@@ -731,7 +731,7 @@ func TestExtensionNode_deleteCollapsedNode(t *testing.T) {
 	data := []core.TrieData{{Key: key}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	dirty, newNode := collapsedEn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), db)
+	dirty, newNode := collapsedEn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), db)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	val, _, _ = newNode.tryGet(key, 0, db)
@@ -1258,7 +1258,7 @@ func TestExtensionNode_insertInSameEn(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes := common.NewModifiedHashesSlice()
+		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 0
@@ -1282,7 +1282,7 @@ func TestExtensionNode_insertInSameEn(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes := common.NewModifiedHashesSlice()
+		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 2
@@ -1318,7 +1318,7 @@ func TestExtensionNode_insertInNewBn(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes := common.NewModifiedHashesSlice()
+		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 1
@@ -1352,7 +1352,7 @@ func TestExtensionNode_insertInNewBn(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes := common.NewModifiedHashesSlice()
+		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 1
@@ -1385,7 +1385,7 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes := common.NewModifiedHashesSlice()
+		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		dirty, newNode := en.delete(data, goRoutinesManager, modifiedHashes, nil)
 		assert.False(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())
@@ -1408,7 +1408,7 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes := common.NewModifiedHashesSlice()
+		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		dirty, newNode := en.delete(data, goRoutinesManager, modifiedHashes, nil)
 		assert.True(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())
@@ -1431,7 +1431,7 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		_ = en.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
+		_ = en.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
 		err = en.commitDirty(0, 5, testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
 		assert.Nil(t, err)
 
@@ -1439,7 +1439,7 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 			getTrieDataWithDefaultVersion(string([]byte{1, 2, 7, 7, 8, 9}), "dog"),
 		}
 
-		modifiedHashes := common.NewModifiedHashesSlice()
+		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		dirty, newNode := en.delete(dataForRemoval, goRoutinesManager, modifiedHashes, nil)
 		assert.True(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())
@@ -1466,7 +1466,7 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes := common.NewModifiedHashesSlice()
+		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		dirty, newNode := en.delete(data, goRoutinesManager, modifiedHashes, nil)
 		assert.True(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())

--- a/trie/extensionNode_test.go
+++ b/trie/extensionNode_test.go
@@ -495,12 +495,10 @@ func TestExtensionNode_insert(t *testing.T) {
 	en, _ := getEnAndCollapsedEn()
 	key := []byte{100, 15, 5, 6}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
-	newNode, _ := en.insert(data, goRoutinesManager, nil)
+	newNode := en.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 
@@ -518,12 +516,10 @@ func TestExtensionNode_insertCollapsedNode(t *testing.T) {
 	_ = en.setHash()
 	_ = en.commitDirty(0, 5, db, db)
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
-	newNode, _ := collapsedEn.insert(data, goRoutinesManager, db)
+	newNode := collapsedEn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 
@@ -545,15 +541,14 @@ func TestExtensionNode_insertInStoredEnSameKey(t *testing.T) {
 	bnHash := bn.getHash()
 	expectedHashes := [][]byte{bnHash, enHash}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
-	newNode, oldHashes := en.insert(data, goRoutinesManager, db)
+	modifiedHashes := common.NewModifiedHashesSlice()
+	newNode := en.insert(data, goRoutinesManager, modifiedHashes, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
-	assert.Equal(t, expectedHashes, oldHashes)
+	assert.Equal(t, expectedHashes, modifiedHashes.Get())
 }
 
 func TestExtensionNode_insertInStoredEnDifferentKey(t *testing.T) {
@@ -568,15 +563,14 @@ func TestExtensionNode_insertInStoredEnDifferentKey(t *testing.T) {
 	_ = en.commitDirty(0, 5, db, db)
 	expectedHashes := [][]byte{en.getHash()}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
 
-	newNode, oldHashes := en.insert(data, goRoutinesManager, db)
+	modifiedHashes := common.NewModifiedHashesSlice()
+	newNode := en.insert(data, goRoutinesManager, modifiedHashes, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
-	assert.Equal(t, expectedHashes, oldHashes)
+	assert.True(t, slicesContainSameElements(expectedHashes, modifiedHashes.Get()))
 }
 
 func TestExtensionNode_insertInDirtyEnSameKey(t *testing.T) {
@@ -585,15 +579,14 @@ func TestExtensionNode_insertInDirtyEnSameKey(t *testing.T) {
 	en, _ := getEnAndCollapsedEn()
 	nodeKey := []byte{100, 11, 12}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
 
-	newNode, oldHashes := en.insert(data, goRoutinesManager, nil)
+	modifiedHashes := common.NewModifiedHashesSlice()
+	newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
-	assert.Equal(t, [][]byte{}, oldHashes)
+	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
 }
 
 func TestExtensionNode_insertInDirtyEnDifferentKey(t *testing.T) {
@@ -604,15 +597,14 @@ func TestExtensionNode_insertInDirtyEnDifferentKey(t *testing.T) {
 	en, _ := newExtensionNode(enKey, bn, bn.marsh, bn.hasher)
 	nodeKey := []byte{11, 12}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
 
-	newNode, oldHashes := en.insert(data, goRoutinesManager, nil)
+	modifiedHashes := common.NewModifiedHashesSlice()
+	newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
-	assert.Equal(t, [][]byte{}, oldHashes)
+	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
 }
 
 func TestExtensionNode_insertInNilNode(t *testing.T) {
@@ -620,12 +612,10 @@ func TestExtensionNode_insertInNilNode(t *testing.T) {
 
 	var en *extensionNode
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
+	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion("key", "val")}
 
-	newNode, _ := en.insert(data, goRoutinesManager, nil)
+	newNode := en.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.Nil(t, newNode)
 	assert.True(t, errors.Is(goRoutinesManager.GetError(), ErrNilExtensionNode))
 	assert.Nil(t, newNode)
@@ -647,11 +637,8 @@ func TestExtensionNode_delete(t *testing.T) {
 	assert.Equal(t, dogBytes, val)
 	data := []core.TrieData{{Key: key}}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
-	dirty, _, _ := en.delete(data, goRoutinesManager, nil)
+	goRoutinesManager := getTestGoroutinesManager()
+	dirty, _ := en.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	val, _, _ = en.tryGet(key, 0, nil)
@@ -676,14 +663,12 @@ func TestExtensionNode_deleteFromStoredEn(t *testing.T) {
 	expectedHashes := [][]byte{ln.getHash(), bn.getHash(), en.getHash()}
 	data := []core.TrieData{{Key: lnPathKey}}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
-	dirty, _, oldHashes := en.delete(data, goRoutinesManager, db)
+	goRoutinesManager := getTestGoroutinesManager()
+	modifiedHashes := common.NewModifiedHashesSlice()
+	dirty, _ := en.delete(data, goRoutinesManager, modifiedHashes, db)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
-	assert.Equal(t, expectedHashes, oldHashes)
+	assert.True(t, slicesContainSameElements(expectedHashes, modifiedHashes.Get()))
 }
 
 func TestExtensionNode_deleteFromDirtyEn(t *testing.T) {
@@ -693,14 +678,12 @@ func TestExtensionNode_deleteFromDirtyEn(t *testing.T) {
 	lnKey := []byte{100, 2, 100, 111, 103}
 	data := []core.TrieData{{Key: lnKey}}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
-	dirty, _, oldHashes := en.delete(data, goRoutinesManager, nil)
+	goRoutinesManager := getTestGoroutinesManager()
+	modifiedHashes := common.NewModifiedHashesSlice()
+	dirty, _ := en.delete(data, goRoutinesManager, modifiedHashes, nil)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
-	assert.Equal(t, [][]byte{}, oldHashes)
+	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
 }
 
 func TestExtendedNode_deleteEmptyNode(t *testing.T) {
@@ -709,11 +692,8 @@ func TestExtendedNode_deleteEmptyNode(t *testing.T) {
 	en := &extensionNode{}
 	data := []core.TrieData{{Key: []byte("dog")}}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
-	dirty, newNode, _ := en.delete(data, goRoutinesManager, nil)
+	goRoutinesManager := getTestGoroutinesManager()
+	dirty, newNode := en.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.False(t, dirty)
 	assert.True(t, errors.Is(goRoutinesManager.GetError(), ErrEmptyExtensionNode))
 	assert.Nil(t, newNode)
@@ -725,11 +705,8 @@ func TestExtensionNode_deleteNilNode(t *testing.T) {
 	var en *extensionNode
 	data := []core.TrieData{{Key: []byte("dog")}}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
-	dirty, newNode, _ := en.delete(data, goRoutinesManager, nil)
+	goRoutinesManager := getTestGoroutinesManager()
+	dirty, newNode := en.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 	assert.False(t, dirty)
 	assert.True(t, errors.Is(goRoutinesManager.GetError(), ErrNilExtensionNode))
 	assert.Nil(t, newNode)
@@ -753,11 +730,8 @@ func TestExtensionNode_deleteCollapsedNode(t *testing.T) {
 	assert.Equal(t, []byte("dog"), val)
 	data := []core.TrieData{{Key: key}}
 
-	th, _ := throttler.NewNumGoRoutinesThrottler(5)
-	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
-	assert.Nil(t, err)
-
-	dirty, newNode, _ := collapsedEn.delete(data, goRoutinesManager, db)
+	goRoutinesManager := getTestGoroutinesManager()
+	dirty, newNode := collapsedEn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), db)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	val, _, _ = newNode.tryGet(key, 0, db)
@@ -1284,10 +1258,11 @@ func TestExtensionNode_insertInSameEn(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		newNode, modifiedHashes := en.insert(data, goRoutinesManager, nil)
+		modifiedHashes := common.NewModifiedHashesSlice()
+		newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 0
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		assert.Nil(t, newNode)
 		assert.False(t, en.dirty)
 	})
@@ -1307,10 +1282,11 @@ func TestExtensionNode_insertInSameEn(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		newNode, modifiedHashes := en.insert(data, goRoutinesManager, nil)
+		modifiedHashes := common.NewModifiedHashesSlice()
+		newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 2
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		en, ok := newNode.(*extensionNode)
 		assert.True(t, ok)
 		assert.True(t, en.dirty)
@@ -1342,10 +1318,11 @@ func TestExtensionNode_insertInNewBn(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		newNode, modifiedHashes := en.insert(data, goRoutinesManager, nil)
+		modifiedHashes := common.NewModifiedHashesSlice()
+		newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 1
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		en, ok := newNode.(*extensionNode)
 		assert.True(t, ok)
 		assert.True(t, en.dirty)
@@ -1375,10 +1352,11 @@ func TestExtensionNode_insertInNewBn(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		newNode, modifiedHashes := en.insert(data, goRoutinesManager, nil)
+		modifiedHashes := common.NewModifiedHashesSlice()
+		newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 1
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		bn, ok := newNode.(*branchNode)
 		assert.True(t, ok)
 		assert.True(t, bn.dirty)
@@ -1407,11 +1385,12 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		dirty, newNode, modifiedHashes := en.delete(data, goRoutinesManager, nil)
+		modifiedHashes := common.NewModifiedHashesSlice()
+		dirty, newNode := en.delete(data, goRoutinesManager, modifiedHashes, nil)
 		assert.False(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 0
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		assert.Equal(t, en, newNode)
 	})
 	t.Run("reduce to leaf after delete", func(t *testing.T) {
@@ -1429,11 +1408,12 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		dirty, newNode, modifiedHashes := en.delete(data, goRoutinesManager, nil)
+		modifiedHashes := common.NewModifiedHashesSlice()
+		dirty, newNode := en.delete(data, goRoutinesManager, modifiedHashes, nil)
 		assert.True(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 4
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		ln, ok := newNode.(*leafNode)
 		assert.True(t, ok)
 		assert.Equal(t, []byte{1, 2, 7, 7, 8, 9}, ln.Key)
@@ -1451,7 +1431,7 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		_, _ = en.insert(data, goRoutinesManager, nil)
+		_ = en.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
 		err = en.commitDirty(0, 5, testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
 		assert.Nil(t, err)
 
@@ -1459,11 +1439,12 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 			getTrieDataWithDefaultVersion(string([]byte{1, 2, 7, 7, 8, 9}), "dog"),
 		}
 
-		dirty, newNode, modifiedHashes := en.delete(dataForRemoval, goRoutinesManager, nil)
+		modifiedHashes := common.NewModifiedHashesSlice()
+		dirty, newNode := en.delete(dataForRemoval, goRoutinesManager, modifiedHashes, nil)
 		assert.True(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 3
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		en, ok := newNode.(*extensionNode)
 		assert.True(t, ok)
 		assert.Equal(t, []byte{1, 2, 4}, en.Key)
@@ -1485,11 +1466,12 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		dirty, newNode, modifiedHashes := en.delete(data, goRoutinesManager, nil)
+		modifiedHashes := common.NewModifiedHashesSlice()
+		dirty, newNode := en.delete(data, goRoutinesManager, modifiedHashes, nil)
 		assert.True(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 4
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes))
+		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		assert.Nil(t, newNode)
 	})
 }

--- a/trie/goroutinesManager.go
+++ b/trie/goroutinesManager.go
@@ -1,0 +1,79 @@
+package trie
+
+import (
+	"sync"
+
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-go/common"
+)
+
+type goroutinesManager struct {
+	throttler    core.Throttler
+	errorChannel common.BufferedErrChan
+	chanClose    chan struct{}
+
+	mutex      sync.RWMutex
+	canProcess bool
+}
+
+func NewGoroutinesManager(
+	throttler core.Throttler,
+	errorChannel common.BufferedErrChan,
+	chanClose chan struct{},
+) (common.TrieGoroutinesManager, error) {
+	// TODO: check arguments and add logging in this file
+
+	return &goroutinesManager{
+		throttler:    throttler,
+		errorChannel: errorChannel,
+		chanClose:    chanClose,
+		canProcess:   true,
+	}, nil
+}
+
+func (gm *goroutinesManager) ShouldContinueProcessing() bool {
+	select {
+	case <-gm.chanClose:
+		return false
+	default:
+		gm.mutex.RLock()
+		defer gm.mutex.RUnlock()
+
+		return gm.canProcess
+	}
+}
+
+func (gm *goroutinesManager) CanStartGoRoutine() bool {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
+
+	if !gm.throttler.CanProcess() {
+		return false
+	}
+
+	gm.throttler.StartProcessing()
+	return true
+}
+
+func (gm *goroutinesManager) EndGoRoutineProcessing() {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
+
+	gm.throttler.EndProcessing()
+}
+
+func (gm *goroutinesManager) SetError(err error) {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
+
+	gm.errorChannel.WriteInChanNonBlocking(err)
+	gm.canProcess = false
+}
+
+func (gm *goroutinesManager) GetError() error {
+	return gm.errorChannel.ReadFromChanNonBlocking()
+}
+
+func (gm *goroutinesManager) IsInterfaceNil() bool {
+	return gm == nil
+}

--- a/trie/goroutinesManager.go
+++ b/trie/goroutinesManager.go
@@ -75,6 +75,20 @@ func (gm *goroutinesManager) EndGoRoutineProcessing() {
 	gm.throttler.EndProcessing()
 }
 
+// SetNewErrorChannel sets a new error channel
+func (gm *goroutinesManager) SetNewErrorChannel(errChan common.BufferedErrChan) error {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
+
+	err := gm.errorChannel.ReadFromChanNonBlocking()
+	if err != nil {
+		return err
+	}
+
+	gm.errorChannel = errChan
+	return nil
+}
+
 // SetError sets an error in the error channel
 func (gm *goroutinesManager) SetError(err error) {
 	gm.mutex.Lock()

--- a/trie/goroutinesManager.go
+++ b/trie/goroutinesManager.go
@@ -22,7 +22,7 @@ func NewGoroutinesManager(
 	throttler core.Throttler,
 	errorChannel common.BufferedErrChan,
 	chanClose chan struct{},
-) (common.TrieGoroutinesManager, error) {
+) (*goroutinesManager, error) {
 	if check.IfNil(throttler) {
 		return nil, ErrNilThrottler
 	}

--- a/trie/goroutinesManager_test.go
+++ b/trie/goroutinesManager_test.go
@@ -39,7 +39,7 @@ func TestNewGoroutinesManager(t *testing.T) {
 		manager, err := NewGoroutinesManager(&mock.ThrottlerStub{}, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.NotNil(t, manager)
 		assert.Nil(t, err)
-		assert.True(t, manager.(*goroutinesManager).canProcess)
+		assert.True(t, manager.canProcess)
 	})
 }
 
@@ -138,7 +138,7 @@ func TestGoroutinesManager_SetError(t *testing.T) {
 
 		err = errCh.ReadFromChanNonBlocking()
 		assert.Equal(t, expectedErr, err)
-		assert.False(t, manager.(*goroutinesManager).canProcess)
+		assert.False(t, manager.canProcess)
 	})
 	t.Run("set multiple errors should not block", func(t *testing.T) {
 		t.Parallel()
@@ -156,7 +156,7 @@ func TestGoroutinesManager_SetError(t *testing.T) {
 
 		err = errCh.ReadFromChanNonBlocking()
 		assert.Equal(t, expectedErr, err)
-		assert.False(t, manager.(*goroutinesManager).canProcess)
+		assert.False(t, manager.canProcess)
 	})
 }
 

--- a/trie/goroutinesManager_test.go
+++ b/trie/goroutinesManager_test.go
@@ -1,0 +1,177 @@
+package trie
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/multiversx/mx-chain-go/common/errChan"
+	"github.com/multiversx/mx-chain-go/trie/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewGoroutinesManager(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil throttler", func(t *testing.T) {
+		t.Parallel()
+
+		manager, err := NewGoroutinesManager(nil, nil, nil)
+		assert.Nil(t, manager)
+		assert.Equal(t, ErrNilThrottler, err)
+	})
+	t.Run("nil error channel", func(t *testing.T) {
+		t.Parallel()
+
+		manager, err := NewGoroutinesManager(&mock.ThrottlerStub{}, nil, nil)
+		assert.Nil(t, manager)
+		assert.Equal(t, ErrNilBufferedErrChan, err)
+	})
+	t.Run("nil chan close", func(t *testing.T) {
+		t.Parallel()
+
+		manager, err := NewGoroutinesManager(&mock.ThrottlerStub{}, errChan.NewErrChanWrapper(), nil)
+		assert.Nil(t, manager)
+		assert.Equal(t, ErrNilChanClose, err)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		manager, err := NewGoroutinesManager(&mock.ThrottlerStub{}, errChan.NewErrChanWrapper(), make(chan struct{}))
+		assert.NotNil(t, manager)
+		assert.Nil(t, err)
+		assert.True(t, manager.(*goroutinesManager).canProcess)
+	})
+}
+
+func TestGoroutinesManager_ShouldContinueProcessing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return false if chan is closed", func(t *testing.T) {
+		t.Parallel()
+
+		closeChan := make(chan struct{})
+		manager, _ := NewGoroutinesManager(&mock.ThrottlerStub{}, errChan.NewErrChanWrapper(), closeChan)
+
+		close(closeChan)
+		assert.False(t, manager.ShouldContinueProcessing())
+	})
+	t.Run("should return true if canProcess", func(t *testing.T) {
+		t.Parallel()
+
+		closeChan := make(chan struct{})
+		manager, _ := NewGoroutinesManager(&mock.ThrottlerStub{}, errChan.NewErrChanWrapper(), closeChan)
+
+		assert.True(t, manager.ShouldContinueProcessing())
+	})
+	t.Run("should return false if !canProcess", func(t *testing.T) {
+		t.Parallel()
+
+		manager := &goroutinesManager{
+			chanClose:  make(chan struct{}),
+			canProcess: false,
+		}
+
+		assert.False(t, manager.ShouldContinueProcessing())
+	})
+}
+
+func TestGoroutinesManager_CanStartGoRoutine(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return false if !throttler.CanProcess", func(t *testing.T) {
+		t.Parallel()
+
+		throttler := &mock.ThrottlerStub{
+			CanProcessCalled: func() bool {
+				return false
+			},
+		}
+		manager, _ := NewGoroutinesManager(throttler, errChan.NewErrChanWrapper(), make(chan struct{}))
+
+		assert.False(t, manager.CanStartGoRoutine())
+	})
+	t.Run("should return true if throttler.CanProcess", func(t *testing.T) {
+		t.Parallel()
+
+		startProcessingCalled := false
+		throttler := &mock.ThrottlerStub{
+			CanProcessCalled: func() bool {
+				return true
+			},
+			StartProcessingCalled: func() {
+				startProcessingCalled = true
+			},
+		}
+		manager, _ := NewGoroutinesManager(throttler, errChan.NewErrChanWrapper(), make(chan struct{}))
+
+		assert.True(t, manager.CanStartGoRoutine())
+		assert.True(t, startProcessingCalled)
+	})
+}
+
+func TestGoroutinesManager_EndGoRoutineProcessing(t *testing.T) {
+	t.Parallel()
+
+	endProcessingCalled := false
+	throttler := &mock.ThrottlerStub{
+		EndProcessingCalled: func() {
+			endProcessingCalled = true
+		},
+	}
+	manager, _ := NewGoroutinesManager(throttler, errChan.NewErrChanWrapper(), make(chan struct{}))
+	manager.EndGoRoutineProcessing()
+	assert.True(t, endProcessingCalled)
+}
+
+func TestGoroutinesManager_SetError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should set error", func(t *testing.T) {
+		expectedErr := errors.New("error")
+		errCh := errChan.NewErrChanWrapper()
+		manager, _ := NewGoroutinesManager(&mock.ThrottlerStub{}, errCh, make(chan struct{}))
+
+		err := errCh.ReadFromChanNonBlocking()
+		assert.Nil(t, err)
+
+		manager.SetError(expectedErr)
+
+		err = errCh.ReadFromChanNonBlocking()
+		assert.Equal(t, expectedErr, err)
+		assert.False(t, manager.(*goroutinesManager).canProcess)
+	})
+	t.Run("set multiple errors should not block", func(t *testing.T) {
+		t.Parallel()
+
+		expectedErr := errors.New("error")
+		anotherErr := errors.New("another error")
+		errCh := errChan.NewErrChanWrapper()
+		manager, _ := NewGoroutinesManager(&mock.ThrottlerStub{}, errCh, make(chan struct{}))
+
+		err := errCh.ReadFromChanNonBlocking()
+		assert.Nil(t, err)
+
+		manager.SetError(expectedErr)
+		manager.SetError(anotherErr)
+
+		err = errCh.ReadFromChanNonBlocking()
+		assert.Equal(t, expectedErr, err)
+		assert.False(t, manager.(*goroutinesManager).canProcess)
+	})
+}
+
+func TestGoroutinesManager_GetError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("error")
+	errCh := errChan.NewErrChanWrapper()
+	manager, _ := NewGoroutinesManager(&mock.ThrottlerStub{}, errCh, make(chan struct{}))
+
+	err := manager.GetError()
+	assert.Nil(t, err)
+
+	manager.SetError(expectedErr)
+
+	err = manager.GetError()
+	assert.Equal(t, expectedErr, err)
+}

--- a/trie/interface.go
+++ b/trie/interface.go
@@ -30,7 +30,7 @@ type node interface {
 	tryGet(key []byte, depth uint32, db common.TrieStorageInteractor) ([]byte, uint32, error)
 	getNext(key []byte, db common.TrieStorageInteractor) (node, []byte, error)
 	insert(newData []core.TrieData, goRoutinesManager common.TrieGoroutinesManager, db common.TrieStorageInteractor) (node, [][]byte)
-	delete(data []core.TrieData, db common.TrieStorageInteractor) (bool, node, [][]byte, error)
+	delete(data []core.TrieData, goRoutinesManager common.TrieGoroutinesManager, db common.TrieStorageInteractor) (bool, node, [][]byte)
 	reduceNode(pos int) (node, bool, error)
 	isEmptyOrNil() error
 	print(writer io.Writer, index int, db common.TrieStorageInteractor)

--- a/trie/interface.go
+++ b/trie/interface.go
@@ -29,8 +29,8 @@ type node interface {
 	hashChildren() error
 	tryGet(key []byte, depth uint32, db common.TrieStorageInteractor) ([]byte, uint32, error)
 	getNext(key []byte, db common.TrieStorageInteractor) (node, []byte, error)
-	insert(newData []core.TrieData, goRoutinesManager common.TrieGoroutinesManager, db common.TrieStorageInteractor) (node, [][]byte)
-	delete(data []core.TrieData, goRoutinesManager common.TrieGoroutinesManager, db common.TrieStorageInteractor) (bool, node, [][]byte)
+	insert(newData []core.TrieData, goRoutinesManager common.TrieGoroutinesManager, modifiedHashes common.AtomicBytesSlice, db common.TrieStorageInteractor) node
+	delete(data []core.TrieData, goRoutinesManager common.TrieGoroutinesManager, modifiedHashes common.AtomicBytesSlice, db common.TrieStorageInteractor) (bool, node)
 	reduceNode(pos int) (node, bool, error)
 	isEmptyOrNil() error
 	print(writer io.Writer, index int, db common.TrieStorageInteractor)

--- a/trie/interface.go
+++ b/trie/interface.go
@@ -29,7 +29,7 @@ type node interface {
 	hashChildren() error
 	tryGet(key []byte, depth uint32, db common.TrieStorageInteractor) ([]byte, uint32, error)
 	getNext(key []byte, db common.TrieStorageInteractor) (node, []byte, error)
-	insert(newData []core.TrieData, db common.TrieStorageInteractor) (node, [][]byte, error)
+	insert(newData []core.TrieData, goRoutinesManager common.TrieGoroutinesManager, db common.TrieStorageInteractor) (node, [][]byte)
 	delete(data []core.TrieData, db common.TrieStorageInteractor) (bool, node, [][]byte, error)
 	reduceNode(pos int) (node, bool, error)
 	isEmptyOrNil() error

--- a/trie/leafNode.go
+++ b/trie/leafNode.go
@@ -336,7 +336,11 @@ func (ln *leafNode) insertInNewBn(
 	return newNode
 }
 
-func (ln *leafNode) delete(data []core.TrieData, _ common.TrieStorageInteractor) (bool, node, [][]byte, error) {
+func (ln *leafNode) delete(
+	data []core.TrieData,
+	_ common.TrieGoroutinesManager,
+	_ common.TrieStorageInteractor,
+) (bool, node, [][]byte) {
 	for _, d := range data {
 		if bytes.Equal(d.Key, ln.Key) {
 			oldHash := make([][]byte, 0)
@@ -344,10 +348,10 @@ func (ln *leafNode) delete(data []core.TrieData, _ common.TrieStorageInteractor)
 				oldHash = append(oldHash, ln.hash)
 			}
 
-			return true, nil, oldHash, nil
+			return true, nil, oldHash
 		}
 	}
-	return false, ln, [][]byte{}, nil
+	return false, ln, [][]byte{}
 }
 
 func (ln *leafNode) reduceNode(pos int) (node, bool, error) {

--- a/trie/leafNode.go
+++ b/trie/leafNode.go
@@ -238,52 +238,56 @@ func (ln *leafNode) getNext(key []byte, _ common.TrieStorageInteractor) (node, [
 func (ln *leafNode) insert(
 	newData []core.TrieData,
 	goRoutinesManager common.TrieGoroutinesManager,
+	modifiedHashes common.AtomicBytesSlice,
 	db common.TrieStorageInteractor,
-) (node, [][]byte) {
+) node {
 	err := ln.isEmptyOrNil()
 	if err != nil {
 		goRoutinesManager.SetError(fmt.Errorf("insert error %w", err))
-		return nil, [][]byte{}
-	}
-
-	oldHash := make([][]byte, 0)
-	if !ln.dirty {
-		oldHash = append(oldHash, ln.hash)
+		return nil
 	}
 
 	if len(newData) == 1 && bytes.Equal(newData[0].Key, ln.Key) {
-		return ln.insertInSameLn(newData[0], oldHash)
+		return ln.insertInSameLn(newData[0], modifiedHashes)
 	}
 
 	keyMatchLen, _ := getMinKeyMatchLen(newData, ln.Key)
-	bn := ln.insertInNewBn(newData, keyMatchLen, goRoutinesManager, db)
+	bn := ln.insertInNewBn(newData, keyMatchLen, goRoutinesManager, modifiedHashes, db)
 	if !goRoutinesManager.ShouldContinueProcessing() {
-		return nil, [][]byte{}
+		return nil
+	}
+
+	if !ln.dirty {
+		modifiedHashes.Append([][]byte{ln.hash})
 	}
 
 	if keyMatchLen == 0 {
-		return bn, oldHash
+		return bn
 	}
 
 	newEn, err := newExtensionNode(ln.Key[:keyMatchLen], bn, ln.marsh, ln.hasher)
 	if err != nil {
 		goRoutinesManager.SetError(err)
-		return nil, [][]byte{}
+		return nil
 	}
 
-	return newEn, oldHash
+	return newEn
 }
 
-func (ln *leafNode) insertInSameLn(newData core.TrieData, oldHashes [][]byte) (node, [][]byte) {
+func (ln *leafNode) insertInSameLn(newData core.TrieData, modifiedHashes common.AtomicBytesSlice) node {
 	if bytes.Equal(ln.Value, newData.Value) {
-		return nil, [][]byte{}
+		return nil
+	}
+
+	if !ln.dirty {
+		modifiedHashes.Append([][]byte{ln.hash})
 	}
 
 	ln.Value = newData.Value
 	ln.Version = uint32(newData.Version)
 	ln.dirty = true
 	ln.hash = nil
-	return ln, oldHashes
+	return ln
 }
 
 func trimKeys(data []core.TrieData, keyMatchLen int) {
@@ -296,6 +300,7 @@ func (ln *leafNode) insertInNewBn(
 	newData []core.TrieData,
 	keyMatchLen int,
 	goRoutinesManager common.TrieGoroutinesManager,
+	modifiedHashes common.AtomicBytesSlice,
 	db common.TrieStorageInteractor,
 ) node {
 	bn, err := newBranchNode(ln.marsh, ln.hasher)
@@ -332,26 +337,25 @@ func (ln *leafNode) insertInNewBn(
 	bn.setVersionForChild(lnVersion, posForOldLn)
 
 	trimKeys(newData, keyMatchLen)
-	newNode, _ := bn.insert(newData, goRoutinesManager, db)
-	return newNode
+	return bn.insert(newData, goRoutinesManager, modifiedHashes, db)
 }
 
 func (ln *leafNode) delete(
 	data []core.TrieData,
 	_ common.TrieGoroutinesManager,
+	modifiedHashes common.AtomicBytesSlice,
 	_ common.TrieStorageInteractor,
-) (bool, node, [][]byte) {
+) (bool, node) {
 	for _, d := range data {
 		if bytes.Equal(d.Key, ln.Key) {
-			oldHash := make([][]byte, 0)
 			if !ln.dirty {
-				oldHash = append(oldHash, ln.hash)
+				modifiedHashes.Append([][]byte{ln.hash})
 			}
 
-			return true, nil, oldHash
+			return true, nil
 		}
 	}
-	return false, ln, [][]byte{}
+	return false, ln
 }
 
 func (ln *leafNode) reduceNode(pos int) (node, bool, error) {

--- a/trie/leafNode_test.go
+++ b/trie/leafNode_test.go
@@ -327,7 +327,7 @@ func TestLeafNode_insertAtSameKey(t *testing.T) {
 	data := []core.TrieData{getTrieDataWithDefaultVersion(key, expectedVal)}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	newNode := ln.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
+	newNode := ln.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 
@@ -348,7 +348,7 @@ func TestLeafNode_insertAtDifferentKey(t *testing.T) {
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), string(nodeVal))}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	newNode := ln.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
+	newNode := ln.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 
@@ -367,7 +367,7 @@ func TestLeafNode_insertInStoredLnAtSameKey(t *testing.T) {
 	data := []core.TrieData{getTrieDataWithDefaultVersion("dog", "dogs")}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	modifiedHashes := common.NewModifiedHashesSlice()
+	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 	newNode := ln.insert(data, goRoutinesManager, modifiedHashes, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
@@ -385,7 +385,7 @@ func TestLeafNode_insertInStoredLnAtDifferentKey(t *testing.T) {
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string([]byte{4, 5, 6}), "dogs")}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	modifiedHashes := common.NewModifiedHashesSlice()
+	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 	newNode := ln.insert(data, goRoutinesManager, modifiedHashes, db)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
@@ -399,7 +399,7 @@ func TestLeafNode_insertInDirtyLnAtSameKey(t *testing.T) {
 	data := []core.TrieData{getTrieDataWithDefaultVersion("dog", "dogs")}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	modifiedHashes := common.NewModifiedHashesSlice()
+	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 	newNode := ln.insert(data, goRoutinesManager, modifiedHashes, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
@@ -414,7 +414,7 @@ func TestLeafNode_insertInDirtyLnAtDifferentKey(t *testing.T) {
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string([]byte{4, 5, 6}), "dogs")}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	modifiedHashes := common.NewModifiedHashesSlice()
+	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 	newNode := ln.insert(data, goRoutinesManager, modifiedHashes, nil)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
@@ -428,7 +428,7 @@ func TestLeafNode_insertInNilNode(t *testing.T) {
 	data := []core.TrieData{getTrieDataWithDefaultVersion("dog", "dogs")}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	newNode := ln.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
+	newNode := ln.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
 	assert.Nil(t, newNode)
 	assert.True(t, errors.Is(goRoutinesManager.GetError(), ErrNilLeafNode))
 	assert.Nil(t, newNode)
@@ -441,7 +441,7 @@ func TestLeafNode_deletePresent(t *testing.T) {
 	data := []core.TrieData{{Key: []byte("dog")}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	dirty, newNode := ln.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
+	dirty, newNode := ln.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Nil(t, newNode)
@@ -457,7 +457,7 @@ func TestLeafNode_deleteFromStoredLnAtSameKey(t *testing.T) {
 	data := []core.TrieData{{Key: []byte("dog")}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	modifiedHashes := common.NewModifiedHashesSlice()
+	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 	dirty, _ := ln.delete(data, goRoutinesManager, modifiedHashes, db)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
@@ -474,7 +474,7 @@ func TestLeafNode_deleteFromLnAtDifferentKey(t *testing.T) {
 	data := []core.TrieData{{Key: wrongKey}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	modifiedHashes := common.NewModifiedHashesSlice()
+	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 	dirty, _ := ln.delete(data, goRoutinesManager, modifiedHashes, db)
 	assert.False(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
@@ -488,7 +488,7 @@ func TestLeafNode_deleteFromDirtyLnAtSameKey(t *testing.T) {
 	data := []core.TrieData{{Key: []byte("dog")}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	modifiedHashes := common.NewModifiedHashesSlice()
+	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 	dirty, _ := ln.delete(data, goRoutinesManager, modifiedHashes, nil)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
@@ -503,7 +503,7 @@ func TestLeafNode_deleteNotPresent(t *testing.T) {
 	data := []core.TrieData{{Key: wrongKey}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	dirty, newNode := ln.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(), nil)
+	dirty, newNode := ln.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
 	assert.False(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, ln, newNode)
@@ -830,7 +830,7 @@ func TestLeafNode_insertBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes := common.NewModifiedHashesSlice()
+		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		newNode := ln.insert(newData, goRoutinesManager, modifiedHashes, nil)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.True(t, newNode.isDirty())
@@ -851,7 +851,7 @@ func TestLeafNode_insertBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes := common.NewModifiedHashesSlice()
+		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		newNode := ln.insert(newData, goRoutinesManager, modifiedHashes, nil)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Nil(t, newNode)
@@ -876,7 +876,7 @@ func TestLeafNode_insertBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes := common.NewModifiedHashesSlice()
+		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		newNode := ln.insert(newData, goRoutinesManager, modifiedHashes, nil)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Equal(t, [][]byte{originalHash}, modifiedHashes.Get())
@@ -907,7 +907,7 @@ func TestLeafNode_insertBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes := common.NewModifiedHashesSlice()
+		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		newNode := ln.insert(newData, goRoutinesManager, modifiedHashes, nil)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Equal(t, [][]byte{originalHash}, modifiedHashes.Get())
@@ -939,7 +939,7 @@ func TestLeafNode_deleteBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes := common.NewModifiedHashesSlice()
+		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		dirty, newNode := ln.delete(newData, goRoutinesManager, modifiedHashes, nil)
 		assert.True(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())
@@ -961,7 +961,7 @@ func TestLeafNode_deleteBatch(t *testing.T) {
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
 
-		modifiedHashes := common.NewModifiedHashesSlice()
+		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		dirty, newNode := ln.delete(newData, goRoutinesManager, modifiedHashes, nil)
 		assert.False(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())

--- a/trie/leafNode_test.go
+++ b/trie/leafNode_test.go
@@ -456,9 +456,13 @@ func TestLeafNode_deletePresent(t *testing.T) {
 	ln := getLn(getTestMarshalizerAndHasher())
 	data := []core.TrieData{{Key: []byte("dog")}}
 
-	dirty, newNode, _, err := ln.delete(data, nil)
-	assert.True(t, dirty)
+	th, _ := throttler.NewNumGoRoutinesThrottler(5)
+	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 	assert.Nil(t, err)
+
+	dirty, newNode, _ := ln.delete(data, goRoutinesManager, nil)
+	assert.True(t, dirty)
+	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Nil(t, newNode)
 }
 
@@ -471,9 +475,13 @@ func TestLeafNode_deleteFromStoredLnAtSameKey(t *testing.T) {
 	lnHash := ln.getHash()
 	data := []core.TrieData{{Key: []byte("dog")}}
 
-	dirty, _, oldHashes, err := ln.delete(data, db)
-	assert.True(t, dirty)
+	th, _ := throttler.NewNumGoRoutinesThrottler(5)
+	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 	assert.Nil(t, err)
+
+	dirty, _, oldHashes := ln.delete(data, goRoutinesManager, db)
+	assert.True(t, dirty)
+	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{lnHash}, oldHashes)
 }
 
@@ -486,9 +494,13 @@ func TestLeafNode_deleteFromLnAtDifferentKey(t *testing.T) {
 	wrongKey := []byte{1, 2, 3}
 	data := []core.TrieData{{Key: wrongKey}}
 
-	dirty, _, oldHashes, err := ln.delete(data, db)
-	assert.False(t, dirty)
+	th, _ := throttler.NewNumGoRoutinesThrottler(5)
+	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 	assert.Nil(t, err)
+
+	dirty, _, oldHashes := ln.delete(data, goRoutinesManager, db)
+	assert.False(t, dirty)
+	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, oldHashes)
 }
 
@@ -498,9 +510,13 @@ func TestLeafNode_deleteFromDirtyLnAtSameKey(t *testing.T) {
 	ln := getLn(getTestMarshalizerAndHasher())
 	data := []core.TrieData{{Key: []byte("dog")}}
 
-	dirty, _, oldHashes, err := ln.delete(data, nil)
-	assert.True(t, dirty)
+	th, _ := throttler.NewNumGoRoutinesThrottler(5)
+	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 	assert.Nil(t, err)
+
+	dirty, _, oldHashes := ln.delete(data, goRoutinesManager, nil)
+	assert.True(t, dirty)
+	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, oldHashes)
 }
 
@@ -511,9 +527,13 @@ func TestLeafNode_deleteNotPresent(t *testing.T) {
 	wrongKey := []byte{1, 2, 3}
 	data := []core.TrieData{{Key: wrongKey}}
 
-	dirty, newNode, _, err := ln.delete(data, nil)
-	assert.False(t, dirty)
+	th, _ := throttler.NewNumGoRoutinesThrottler(5)
+	goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 	assert.Nil(t, err)
+
+	dirty, newNode, _ := ln.delete(data, goRoutinesManager, nil)
+	assert.False(t, dirty)
+	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, ln, newNode)
 }
 
@@ -939,9 +959,13 @@ func TestLeafNode_deleteBatch(t *testing.T) {
 		_ = ln.commitDirty(0, 5, testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
 		originalHash := ln.getHash()
 
-		dirty, newNode, modifiedHashes, err := ln.delete(newData, nil)
-		assert.True(t, dirty)
+		th, _ := throttler.NewNumGoRoutinesThrottler(5)
+		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
+
+		dirty, newNode, modifiedHashes := ln.delete(newData, goRoutinesManager, nil)
+		assert.True(t, dirty)
+		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Nil(t, newNode)
 		assert.Equal(t, [][]byte{originalHash}, modifiedHashes)
 	})
@@ -956,9 +980,13 @@ func TestLeafNode_deleteBatch(t *testing.T) {
 		}
 		_ = ln.commitDirty(0, 5, testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
 
-		dirty, newNode, modifiedHashes, err := ln.delete(newData, nil)
-		assert.False(t, dirty)
+		th, _ := throttler.NewNumGoRoutinesThrottler(5)
+		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}))
 		assert.Nil(t, err)
+
+		dirty, newNode, modifiedHashes := ln.delete(newData, goRoutinesManager, nil)
+		assert.False(t, dirty)
+		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Equal(t, ln, newNode)
 		assert.Equal(t, [][]byte{}, modifiedHashes)
 	})

--- a/trie/mock/throttlerStub.go
+++ b/trie/mock/throttlerStub.go
@@ -1,0 +1,40 @@
+package mock
+
+// ThrottlerStub -
+type ThrottlerStub struct {
+	CanProcessCalled      func() bool
+	StartProcessingCalled func()
+	EndProcessingCalled   func()
+	StartWasCalled        bool
+	EndWasCalled          bool
+}
+
+// CanProcess -
+func (ts *ThrottlerStub) CanProcess() bool {
+	if ts.CanProcessCalled != nil {
+		return ts.CanProcessCalled()
+	}
+
+	return true
+}
+
+// StartProcessing -
+func (ts *ThrottlerStub) StartProcessing() {
+	ts.StartWasCalled = true
+	if ts.StartProcessingCalled != nil {
+		ts.StartProcessingCalled()
+	}
+}
+
+// EndProcessing -
+func (ts *ThrottlerStub) EndProcessing() {
+	ts.EndWasCalled = true
+	if ts.EndProcessingCalled != nil {
+		ts.EndProcessingCalled()
+	}
+}
+
+// IsInterfaceNil -
+func (ts *ThrottlerStub) IsInterfaceNil() bool {
+	return ts == nil
+}

--- a/trie/node.go
+++ b/trie/node.go
@@ -4,9 +4,11 @@ package trie
 import (
 	"context"
 	"runtime/debug"
+	"sync"
 	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
@@ -36,6 +38,7 @@ type branchNode struct {
 	CollapsedBn
 	children [nrOfChildren]node
 	*baseNode
+	mutex sync.RWMutex
 }
 
 type extensionNode struct {
@@ -137,9 +140,8 @@ func treatLogError(logInstance logger.Logger, err error, key []byte) {
 }
 
 func resolveIfCollapsed(n node, pos byte, db common.TrieStorageInteractor) error {
-	err := n.isEmptyOrNil()
-	if err != nil {
-		return err
+	if check.IfNil(n) {
+		return ErrNilNode
 	}
 
 	if !n.isPosCollapsed(int(pos)) {

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -260,7 +260,7 @@ func TestNode_resolveIfCollapsedNilNode(t *testing.T) {
 	var nodeInstance *extensionNode
 
 	err := resolveIfCollapsed(nodeInstance, 0, nil)
-	assert.Equal(t, ErrNilExtensionNode, err)
+	assert.Equal(t, ErrNilNode, err)
 }
 
 func TestNode_concat(t *testing.T) {

--- a/trie/patriciaMerkleTrie.go
+++ b/trie/patriciaMerkleTrie.go
@@ -218,7 +218,8 @@ func (tr *patriciaMerkleTrie) insertBatch(sortedDataForInsertion []core.TrieData
 		return err
 	}
 
-	newRoot, oldHashes := tr.root.insert(sortedDataForInsertion, manager, tr.trieStorage)
+	oldHashes := common.NewModifiedHashesSlice()
+	newRoot := tr.root.insert(sortedDataForInsertion, manager, oldHashes, tr.trieStorage)
 	err = manager.GetError()
 	if err != nil {
 		return err
@@ -229,9 +230,10 @@ func (tr *patriciaMerkleTrie) insertBatch(sortedDataForInsertion []core.TrieData
 	}
 
 	tr.root = newRoot
-	tr.oldHashes = append(tr.oldHashes, oldHashes...)
+	hashes := oldHashes.Get()
+	tr.oldHashes = append(tr.oldHashes, hashes...)
 
-	logArrayWithTrace("oldHashes after insert", "hash", oldHashes)
+	logArrayWithTrace("oldHashes after insert", "hash", hashes)
 	return nil
 }
 
@@ -253,13 +255,15 @@ func (tr *patriciaMerkleTrie) deleteBatch(data []core.TrieData) error {
 		return err
 	}
 
-	_, newRoot, oldHashes := tr.root.delete(data, manager, tr.trieStorage)
+	modifiedHashes := common.NewModifiedHashesSlice()
+	_, newRoot := tr.root.delete(data, manager, modifiedHashes, tr.trieStorage)
 	err = manager.GetError()
 	if err != nil {
 		return err
 	}
 
 	tr.root = newRoot
+	oldHashes := modifiedHashes.Get()
 	tr.oldHashes = append(tr.oldHashes, oldHashes...)
 	logArrayWithTrace("oldHashes after delete", "hash", oldHashes)
 

--- a/trie/patriciaMerkleTrie.go
+++ b/trie/patriciaMerkleTrie.go
@@ -248,10 +248,17 @@ func (tr *patriciaMerkleTrie) deleteBatch(data []core.TrieData) error {
 		tr.oldRoot = tr.root.getHash()
 	}
 
-	_, newRoot, oldHashes, err := tr.root.delete(data, tr.trieStorage)
+	manager, err := NewGoroutinesManager(tr.goroutinesThrottler, errChan.NewErrChanWrapper(), tr.chanClose)
 	if err != nil {
 		return err
 	}
+
+	_, newRoot, oldHashes := tr.root.delete(data, manager, tr.trieStorage)
+	err = manager.GetError()
+	if err != nil {
+		return err
+	}
+
 	tr.root = newRoot
 	tr.oldHashes = append(tr.oldHashes, oldHashes...)
 	logArrayWithTrace("oldHashes after delete", "hash", oldHashes)


### PR DESCRIPTION
## Reasoning behind the pull request
- All the trie changes are put in a batch. When a commit occurs, the changes batch is added to the trie, but the changes are done in serial. 
  
## Proposed changes
- When the changes from the batch need to be added to the trie, use goroutines where possible in order to speed up the update of the trie 


## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
