### PR TITLE
[sovereign] Shard Storage handler

### DIFF
--- a/epochStart/bootstrap/baseStorageHandler.go
+++ b/epochStart/bootstrap/baseStorageHandler.go
@@ -195,14 +195,28 @@ func (bsh *baseStorageHandler) saveShardHdrToStorage(hdr data.HeaderHandler) ([]
 	return headerHash, nil
 }
 
-func (bsh *baseStorageHandler) saveMetaHdrForEpochTrigger(metaBlock data.HeaderHandler) error {
+func (ssh *baseStorageHandler) saveEpochStartMetaHdrs(components *ComponentsNeededForBootstrap, metaHdrStorerType dataRetriever.UnitType) error {
+	err := ssh.saveMetaHdrForEpochTrigger(components.EpochStartMetaBlock, metaHdrStorerType)
+	if err != nil {
+		return err
+	}
+
+	err = ssh.saveMetaHdrForEpochTrigger(components.PreviousEpochStart, metaHdrStorerType)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (bsh *baseStorageHandler) saveMetaHdrForEpochTrigger(metaBlock data.HeaderHandler, metaHdrStorerType dataRetriever.UnitType) error {
 	lastHeaderBytes, err := bsh.marshalizer.Marshal(metaBlock)
 	if err != nil {
 		return err
 	}
 
 	epochStartIdentifier := core.EpochStartIdentifier(metaBlock.GetEpoch())
-	metaHdrStorage, err := bsh.storageService.GetStorer(dataRetriever.MetaBlockUnit)
+	metaHdrStorage, err := bsh.storageService.GetStorer(metaHdrStorerType)
 	if err != nil {
 		return err
 	}

--- a/epochStart/bootstrap/bootStrapSovereignShardProcessor.go
+++ b/epochStart/bootstrap/bootStrapSovereignShardProcessor.go
@@ -44,13 +44,15 @@ func (e *sovereignBootStrapShardProcessor) requestAndProcessForShard(peerMiniBlo
 		return err
 	}
 
-	defer storageHandlerComponent.CloseStorageService()
+	sovStorageHandler := newSovereignShardStorageHandler(storageHandlerComponent)
+
+	defer sovStorageHandler.CloseStorageService()
 
 	e.closeTrieComponents()
 	triesContainer, trieStorageManagers, err := factory.CreateTriesComponentsForShardId(
 		e.generalConfig,
 		e.coreComponentsHolder,
-		storageHandlerComponent.storageService,
+		sovStorageHandler.storageService,
 		e.stateStatsHandler,
 	)
 	if err != nil {
@@ -83,7 +85,7 @@ func (e *sovereignBootStrapShardProcessor) requestAndProcessForShard(peerMiniBlo
 		PeerMiniBlocks:      peerMiniBlocks,
 	}
 
-	return storageHandlerComponent.SaveDataToStorage(components, e.epochStartMeta, false, make(map[string]*block.MiniBlock))
+	return sovStorageHandler.SaveDataToStorage(components, e.epochStartMeta, false, make(map[string]*block.MiniBlock))
 }
 
 func (e *sovereignBootStrapShardProcessor) computeNumShards(_ data.MetaHeaderHandler) uint32 {

--- a/epochStart/bootstrap/bootStrapSovereignShardProcessor_test.go
+++ b/epochStart/bootstrap/bootStrapSovereignShardProcessor_test.go
@@ -86,23 +86,6 @@ func TestBootStrapSovereignShardProcessor_requestAndProcessForShard(t *testing.T
 
 	err := sovProc.requestAndProcessForShard(make([]*block.MiniBlock, 0))
 	require.Nil(t, err)
-
-	// take this and use to test sov bootstrapper
-	/*
-		//epochStartBlock_0
-		bootStorer, err := sovProc.storageService.GetStorer(dataRetriever.BootstrapUnit)
-		require.Nil(t, err)
-
-		roundToUseAsKey := int64(metaBlockInstance.GetRound())
-		key := []byte(strconv.FormatInt(roundToUseAsKey, 10))
-		bootStrapDataBytes, err := bootStorer.Get(key)
-		require.Nil(t, err)
-
-		bootStrapData := &bootstrapStorage.BootstrapData{}
-
-		err = sovProc.coreComponentsHolder.InternalMarshalizer().Unmarshal(bootStrapData, bootStrapDataBytes)
-		require.Nil(t, err)
-	*/
 }
 
 func TestBootStrapSovereignShardProcessor_computeNumShards(t *testing.T) {

--- a/epochStart/bootstrap/bootStrapSovereignShardProcessor_test.go
+++ b/epochStart/bootstrap/bootStrapSovereignShardProcessor_test.go
@@ -84,10 +84,25 @@ func TestBootStrapSovereignShardProcessor_requestAndProcessForShard(t *testing.T
 		},
 	}
 
-	// This will not work properly until we have a sovereign shard storage handler and
-	// overwrite SaveDataToStorage, tbd in next PRs
 	err := sovProc.requestAndProcessForShard(make([]*block.MiniBlock, 0))
-	require.NotNil(t, err)
+	require.Nil(t, err)
+
+	// take this and use to test sov bootstrapper
+	/*
+		//epochStartBlock_0
+		bootStorer, err := sovProc.storageService.GetStorer(dataRetriever.BootstrapUnit)
+		require.Nil(t, err)
+
+		roundToUseAsKey := int64(metaBlockInstance.GetRound())
+		key := []byte(strconv.FormatInt(roundToUseAsKey, 10))
+		bootStrapDataBytes, err := bootStorer.Get(key)
+		require.Nil(t, err)
+
+		bootStrapData := &bootstrapStorage.BootstrapData{}
+
+		err = sovProc.coreComponentsHolder.InternalMarshalizer().Unmarshal(bootStrapData, bootStrapDataBytes)
+		require.Nil(t, err)
+	*/
 }
 
 func TestBootStrapSovereignShardProcessor_computeNumShards(t *testing.T) {

--- a/epochStart/bootstrap/interface.go
+++ b/epochStart/bootstrap/interface.go
@@ -109,3 +109,7 @@ type bootStrapShardProcessorHandler interface {
 	) (map[string]data.HeaderHandler, error)
 	processNodesConfigFromStorage(pubKey []byte, importDBTargetShardID uint32) (nodesCoordinator.NodesCoordinatorRegistryHandler, uint32, error)
 }
+
+type shardTriggerRegistryHandler interface {
+	GetEpochStartHeaderHandler() data.HeaderHandler
+}

--- a/epochStart/bootstrap/metaStorageHandler.go
+++ b/epochStart/bootstrap/metaStorageHandler.go
@@ -87,12 +87,7 @@ func (msh *metaStorageHandler) SaveDataToStorage(components *ComponentsNeededFor
 		return err
 	}
 
-	err = msh.saveMetaHdrForEpochTrigger(components.EpochStartMetaBlock)
-	if err != nil {
-		return err
-	}
-
-	err = msh.saveMetaHdrForEpochTrigger(components.PreviousEpochStart)
+	err = msh.saveEpochStartMetaHdrs(components, dataRetriever.MetaBlockUnit)
 	if err != nil {
 		return err
 	}

--- a/epochStart/bootstrap/shardSovereignStorageHandler.go
+++ b/epochStart/bootstrap/shardSovereignStorageHandler.go
@@ -1,0 +1,138 @@
+package bootstrap
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/dataRetriever"
+	"github.com/multiversx/mx-chain-go/process"
+	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
+)
+
+type sovereignShardStorageHandler struct {
+	*shardStorageHandler
+}
+
+// internal constructor, no need to check for nils
+func newSovereignShardStorageHandler(shardStorageHandler *shardStorageHandler) *sovereignShardStorageHandler {
+	return &sovereignShardStorageHandler{
+		shardStorageHandler,
+	}
+}
+
+// SaveDataToStorage will save the fetched data to storage, so it will be used by the storage bootstrap component
+func (ssh *sovereignShardStorageHandler) SaveDataToStorage(components *ComponentsNeededForBootstrap, notarizedShardHeader data.HeaderHandler, withScheduled bool, syncedMiniBlocks map[string]*block.MiniBlock) error {
+	bootStorer, err := ssh.storageService.GetStorer(dataRetriever.BootstrapUnit)
+	if err != nil {
+		return err
+	}
+
+	lastHeader, err := ssh.saveLastHeader(components.ShardHeader)
+	if err != nil {
+		return err
+	}
+
+	err = ssh.saveEpochStartMetaHdrs(components)
+	if err != nil {
+		return err
+	}
+
+	ssh.saveMiniblocksFromComponents(components)
+
+	log.Debug("saving synced miniblocks", "num miniblocks", len(syncedMiniBlocks))
+	ssh.saveMiniblocks(syncedMiniBlocks)
+
+	triggerConfigKey, err := ssh.saveTriggerRegistry(components)
+	if err != nil {
+		return err
+	}
+
+	components.NodesConfig.SetCurrentEpoch(components.ShardHeader.GetEpoch())
+	nodesCoordinatorConfigKey, err := ssh.saveNodesCoordinatorRegistry(components.EpochStartMetaBlock, components.NodesConfig)
+	if err != nil {
+		return err
+	}
+
+	bootStrapData := bootstrapStorage.BootstrapData{
+		LastHeader:                 lastHeader,
+		LastCrossNotarizedHeaders:  []bootstrapStorage.BootstrapHeaderInfo{},
+		LastSelfNotarizedHeaders:   []bootstrapStorage.BootstrapHeaderInfo{lastHeader},
+		ProcessedMiniBlocks:        []bootstrapStorage.MiniBlocksInMeta{},
+		PendingMiniBlocks:          []bootstrapStorage.PendingMiniBlocksInfo{},
+		NodesCoordinatorConfigKey:  nodesCoordinatorConfigKey,
+		EpochStartTriggerConfigKey: triggerConfigKey,
+		HighestFinalBlockNonce:     lastHeader.Nonce,
+		LastRound:                  0,
+	}
+	bootStrapDataBytes, err := ssh.marshalizer.Marshal(&bootStrapData)
+	if err != nil {
+		return err
+	}
+
+	roundToUseAsKey := int64(components.ShardHeader.GetRound())
+	roundNum := bootstrapStorage.RoundNum{Num: roundToUseAsKey}
+	roundNumBytes, err := ssh.marshalizer.Marshal(&roundNum)
+	if err != nil {
+		return err
+	}
+
+	err = bootStorer.Put([]byte(common.HighestRoundFromBootStorage), roundNumBytes)
+	if err != nil {
+		return err
+	}
+
+	log.Info("saved bootstrap data to storage", "round", roundToUseAsKey)
+	key := []byte(strconv.FormatInt(roundToUseAsKey, 10))
+	err = bootStorer.Put(key, bootStrapDataBytes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ssh *sovereignShardStorageHandler) saveTriggerRegistry(components *ComponentsNeededForBootstrap) ([]byte, error) {
+	sovHeader, castOk := components.EpochStartMetaBlock.(*block.SovereignChainHeader)
+	if !castOk {
+		return nil, fmt.Errorf("%w in sovereignShardStorageHandler.saveTriggerRegistry", process.ErrWrongTypeAssertion)
+	}
+
+	metaBlockHash, err := core.CalculateHash(ssh.marshalizer, ssh.hasher, sovHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	triggerReg := block.SovereignShardTriggerRegistry{
+		Epoch:                       sovHeader.GetEpoch(),
+		CurrentRound:                sovHeader.GetRound(),
+		EpochFinalityAttestingRound: sovHeader.GetRound(),
+		CurrEpochStartRound:         sovHeader.GetRound(),
+		PrevEpochStartRound:         components.PreviousEpochStart.GetRound(),
+		EpochStartMetaHash:          metaBlockHash,
+		SovereignChainHeader:        sovHeader,
+	}
+
+	bootstrapKey := []byte(fmt.Sprint(sovHeader.GetRound()))
+	trigInternalKey := append([]byte(common.TriggerRegistryKeyPrefix), bootstrapKey...)
+
+	triggerRegBytes, err := ssh.marshalizer.Marshal(&triggerReg)
+	if err != nil {
+		return nil, err
+	}
+
+	bootstrapStorer, err := ssh.storageService.GetStorer(dataRetriever.BootstrapUnit)
+	if err != nil {
+		return nil, err
+	}
+
+	errPut := bootstrapStorer.Put(trigInternalKey, triggerRegBytes)
+	if errPut != nil {
+		return nil, errPut
+	}
+
+	return bootstrapKey, nil
+}

--- a/epochStart/bootstrap/shardSovereignStorageHandler.go
+++ b/epochStart/bootstrap/shardSovereignStorageHandler.go
@@ -6,7 +6,6 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
-	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
@@ -87,23 +86,5 @@ func (ssh *sovereignShardStorageHandler) saveTriggerRegistry(components *Compone
 		SovereignChainHeader:        sovHeader,
 	}
 
-	bootstrapKey := []byte(fmt.Sprint(sovHeader.GetRound()))
-	trigInternalKey := append([]byte(common.TriggerRegistryKeyPrefix), bootstrapKey...)
-
-	triggerRegBytes, err := ssh.marshalizer.Marshal(&triggerReg)
-	if err != nil {
-		return nil, err
-	}
-
-	bootstrapStorer, err := ssh.storageService.GetStorer(dataRetriever.BootstrapUnit)
-	if err != nil {
-		return nil, err
-	}
-
-	errPut := bootstrapStorer.Put(trigInternalKey, triggerRegBytes)
-	if errPut != nil {
-		return nil, errPut
-	}
-
-	return bootstrapKey, nil
+	return ssh.baseSaveTriggerRegistry(&triggerReg, sovHeader.GetRound())
 }

--- a/epochStart/bootstrap/shardSovereignStorageHandler_test.go
+++ b/epochStart/bootstrap/shardSovereignStorageHandler_test.go
@@ -1,0 +1,126 @@
+package bootstrap
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-go/dataRetriever"
+	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
+	"github.com/multiversx/mx-chain-go/sharding/nodesCoordinator"
+	"github.com/multiversx/mx-chain-go/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getStoredBootstrapData(
+	t *testing.T,
+	sovShardStorage *sovereignShardStorageHandler,
+	bootStorer storage.Storer,
+	round uint64,
+) *bootstrapStorage.BootstrapData {
+	roundToUseAsKey := int64(round)
+	key := []byte(strconv.FormatInt(roundToUseAsKey, 10))
+	bootStrapDataBytes, err := bootStorer.Get(key)
+	require.Nil(t, err)
+
+	bootStrapData := &bootstrapStorage.BootstrapData{}
+	err = sovShardStorage.marshalizer.Unmarshal(bootStrapData, bootStrapDataBytes)
+	require.Nil(t, err)
+
+	return bootStrapData
+}
+
+func TestSovereignShardStorageHandler_SaveDataToStorage(t *testing.T) {
+	t.Parallel()
+
+	args := createStorageHandlerArgs()
+	shardStorage, _ := NewShardStorageHandler(args)
+	sovShardStorage := newSovereignShardStorageHandler(shardStorage)
+
+	hash1 := []byte("hash1")
+	hash2 := []byte("hash2")
+	hdr1 := &block.SovereignChainHeader{
+		Header: &block.Header{
+			Nonce: 1,
+			Round: 1,
+			Epoch: 1,
+		},
+	}
+	hdr2 := &block.SovereignChainHeader{
+		Header: &block.Header{
+			Nonce: 2,
+			Round: 2,
+			Epoch: 2,
+		},
+	}
+	headers := map[string]data.HeaderHandler{
+		string(hash1): hdr1,
+		string(hash2): hdr2,
+	}
+
+	components := &ComponentsNeededForBootstrap{
+		EpochStartMetaBlock: hdr1,
+		PreviousEpochStart:  hdr2,
+		ShardHeader:         hdr1,
+		Headers:             headers,
+		NodesConfig:         &nodesCoordinator.NodesCoordinatorRegistry{},
+	}
+
+	err := sovShardStorage.SaveDataToStorage(components, components.ShardHeader, false, nil)
+	assert.Nil(t, err)
+
+	bootStorer, err := sovShardStorage.storageService.GetStorer(dataRetriever.BootstrapUnit)
+	require.Nil(t, err)
+
+	hdrHash, err := core.CalculateHash(sovShardStorage.marshalizer, sovShardStorage.hasher, hdr1)
+	require.Nil(t, err)
+
+	bootStrapData := getStoredBootstrapData(t, sovShardStorage, bootStorer, hdr1.GetRound())
+	require.Equal(t, &bootstrapStorage.BootstrapData{
+		LastHeader: bootstrapStorage.BootstrapHeaderInfo{
+			Nonce: 1,
+			Epoch: 1,
+			Hash:  hdrHash,
+		},
+		LastCrossNotarizedHeaders: []bootstrapStorage.BootstrapHeaderInfo{},
+		LastSelfNotarizedHeaders: []bootstrapStorage.BootstrapHeaderInfo{{
+			Nonce: 1,
+			Epoch: 1,
+			Hash:  hdrHash,
+		}},
+		ProcessedMiniBlocks:        []bootstrapStorage.MiniBlocksInMeta{},
+		PendingMiniBlocks:          []bootstrapStorage.PendingMiniBlocksInfo{},
+		NodesCoordinatorConfigKey:  nil,
+		EpochStartTriggerConfigKey: []byte(fmt.Sprint(1)),
+		HighestFinalBlockNonce:     hdr1.GetNonce(),
+		LastRound:                  0,
+	}, bootStrapData)
+
+	hdr1Bytes, err := bootStorer.Get([]byte("epochStartBlock_1"))
+	require.Nil(t, err)
+
+	hdr2Bytes, err := bootStorer.Get([]byte("epochStartBlock_2"))
+	require.Nil(t, err)
+
+	hdr1Stored := &block.SovereignChainHeader{}
+	err = sovShardStorage.marshalizer.Unmarshal(hdr1Stored, hdr1Bytes)
+	require.Nil(t, err)
+	require.Equal(t, hdr1, hdr1Stored)
+
+	hdr2Stored := &block.SovereignChainHeader{}
+	err = sovShardStorage.marshalizer.Unmarshal(hdr2Stored, hdr2Bytes)
+	require.Nil(t, err)
+	require.Equal(t, hdr2, hdr2Stored)
+
+	// no meta block unit storage key saved
+	metaStorer, err := sovShardStorage.storageService.GetStorer(dataRetriever.MetaBlockUnit)
+	require.Nil(t, err)
+	_, err = metaStorer.Get([]byte("epochStartBlock_1"))
+	require.NotNil(t, err)
+	_, err = metaStorer.Get([]byte("epochStartBlock_2"))
+	require.NotNil(t, err)
+}

--- a/epochStart/bootstrap/shardSovereignStorageHandler_test.go
+++ b/epochStart/bootstrap/shardSovereignStorageHandler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
 	"github.com/multiversx/mx-chain-go/sharding/nodesCoordinator"
@@ -18,7 +19,7 @@ import (
 
 func getStoredBootstrapData(
 	t *testing.T,
-	sovShardStorage *sovereignShardStorageHandler,
+	marshaller marshal.Marshalizer,
 	bootStorer storage.Storer,
 	round uint64,
 ) *bootstrapStorage.BootstrapData {
@@ -28,7 +29,7 @@ func getStoredBootstrapData(
 	require.Nil(t, err)
 
 	bootStrapData := &bootstrapStorage.BootstrapData{}
-	err = sovShardStorage.marshalizer.Unmarshal(bootStrapData, bootStrapDataBytes)
+	err = marshaller.Unmarshal(bootStrapData, bootStrapDataBytes)
 	require.Nil(t, err)
 
 	return bootStrapData
@@ -79,7 +80,7 @@ func TestSovereignShardStorageHandler_SaveDataToStorage(t *testing.T) {
 	hdrHash, err := core.CalculateHash(sovShardStorage.marshalizer, sovShardStorage.hasher, hdr1)
 	require.Nil(t, err)
 
-	bootStrapData := getStoredBootstrapData(t, sovShardStorage, bootStorer, hdr1.GetRound())
+	bootStrapData := getStoredBootstrapData(t, sovShardStorage.marshalizer, bootStorer, hdr1.GetRound())
 	require.Equal(t, &bootstrapStorage.BootstrapData{
 		LastHeader: bootstrapStorage.BootstrapHeaderInfo{
 			Nonce: 1,

--- a/epochStart/bootstrap/shardStorageHandler.go
+++ b/epochStart/bootstrap/shardStorageHandler.go
@@ -81,17 +81,12 @@ func (ssh *shardStorageHandler) CloseStorageService() {
 
 // SaveDataToStorage will save the fetched data to storage, so it will be used by the storage bootstrap component
 func (ssh *shardStorageHandler) SaveDataToStorage(components *ComponentsNeededForBootstrap, notarizedShardHeader data.HeaderHandler, withScheduled bool, syncedMiniBlocks map[string]*block.MiniBlock) error {
-	bootStorer, err := ssh.storageService.GetStorer(dataRetriever.BootstrapUnit)
-	if err != nil {
-		return err
-	}
-
 	lastHeader, err := ssh.saveLastHeader(components.ShardHeader)
 	if err != nil {
 		return err
 	}
 
-	err = ssh.saveEpochStartMetaHdrs(components)
+	err = ssh.saveEpochStartMetaHdrs(components, dataRetriever.MetaBlockUnit)
 	if err != nil {
 		return err
 	}
@@ -133,6 +128,18 @@ func (ssh *shardStorageHandler) SaveDataToStorage(components *ComponentsNeededFo
 		HighestFinalBlockNonce:     lastHeader.Nonce,
 		LastRound:                  0,
 	}
+	return ssh.saveBootStrapData(components, bootStrapData)
+}
+
+func (ssh *shardStorageHandler) saveBootStrapData(
+	components *ComponentsNeededForBootstrap,
+	bootStrapData bootstrapStorage.BootstrapData,
+) error {
+	bootStorer, err := ssh.storageService.GetStorer(dataRetriever.BootstrapUnit)
+	if err != nil {
+		return err
+	}
+
 	bootStrapDataBytes, err := ssh.marshalizer.Marshal(&bootStrapData)
 	if err != nil {
 		return err
@@ -153,20 +160,6 @@ func (ssh *shardStorageHandler) SaveDataToStorage(components *ComponentsNeededFo
 	log.Info("saved bootstrap data to storage", "round", roundToUseAsKey)
 	key := []byte(strconv.FormatInt(roundToUseAsKey, 10))
 	err = bootStorer.Put(key, bootStrapDataBytes)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (ssh *shardStorageHandler) saveEpochStartMetaHdrs(components *ComponentsNeededForBootstrap) error {
-	err := ssh.saveMetaHdrForEpochTrigger(components.EpochStartMetaBlock)
-	if err != nil {
-		return err
-	}
-
-	err = ssh.saveMetaHdrForEpochTrigger(components.PreviousEpochStart)
 	if err != nil {
 		return err
 	}

--- a/epochStart/bootstrap/shardStorageHandler.go
+++ b/epochStart/bootstrap/shardStorageHandler.go
@@ -828,10 +828,14 @@ func (ssh *shardStorageHandler) saveTriggerRegistry(components *ComponentsNeeded
 		EpochStartShardHeader:       &block.Header{},
 	}
 
-	bootstrapKey := []byte(fmt.Sprint(shardHeader.GetRound()))
+	return ssh.baseSaveTriggerRegistry(&triggerReg, shardHeader.GetRound())
+}
+
+func (ssh *shardStorageHandler) baseSaveTriggerRegistry(triggerReg shardTriggerRegistryHandler, round uint64) ([]byte, error) {
+	bootstrapKey := []byte(fmt.Sprint(round))
 	trigInternalKey := append([]byte(common.TriggerRegistryKeyPrefix), bootstrapKey...)
 
-	triggerRegBytes, err := ssh.marshalizer.Marshal(&triggerReg)
+	triggerRegBytes, err := ssh.marshalizer.Marshal(triggerReg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- Sovereign shard storage handler for bootstrap
  
## Proposed changes
- Used internal `sovereignShardStorageHandler` constructor to be used in `sovereignBootStrapShardProcessor` for saving bootstrap data.
- `SaveDataToStorage` is a bit of combination of both `shardStorageHandler` & `metaStorageHandler`, but more inspired by meta one. Please careful review here

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
