### PR TITLE
[sovereign] Extend staked node tests

### DIFF
--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
@@ -102,7 +102,7 @@ func TestSovereignChainSimulator_EpochChange(t *testing.T) {
 	require.Empty(t, accFeesInEpoch.Bytes())
 	require.Empty(t, devFeesInEpoch.Bytes())
 
-	staking.StakeNodes(t, cs, 10)
+	staking.StakeNodes(t, cs, nodeHandler, 10)
 	err = nodeHandler.GetProcessComponents().ValidatorsProvider().ForceUpdate()
 	require.Nil(t, err)
 

--- a/integrationTests/chainSimulator/staking/stake/stakeAndUnStake_test.go
+++ b/integrationTests/chainSimulator/staking/stake/stakeAndUnStake_test.go
@@ -2526,7 +2526,7 @@ func TestChainSimulator_EdgeCaseLowWaitingList(t *testing.T) {
 	require.Equal(t, 0, len(unQualified))
 
 	// stake 16 mode nodes, these will go to auction list
-	staking.StakeNodes(t, cs, 17)
+	staking.StakeNodes(t, cs, metachainNode, 17)
 
 	epochToCheck += 1
 	err = cs.GenerateBlocksUntilEpochIsReached(epochToCheck)
@@ -2558,7 +2558,7 @@ func checkKeysNotInMap(t *testing.T, m map[uint32][][]byte, keys []string) {
 }
 
 func stakeOneNode(t *testing.T, cs chainSimulatorIntegrationTests.ChainSimulator) {
-	txStake := staking.CreateStakeTransaction(t, cs)
+	txStake, _ := staking.CreateStakeTransaction(t, cs)
 	stakeTx, err := cs.SendTxAndGenerateBlockTilTxIsExecuted(txStake, staking.MaxNumOfBlockToGenerateWhenExecutingTx)
 	require.Nil(t, err)
 	require.NotNil(t, stakeTx)


### PR DESCRIPTION
## Reasoning behind the pull request
- Check vm query staked bls key status for staked nodes in integration tests for sovereign
  
## Proposed changes
- 
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
