### PR TITLE
[sovereign] Save metrics for committed block

### DIFF
--- a/process/block/metrics.go
+++ b/process/block/metrics.go
@@ -84,7 +84,7 @@ func getMetricsFromHeader(
 	appStatusHandler.SetUInt64Value(common.MetricTxPoolLoad, numTxWithDst)
 }
 
-func saveMetricsForCommittedShardBlock(
+func saveMetricsForCommittedShardAndCrossBlock(
 	nodesCoordinator nodesCoordinator.NodesCoordinator,
 	appStatusHandler core.AppStatusHandler,
 	currentBlockHash string,
@@ -93,12 +93,23 @@ func saveMetricsForCommittedShardBlock(
 	shardHeader data.HeaderHandler,
 	managedPeersHolder common.ManagedPeersHolder,
 ) {
+	baseSaveMetricsForCommittedShardBlock(nodesCoordinator, appStatusHandler, currentBlockHash, highestFinalBlockNonce, shardHeader, managedPeersHolder)
+	appStatusHandler.SetStringValue(common.MetricCrossCheckBlockHeight, fmt.Sprintf("meta %d", metaBlock.GetNonce()))
+	appStatusHandler.SetUInt64Value(common.MetricCrossCheckBlockHeightMeta, metaBlock.GetNonce())
+}
+
+func baseSaveMetricsForCommittedShardBlock(
+	nodesCoordinator nodesCoordinator.NodesCoordinator,
+	appStatusHandler core.AppStatusHandler,
+	currentBlockHash string,
+	highestFinalBlockNonce uint64,
+	shardHeader data.HeaderHandler,
+	managedPeersHolder common.ManagedPeersHolder,
+) {
 	incrementMetricCountConsensusAcceptedBlocks(shardHeader, shardHeader.GetEpoch(), nodesCoordinator, appStatusHandler, managedPeersHolder)
 	appStatusHandler.SetUInt64Value(common.MetricEpochNumber, uint64(shardHeader.GetEpoch()))
 	appStatusHandler.SetStringValue(common.MetricCurrentBlockHash, currentBlockHash)
 	appStatusHandler.SetUInt64Value(common.MetricHighestFinalBlock, highestFinalBlockNonce)
-	appStatusHandler.SetStringValue(common.MetricCrossCheckBlockHeight, fmt.Sprintf("meta %d", metaBlock.GetNonce()))
-	appStatusHandler.SetUInt64Value(common.MetricCrossCheckBlockHeightMeta, metaBlock.GetNonce())
 }
 
 func saveMetricsForCommitMetachainBlock(

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -1043,7 +1043,7 @@ func (sp *shardProcessor) CommitBlock(
 		return err
 	}
 
-	saveMetricsForCommittedShardBlock(
+	saveMetricsForCommittedShardAndCrossBlock(
 		sp.nodesCoordinator,
 		sp.appStatusHandler,
 		logger.DisplayByteSlice(headerHash),

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -1515,6 +1515,7 @@ func (scbp *sovereignChainBlockProcessor) CommitBlock(headerHandler data.HeaderH
 	if err != nil {
 		return err
 	}
+
 	// TODO: MX-15748 Analyse if !check.IfNil(lastMetaBlock) && lastMetaBlock.IsStartOfEpochBlock() from metablock.go
 	err = scbp.commonHeaderAndBodyCommit(headerHandler, body, headerHash, []data.HeaderHandler{lastSelfNotarizedHeader}, [][]byte{lastSelfNotarizedHeaderHash})
 	if err != nil {


### PR DESCRIPTION
## Reasoning behind the pull request
- Save missing metrics for committed sovereign block
- Added cross metric for main chain notarized header, similar to the one from meta chain on mainnet

## Proposed changes
- 
- 
- 

## Testing procedure
```
/ 20241002182609
// http://127.0.0.1:10000/network/status

{
  "data": {
    "status": {
      "erd_block_timestamp": 1727882769,
      "erd_cross_check_block_height": "mainChain 0",
      "erd_current_round": 451,
      "erd_epoch_number": 20,
      "erd_highest_final_nonce": 450,
      "erd_nonce": 451,
      "erd_nonce_at_epoch_start": 440,
      "erd_nonces_passed_in_current_epoch": 11,
      "erd_round_at_epoch_start": 440,
      "erd_rounds_passed_in_current_epoch": 11,
      "erd_rounds_per_epoch": 21
    }
  },
  "error": "",
  "code": "successful"
}
```

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
