### PR TITLE
fix gas used and fee relayed v3

### DIFF
--- a/genesis/process/disabled/feeHandler.go
+++ b/genesis/process/disabled/feeHandler.go
@@ -12,6 +12,16 @@ import (
 type FeeHandler struct {
 }
 
+// ComputeRelayedTxV3GasUnits -
+func (fh *FeeHandler) ComputeRelayedTxV3GasUnits(_ data.TransactionWithFeeHandler, _ uint32) uint64 {
+	return 0
+}
+
+// ComputeGasUnitsFromRefundValue -
+func (fh *FeeHandler) ComputeGasUnitsFromRefundValue(_ data.TransactionWithFeeHandler, _ *big.Int) uint64 {
+	return 0
+}
+
 // GasPriceModifier returns 1.0
 func (fh *FeeHandler) GasPriceModifier() float64 {
 	return 1.0

--- a/genesis/process/disabled/feeHandler.go
+++ b/genesis/process/disabled/feeHandler.go
@@ -18,7 +18,7 @@ func (fh *FeeHandler) ComputeRelayedTxV3GasUnits(_ data.TransactionWithFeeHandle
 }
 
 // ComputeGasUnitsFromRefundValue -
-func (fh *FeeHandler) ComputeGasUnitsFromRefundValue(_ data.TransactionWithFeeHandler, _ *big.Int) uint64 {
+func (fh *FeeHandler) ComputeGasUnitsFromRefundValue(_ data.TransactionWithFeeHandler, _ *big.Int, _ uint32) uint64 {
 	return 0
 }
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/multiversx/mx-chain-communication-go v1.1.0
 	github.com/multiversx/mx-chain-core-go v1.2.23-0.20241017083841-5e7b1485b6a1
 	github.com/multiversx/mx-chain-crypto-go v1.2.12
-	github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241011172845-d1739bada80e
+	github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241017103233-5709b0b0c463
 	github.com/multiversx/mx-chain-logger-go v1.0.15
 	github.com/multiversx/mx-chain-scenario-go v1.4.4
 	github.com/multiversx/mx-chain-storage-go v1.0.16

--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,9 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.5
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiversx/mx-chain-communication-go v1.1.0
-	github.com/multiversx/mx-chain-core-go v1.2.23-0.20241017083841-5e7b1485b6a1
+	github.com/multiversx/mx-chain-core-go v1.2.23-0.20241018055916-203f32de05ad
 	github.com/multiversx/mx-chain-crypto-go v1.2.12
-	github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241017103233-5709b0b0c463
+	github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241018070419-4c779fec3824
 	github.com/multiversx/mx-chain-logger-go v1.0.15
 	github.com/multiversx/mx-chain-scenario-go v1.4.4
 	github.com/multiversx/mx-chain-storage-go v1.0.16

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.5
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiversx/mx-chain-communication-go v1.1.0
-	github.com/multiversx/mx-chain-core-go v1.2.23-0.20241016115557-6a55050d2ade
+	github.com/multiversx/mx-chain-core-go v1.2.23-0.20241017083841-5e7b1485b6a1
 	github.com/multiversx/mx-chain-crypto-go v1.2.12
 	github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241011172845-d1739bada80e
 	github.com/multiversx/mx-chain-logger-go v1.0.15

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.5
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiversx/mx-chain-communication-go v1.1.0
-	github.com/multiversx/mx-chain-core-go v1.2.22
+	github.com/multiversx/mx-chain-core-go v1.2.23-0.20241016115557-6a55050d2ade
 	github.com/multiversx/mx-chain-crypto-go v1.2.12
 	github.com/multiversx/mx-chain-es-indexer-go v1.7.9
 	github.com/multiversx/mx-chain-logger-go v1.0.15

--- a/go.sum
+++ b/go.sum
@@ -391,8 +391,8 @@ github.com/multiversx/mx-chain-core-go v1.2.23-0.20241017083841-5e7b1485b6a1 h1:
 github.com/multiversx/mx-chain-core-go v1.2.23-0.20241017083841-5e7b1485b6a1/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
 github.com/multiversx/mx-chain-crypto-go v1.2.12 h1:zWip7rpUS4CGthJxfKn5MZfMfYPjVjIiCID6uX5BSOk=
 github.com/multiversx/mx-chain-crypto-go v1.2.12/go.mod h1:HzcPpCm1zanNct/6h2rIh+MFrlXbjA5C8+uMyXj3LI4=
-github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241011172845-d1739bada80e h1:cj4kURXUPtjdSHeXPQolpkfduZV2AmF352Py0rLyEAI=
-github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241011172845-d1739bada80e/go.mod h1:oGcRK2E3Syv6vRTszWrrb/TqD8akq0yeoMr1wPPiTO4=
+github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241017103233-5709b0b0c463 h1:GWq3HCJTG0rLoiSMl+PjY0RSQl2c3djv84QJ/qCP/jM=
+github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241017103233-5709b0b0c463/go.mod h1:2yLQoJbanIr46hOqlZcvYVxFyboP4C1KJL+Zjp2io+U=
 github.com/multiversx/mx-chain-logger-go v1.0.15 h1:HlNdK8etyJyL9NQ+6mIXyKPEBo+wRqOwi3n+m2QIHXc=
 github.com/multiversx/mx-chain-logger-go v1.0.15/go.mod h1:t3PRKaWB1M+i6gUfD27KXgzLJJC+mAQiN+FLlL1yoGQ=
 github.com/multiversx/mx-chain-scenario-go v1.4.4 h1:DVE2V+FPeyD/yWoC+KEfPK3jsFzHeruelESfpTlf460=

--- a/go.sum
+++ b/go.sum
@@ -387,8 +387,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.1.0 h1:J7bX6HoN3HiHY7cUeEjG8AJWgQDDPcY+OPDOsSUOkRE=
 github.com/multiversx/mx-chain-communication-go v1.1.0/go.mod h1:WK6bP4pGEHGDDna/AYRIMtl6G9OA0NByI1Lw8PmOnRM=
-github.com/multiversx/mx-chain-core-go v1.2.22 h1:yDYrvoQOBbsDerEp7L3+de5AfMy3pTF333gWPpd+FNk=
-github.com/multiversx/mx-chain-core-go v1.2.22/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
+github.com/multiversx/mx-chain-core-go v1.2.23-0.20241016115557-6a55050d2ade h1:29XqGze9121Z4UxujgEeiBdNS9Nw9Q+VC7w62iVGk7o=
+github.com/multiversx/mx-chain-core-go v1.2.23-0.20241016115557-6a55050d2ade/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
 github.com/multiversx/mx-chain-crypto-go v1.2.12 h1:zWip7rpUS4CGthJxfKn5MZfMfYPjVjIiCID6uX5BSOk=
 github.com/multiversx/mx-chain-crypto-go v1.2.12/go.mod h1:HzcPpCm1zanNct/6h2rIh+MFrlXbjA5C8+uMyXj3LI4=
 github.com/multiversx/mx-chain-es-indexer-go v1.7.9 h1:rWq9phJu8GG6TtoJ5cL+MmhyReWCEyqBE5ymXUvudCg=

--- a/go.sum
+++ b/go.sum
@@ -387,12 +387,12 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.1.0 h1:J7bX6HoN3HiHY7cUeEjG8AJWgQDDPcY+OPDOsSUOkRE=
 github.com/multiversx/mx-chain-communication-go v1.1.0/go.mod h1:WK6bP4pGEHGDDna/AYRIMtl6G9OA0NByI1Lw8PmOnRM=
-github.com/multiversx/mx-chain-core-go v1.2.23-0.20241016115557-6a55050d2ade h1:29XqGze9121Z4UxujgEeiBdNS9Nw9Q+VC7w62iVGk7o=
-github.com/multiversx/mx-chain-core-go v1.2.23-0.20241016115557-6a55050d2ade/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
+github.com/multiversx/mx-chain-core-go v1.2.23-0.20241017083841-5e7b1485b6a1 h1:TyWMSr3wx1DR3rlKnp7Iw/nEMYDp7any7DtMpz2aAlU=
+github.com/multiversx/mx-chain-core-go v1.2.23-0.20241017083841-5e7b1485b6a1/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
 github.com/multiversx/mx-chain-crypto-go v1.2.12 h1:zWip7rpUS4CGthJxfKn5MZfMfYPjVjIiCID6uX5BSOk=
 github.com/multiversx/mx-chain-crypto-go v1.2.12/go.mod h1:HzcPpCm1zanNct/6h2rIh+MFrlXbjA5C8+uMyXj3LI4=
-github.com/multiversx/mx-chain-es-indexer-go v1.7.9 h1:rWq9phJu8GG6TtoJ5cL+MmhyReWCEyqBE5ymXUvudCg=
-github.com/multiversx/mx-chain-es-indexer-go v1.7.9/go.mod h1:oGcRK2E3Syv6vRTszWrrb/TqD8akq0yeoMr1wPPiTO4=
+github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241011172845-d1739bada80e h1:cj4kURXUPtjdSHeXPQolpkfduZV2AmF352Py0rLyEAI=
+github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241011172845-d1739bada80e/go.mod h1:oGcRK2E3Syv6vRTszWrrb/TqD8akq0yeoMr1wPPiTO4=
 github.com/multiversx/mx-chain-logger-go v1.0.15 h1:HlNdK8etyJyL9NQ+6mIXyKPEBo+wRqOwi3n+m2QIHXc=
 github.com/multiversx/mx-chain-logger-go v1.0.15/go.mod h1:t3PRKaWB1M+i6gUfD27KXgzLJJC+mAQiN+FLlL1yoGQ=
 github.com/multiversx/mx-chain-scenario-go v1.4.4 h1:DVE2V+FPeyD/yWoC+KEfPK3jsFzHeruelESfpTlf460=

--- a/go.sum
+++ b/go.sum
@@ -387,12 +387,12 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.1.0 h1:J7bX6HoN3HiHY7cUeEjG8AJWgQDDPcY+OPDOsSUOkRE=
 github.com/multiversx/mx-chain-communication-go v1.1.0/go.mod h1:WK6bP4pGEHGDDna/AYRIMtl6G9OA0NByI1Lw8PmOnRM=
-github.com/multiversx/mx-chain-core-go v1.2.23-0.20241017083841-5e7b1485b6a1 h1:TyWMSr3wx1DR3rlKnp7Iw/nEMYDp7any7DtMpz2aAlU=
-github.com/multiversx/mx-chain-core-go v1.2.23-0.20241017083841-5e7b1485b6a1/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
+github.com/multiversx/mx-chain-core-go v1.2.23-0.20241018055916-203f32de05ad h1:EFWFNts9am6Dp+tJxYiHfsepK4TF0J931mTEZ3Aireo=
+github.com/multiversx/mx-chain-core-go v1.2.23-0.20241018055916-203f32de05ad/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
 github.com/multiversx/mx-chain-crypto-go v1.2.12 h1:zWip7rpUS4CGthJxfKn5MZfMfYPjVjIiCID6uX5BSOk=
 github.com/multiversx/mx-chain-crypto-go v1.2.12/go.mod h1:HzcPpCm1zanNct/6h2rIh+MFrlXbjA5C8+uMyXj3LI4=
-github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241017103233-5709b0b0c463 h1:GWq3HCJTG0rLoiSMl+PjY0RSQl2c3djv84QJ/qCP/jM=
-github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241017103233-5709b0b0c463/go.mod h1:2yLQoJbanIr46hOqlZcvYVxFyboP4C1KJL+Zjp2io+U=
+github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241018070419-4c779fec3824 h1:vC8PQ6+w2geSm2z+aA100L6ixMY0dIx7MtaMXUKnByo=
+github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241018070419-4c779fec3824/go.mod h1:F1gsY0L3Cth/7ajD8Aw9YIqFAPXBnY+f5gKjLEjsYQE=
 github.com/multiversx/mx-chain-logger-go v1.0.15 h1:HlNdK8etyJyL9NQ+6mIXyKPEBo+wRqOwi3n+m2QIHXc=
 github.com/multiversx/mx-chain-logger-go v1.0.15/go.mod h1:t3PRKaWB1M+i6gUfD27KXgzLJJC+mAQiN+FLlL1yoGQ=
 github.com/multiversx/mx-chain-scenario-go v1.4.4 h1:DVE2V+FPeyD/yWoC+KEfPK3jsFzHeruelESfpTlf460=

--- a/node/external/timemachine/fee/feeComputer.go
+++ b/node/external/timemachine/fee/feeComputer.go
@@ -45,6 +45,11 @@ func (computer *feeComputer) ComputeGasLimit(tx *transaction.ApiTransactionResul
 	return computer.economicsInstance.ComputeGasLimitInEpoch(tx.Tx, tx.Epoch)
 }
 
+// ComputeGasUnitForRelayedV3 will compute the gas units for a relayed v3 transaction
+func (computer *feeComputer) ComputeGasUnitForRelayedV3(tx *transaction.ApiTransactionResult) uint64 {
+	return computer.economicsInstance.ComputeRelayedTxV3GasUnits(tx.Tx, tx.Epoch)
+}
+
 // ComputeTransactionFee computes a transaction fee, at a given epoch
 func (computer *feeComputer) ComputeTransactionFee(tx *transaction.ApiTransactionResult) *big.Int {
 	return computer.economicsInstance.ComputeTxFeeInEpoch(tx.Tx, tx.Epoch)

--- a/node/external/transactionAPI/gasUsedAndFeeProcessor.go
+++ b/node/external/transactionAPI/gasUsedAndFeeProcessor.go
@@ -78,6 +78,18 @@ func (gfp *gasUsedAndFeeProcessor) computeAndAttachGasUsedAndFee(tx *transaction
 		return
 	}
 
+	isRelayedV3AndNoRefund := len(tx.InnerTransactions) > 0 && !hasRefundForSender
+	if isRelayedV3AndNoRefund {
+		txFee := gfp.feeComputer.ComputeTransactionFee(tx)
+		gasUsedRelayed := gfp.feeComputer.ComputeGasUnitForRelayedV3(tx)
+
+		tx.GasUsed = gasUsedRelayed
+		tx.Fee = txFee.String()
+		tx.InitiallyPaidFee = txFee.String()
+
+		return
+	}
+
 	gfp.prepareTxWithResultsBasedOnLogs(tx, hasRefundForSender)
 }
 

--- a/node/external/transactionAPI/gasUsedAndFeeProcessor_test.go
+++ b/node/external/transactionAPI/gasUsedAndFeeProcessor_test.go
@@ -465,7 +465,8 @@ func testComputeAndAttachGasUsedAndFeeRelayedV3WithInnerTxFailed(
 			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
 				return flag == common.GasPriceModifierFlag ||
 					flag == common.PenalizedTooMuchGasFlag ||
-					flag == common.RelayedTransactionsV3Flag
+					flag == common.RelayedTransactionsV3Flag ||
+					flag == common.LinkInnerTransactionFlag
 			},
 		}
 		feeComp, _ := fee.NewFeeComputer(createEconomicsData(enableEpochsHandler))

--- a/node/external/transactionAPI/interface.go
+++ b/node/external/transactionAPI/interface.go
@@ -11,6 +11,7 @@ type feeComputer interface {
 	ComputeGasUsedAndFeeBasedOnRefundValue(tx *transaction.ApiTransactionResult, refundValue *big.Int) (uint64, *big.Int)
 	ComputeTxFeeBasedOnGasUsed(tx *transaction.ApiTransactionResult, gasUsed uint64) *big.Int
 	ComputeGasLimit(tx *transaction.ApiTransactionResult) uint64
+	ComputeGasUnitForRelayedV3(tx *transaction.ApiTransactionResult) uint64
 	ComputeTransactionFee(tx *transaction.ApiTransactionResult) *big.Int
 	IsInterfaceNil() bool
 }

--- a/node/external/transactionAPI/testData/relayedV3WithAllInnerTxFailed.json
+++ b/node/external/transactionAPI/testData/relayedV3WithAllInnerTxFailed.json
@@ -1,0 +1,174 @@
+{
+  "type": "normal",
+  "processingTypeOnSource": "RelayedTxV3",
+  "processingTypeOnDestination": "RelayedTxV3",
+  "hash": "9034190d93ab39cf1c6e82832238777512d274c0867e6a3462950695606f10f8",
+  "nonce": 3,
+  "value": "0",
+  "receiver": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+  "sender": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+  "gasPrice": 1000000000,
+  "gasLimit": 500000000,
+  "isRelayed": true,
+  "innerTransactions": [
+    {
+      "type": "inner",
+      "hash": "f820c6cef9288bc627c42df6ac57c64429f7822fa01ba58db5d57f138f3833bf",
+      "nonce": 6,
+      "value": "0",
+      "receiver": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+      "sender": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+      "gasPrice": 1000000000,
+      "gasLimit": 20000000,
+      "data": "RVNEVE5GVENyZWF0ZUA0MTRjNDU1ODJkMzk2NDY1MzgzOTY2QDAxQDU0NjU3Mzc0QDAzZThANTE2ZDY2NDEzMjQ4NzQ2NTcyNmU2NzRkNjI0MjY1NTQ2NzUwNmIzMjYxMzI3YTZmNGQzNTc5NjU2MTZmMzM0NTZmNjEzNzM2Nzg1MTM3NzUzNDZkNjM2NDY5NDdANzQ2MTY3NzMzYTc0NjU3Mzc0MmM2NjcyNjU2NTJjNjY3NTZlM2I2ZDY1NzQ2MTY0NjE3NDYxM2E1NDY4Njk3MzIwNjk3MzIwNjEyMDc0NjU3Mzc0MjA2NDY1NzM2MzcyNjk3MDc0Njk2ZjZlMjA2NjZmNzIyMDYxNmUyMDYxNzc2NTczNmY2ZDY1MjA2ZTY2NzRAMDEwMQ==",
+      "smartContractResults": [
+        {
+          "hash": "8cee6b30bc1ed2efdc6cc1ad08d7e8ab5cda5dec54cec2f690679e8c2b672b93",
+          "nonce": 6,
+          "value": 0,
+          "receiver": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+          "sender": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTNFTCreate@414c45582d396465383966@01@54657374@03e8@516d664132487465726e674d6242655467506b3261327a6f4d357965616f33456f61373678513775346d63646947@746167733a746573742c667265652c66756e3b6d657461646174613a5468697320697320612074657374206465736372697074696f6e20666f7220616e20617765736f6d65206e6674@0101",
+          "prevTxHash": "f820c6cef9288bc627c42df6ac57c64429f7822fa01ba58db5d57f138f3833bf",
+          "originalTxHash": "9034190d93ab39cf1c6e82832238777512d274c0867e6a3462950695606f10f8",
+          "gasLimit": 19503000,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "logs": {
+            "address": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+            "events": [
+              {
+                "address": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+                "identifier": "signalError",
+                "topics": [
+                  "KQclkV+pF/02MiTDTYE5sCvEqMWPbC093vxwHQBTJEM=",
+                  "YWN0aW9uIGlzIG5vdCBhbGxvd2Vk"
+                ],
+                "data": "QDYxNjM3NDY5NmY2ZTIwNjk3MzIwNmU2Zjc0MjA2MTZjNmM2Zjc3NjU2NA==",
+                "additionalData": [
+                  "QDYxNjM3NDY5NmY2ZTIwNjk3MzIwNmU2Zjc0MjA2MTZjNmM2Zjc3NjU2NA=="
+                ]
+              }
+            ]
+          },
+          "tokens": [
+            "ALEX-9de89f"
+          ],
+          "esdtValues": [
+            "1"
+          ],
+          "operation": "ESDTNFTCreate"
+        }
+      ],
+      "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n"
+    },
+    {
+      "type": "inner",
+      "hash": "68c279534fbc7c737355463233a6d792b8fcf1d37502501da2586aee89068ceb",
+      "nonce": 7,
+      "value": "0",
+      "receiver": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+      "sender": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+      "gasPrice": 1000000000,
+      "gasLimit": 20000000,
+      "data": "RVNEVE5GVENyZWF0ZUA0MTRjNDU1ODJkMzk2NDY1MzgzOTY2QDAxQDU0NjU3Mzc0QDAzZThANTE2ZDY2NDEzMjQ4NzQ2NTcyNmU2NzRkNjI0MjY1NTQ2NzUwNmIzMjYxMzI3YTZmNGQzNTc5NjU2MTZmMzM0NTZmNjEzNzM2Nzg1MTM3NzUzNDZkNjM2NDY5NDdANzQ2MTY3NzMzYTc0NjU3Mzc0MmM2NjcyNjU2NTJjNjY3NTZlM2I2ZDY1NzQ2MTY0NjE3NDYxM2E1NDY4Njk3MzIwNjk3MzIwNjEyMDc0NjU3Mzc0MjA2NDY1NzM2MzcyNjk3MDc0Njk2ZjZlMjA2NjZmNzIyMDYxNmUyMDYxNzc2NTczNmY2ZDY1MjA2ZTY2NzRAMDEwMQ==",
+      "smartContractResults": [
+        {
+          "hash": "633a15dbd5300c49a947d264501b4068a1b9c70a86ddfb31615b346594de76f7",
+          "nonce": 7,
+          "value": 0,
+          "receiver": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+          "sender": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTNFTCreate@414c45582d396465383966@01@54657374@03e8@516d664132487465726e674d6242655467506b3261327a6f4d357965616f33456f61373678513775346d63646947@746167733a746573742c667265652c66756e3b6d657461646174613a5468697320697320612074657374206465736372697074696f6e20666f7220616e20617765736f6d65206e6674@0101",
+          "prevTxHash": "68c279534fbc7c737355463233a6d792b8fcf1d37502501da2586aee89068ceb",
+          "originalTxHash": "9034190d93ab39cf1c6e82832238777512d274c0867e6a3462950695606f10f8",
+          "gasLimit": 19503000,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "logs": {
+            "address": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+            "events": [
+              {
+                "address": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+                "identifier": "signalError",
+                "topics": [
+                  "KQclkV+pF/02MiTDTYE5sCvEqMWPbC093vxwHQBTJEM=",
+                  "YWN0aW9uIGlzIG5vdCBhbGxvd2Vk"
+                ],
+                "data": "QDYxNjM3NDY5NmY2ZTIwNjk3MzIwNmU2Zjc0MjA2MTZjNmM2Zjc3NjU2NA==",
+                "additionalData": [
+                  "QDYxNjM3NDY5NmY2ZTIwNjk3MzIwNmU2Zjc0MjA2MTZjNmM2Zjc3NjU2NA=="
+                ]
+              }
+            ]
+          },
+          "tokens": [
+            "ALEX-9de89f"
+          ],
+          "esdtValues": [
+            "1"
+          ],
+          "operation": "ESDTNFTCreate"
+        }
+      ],
+      "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n"
+    },
+    {
+      "type": "inner",
+      "hash": "098ad3df7abab3d5603438995983f81923279ee849397c56e10969f83ed7041c",
+      "nonce": 8,
+      "value": "0",
+      "receiver": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+      "sender": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+      "gasPrice": 1000000000,
+      "gasLimit": 20000000,
+      "data": "RVNEVE5GVENyZWF0ZUA0MTRjNDU1ODJkMzk2NDY1MzgzOTY2QDAxQDU0NjU3Mzc0QDAzZThANTE2ZDY2NDEzMjQ4NzQ2NTcyNmU2NzRkNjI0MjY1NTQ2NzUwNmIzMjYxMzI3YTZmNGQzNTc5NjU2MTZmMzM0NTZmNjEzNzM2Nzg1MTM3NzUzNDZkNjM2NDY5NDdANzQ2MTY3NzMzYTc0NjU3Mzc0MmM2NjcyNjU2NTJjNjY3NTZlM2I2ZDY1NzQ2MTY0NjE3NDYxM2E1NDY4Njk3MzIwNjk3MzIwNjEyMDc0NjU3Mzc0MjA2NDY1NzM2MzcyNjk3MDc0Njk2ZjZlMjA2NjZmNzIyMDYxNmUyMDYxNzc2NTczNmY2ZDY1MjA2ZTY2NzRAMDEwMQ==",
+      "smartContractResults": [
+        {
+          "hash": "19ea4142f37c3079bd511aed503ffb0bafad1b4921ef618d79c6a0a185753b78",
+          "nonce": 8,
+          "value": 0,
+          "receiver": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+          "sender": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTNFTCreate@414c45582d396465383966@01@54657374@03e8@516d664132487465726e674d6242655467506b3261327a6f4d357965616f33456f61373678513775346d63646947@746167733a746573742c667265652c66756e3b6d657461646174613a5468697320697320612074657374206465736372697074696f6e20666f7220616e20617765736f6d65206e6674@0101",
+          "prevTxHash": "098ad3df7abab3d5603438995983f81923279ee849397c56e10969f83ed7041c",
+          "originalTxHash": "9034190d93ab39cf1c6e82832238777512d274c0867e6a3462950695606f10f8",
+          "gasLimit": 19503000,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "logs": {
+            "address": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+            "events": [
+              {
+                "address": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+                "identifier": "signalError",
+                "topics": [
+                  "KQclkV+pF/02MiTDTYE5sCvEqMWPbC093vxwHQBTJEM=",
+                  "YWN0aW9uIGlzIG5vdCBhbGxvd2Vk"
+                ],
+                "data": "QDYxNjM3NDY5NmY2ZTIwNjk3MzIwNmU2Zjc0MjA2MTZjNmM2Zjc3NjU2NA==",
+                "additionalData": [
+                  "QDYxNjM3NDY5NmY2ZTIwNjk3MzIwNmU2Zjc0MjA2MTZjNmM2Zjc3NjU2NA=="
+                ]
+              }
+            ]
+          },
+          "tokens": [
+            "ALEX-9de89f"
+          ],
+          "esdtValues": [
+            "1"
+          ],
+          "operation": "ESDTNFTCreate"
+        }
+      ],
+      "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n"
+    }
+  ]
+}

--- a/node/external/transactionAPI/testData/relayedV3WithOneInnerFailedAndTwoRefunds.json
+++ b/node/external/transactionAPI/testData/relayedV3WithOneInnerFailedAndTwoRefunds.json
@@ -1,0 +1,605 @@
+{
+  "type": "normal",
+  "processingTypeOnSource": "RelayedTxV3",
+  "processingTypeOnDestination": "RelayedTxV3",
+  "hash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+  "nonce": 47,
+  "value": "0",
+  "receiver": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+  "sender": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+  "gasPrice": 1000000000,
+  "gasLimit": 500000000,
+  "isRelayed": true,
+  "innerTransactions": [
+    {
+      "type": "inner",
+      "hash": "9a64f50a80a71e9234447aaa6209c0b6dc543790192432908a024bdaf0100c73",
+      "nonce": 7,
+      "value": "5000000000000000000",
+      "receiver": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+      "sender": "erd1e2ftj4hj43lkduwps9xdmtgjnmugkh9mndph4n2cxfmf6ufvn4ks0zut84",
+      "gasPrice": 1000000000,
+      "gasLimit": 60000000,
+      "data": "aXNzdWVOb25GdW5naWJsZUA0ZDU5NGU0NjU0QDQxNGM0NTU4QDYzNjE2ZTQ2NzI2NTY1N2E2NUA3NDcyNzU2NUA2MzYxNmU1NzY5NzA2NUA3NDcyNzU2NUA2MzYxNmU1MDYxNzU3MzY1QDc0NzI3NTY1QDYzNjE2RTU0NzI2MTZFNzM2NjY1NzI0RTQ2NTQ0MzcyNjU2MTc0NjU1MjZGNkM2NUA3NDcyNzU2NQ==",
+      "smartContractResults": [
+        {
+          "hash": "c4535975592aaa2a1f69b2f5b2b069416a96b06cd9c6a3e6e6b9840c39f834c9",
+          "nonce": 1,
+          "value": 0,
+          "receiver": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqsl6e366",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTSetTokenType@414c45582d396536393235@4e6f6e46756e6769626c65455344547632",
+          "prevTxHash": "73649ed46a1de29139612a4889f431d8c6dbcd137e1dbf4f6987651c1485ff35",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "logs": {
+            "address": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqsl6e366",
+            "events": [
+              {
+                "address": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqsl6e366",
+                "identifier": "completedTxEvent",
+                "topics": [
+                  "c2Se1God4pE5YSpIifQx2MbbzRN+Hb9PaYdlHBSF/zU="
+                ],
+                "data": null,
+                "additionalData": null
+              }
+            ]
+          },
+          "operation": "ESDTSetTokenType"
+        },
+        {
+          "hash": "ae6a1c55783b7dcb27817e22e498985ae32fa17b3f6ce00642cfb6c1e5784f8e",
+          "nonce": 0,
+          "value": 0,
+          "receiver": "erd1lllllllllllllllllllllllllllllllllllllllllllllllllupq9x7ny0",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTSetBurnRoleForAll@414c45582d396536393235",
+          "prevTxHash": "73649ed46a1de29139612a4889f431d8c6dbcd137e1dbf4f6987651c1485ff35",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "operation": "transfer"
+        },
+        {
+          "hash": "73649ed46a1de29139612a4889f431d8c6dbcd137e1dbf4f6987651c1485ff35",
+          "nonce": 7,
+          "value": 5000000000000000000,
+          "receiver": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "sender": "erd1e2ftj4hj43lkduwps9xdmtgjnmugkh9mndph4n2cxfmf6ufvn4ks0zut84",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "issueNonFungible@4d594e4654@414c4558@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616E5472616E736665724E4654437265617465526F6C65@74727565",
+          "prevTxHash": "9a64f50a80a71e9234447aaa6209c0b6dc543790192432908a024bdaf0100c73",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 59692000,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "logs": {
+            "address": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+            "events": [
+              {
+                "address": "erd1e2ftj4hj43lkduwps9xdmtgjnmugkh9mndph4n2cxfmf6ufvn4ks0zut84",
+                "identifier": "upgradeProperties",
+                "topics": [
+                  "QUxFWC05ZTY5MjU=",
+                  "",
+                  "Y2FuRnJlZXpl",
+                  "dHJ1ZQ==",
+                  "Y2FuV2lwZQ==",
+                  "dHJ1ZQ==",
+                  "Y2FuUGF1c2U=",
+                  "dHJ1ZQ==",
+                  "Y2FuVHJhbnNmZXJORlRDcmVhdGVSb2xl",
+                  "dHJ1ZQ==",
+                  "Y2FuVXBncmFkZQ==",
+                  "dHJ1ZQ==",
+                  "Y2FuQWRkU3BlY2lhbFJvbGVz",
+                  "dHJ1ZQ=="
+                ],
+                "data": null,
+                "additionalData": null
+              },
+              {
+                "address": "erd1e2ftj4hj43lkduwps9xdmtgjnmugkh9mndph4n2cxfmf6ufvn4ks0zut84",
+                "identifier": "ESDTSetBurnRoleForAll",
+                "topics": [
+                  "QUxFWC05ZTY5MjU=",
+                  "",
+                  "",
+                  "RVNEVFJvbGVCdXJuRm9yQWxs"
+                ],
+                "data": null,
+                "additionalData": null
+              },
+              {
+                "address": "erd1e2ftj4hj43lkduwps9xdmtgjnmugkh9mndph4n2cxfmf6ufvn4ks0zut84",
+                "identifier": "ESDTSetTokenType",
+                "topics": [
+                  "QUxFWC05ZTY5MjU=",
+                  "Tm9uRnVuZ2libGVFU0RUdjI="
+                ],
+                "data": null,
+                "additionalData": null
+              },
+              {
+                "address": "erd1e2ftj4hj43lkduwps9xdmtgjnmugkh9mndph4n2cxfmf6ufvn4ks0zut84",
+                "identifier": "issueNonFungible",
+                "topics": [
+                  "QUxFWC05ZTY5MjU=",
+                  "TVlORlQ=",
+                  "QUxFWA==",
+                  "Tm9uRnVuZ2libGVFU0RUdjI=",
+                  ""
+                ],
+                "data": null,
+                "additionalData": null
+              },
+              {
+                "address": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+                "identifier": "writeLog",
+                "topics": [
+                  "ypK5VvKsf2bxwYFM3a0SnviLXLubQ3rNWDJ2nXEsnW0="
+                ],
+                "data": "QDZmNmJANDE0YzQ1NTgyZDM5NjUzNjM5MzIzNQ==",
+                "additionalData": [
+                  "QDZmNmJANDE0YzQ1NTgyZDM5NjUzNjM5MzIzNQ=="
+                ]
+              }
+            ]
+          },
+          "operation": "transfer",
+          "function": "issueNonFungible"
+        },
+        {
+          "hash": "2bcadb8911a7b027073ff9da3ead77b533856da31033b86970dcfc4cab58c32a",
+          "nonce": 0,
+          "value": 0,
+          "receiver": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqsl6e366",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTSetBurnRoleForAll@414c45582d396536393235",
+          "prevTxHash": "73649ed46a1de29139612a4889f431d8c6dbcd137e1dbf4f6987651c1485ff35",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "logs": {
+            "address": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqsl6e366",
+            "events": [
+              {
+                "address": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqsl6e366",
+                "identifier": "completedTxEvent",
+                "topics": [
+                  "c2Se1God4pE5YSpIifQx2MbbzRN+Hb9PaYdlHBSF/zU="
+                ],
+                "data": null,
+                "additionalData": null
+              }
+            ]
+          },
+          "operation": "transfer"
+        },
+        {
+          "hash": "78e4c87f3cc29dfd111fd72a424e1155e901aed7edcf6a32a6eef8c884607c6b",
+          "nonce": 1,
+          "value": 0,
+          "receiver": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqq2m3f0f",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTSetTokenType@414c45582d396536393235@4e6f6e46756e6769626c65455344547632",
+          "prevTxHash": "73649ed46a1de29139612a4889f431d8c6dbcd137e1dbf4f6987651c1485ff35",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "operation": "ESDTSetTokenType"
+        },
+        {
+          "hash": "227d1bb7322a956594f4caef7a28a67b5decf400753fab971c17278905b14ae6",
+          "nonce": 8,
+          "value": 96920000000000,
+          "receiver": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "prevTxHash": "73649ed46a1de29139612a4889f431d8c6dbcd137e1dbf4f6987651c1485ff35",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "returnMessage": "gas refund for relayer",
+          "logs": {
+            "address": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+            "events": [
+              {
+                "address": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+                "identifier": "completedTxEvent",
+                "topics": [
+                  "c2Se1God4pE5YSpIifQx2MbbzRN+Hb9PaYdlHBSF/zU="
+                ],
+                "data": null,
+                "additionalData": null
+              }
+            ]
+          },
+          "operation": "transfer",
+          "isRefund": true
+        },
+        {
+          "hash": "21abaea2ef611b30f5dcc79302bcfcc460f95a0c899ac705d1bbb7624de844c1",
+          "nonce": 1,
+          "value": 0,
+          "receiver": "erd1lllllllllllllllllllllllllllllllllllllllllllllllllupq9x7ny0",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTSetTokenType@414c45582d396536393235@4e6f6e46756e6769626c65455344547632",
+          "prevTxHash": "73649ed46a1de29139612a4889f431d8c6dbcd137e1dbf4f6987651c1485ff35",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "operation": "ESDTSetTokenType"
+        },
+        {
+          "hash": "4b1676a8dcbc21513122c73a8474e2d4aca3941071d1df80fd694ca3770f7931",
+          "nonce": 0,
+          "value": 0,
+          "receiver": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqq2m3f0f",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTSetBurnRoleForAll@414c45582d396536393235",
+          "prevTxHash": "73649ed46a1de29139612a4889f431d8c6dbcd137e1dbf4f6987651c1485ff35",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "operation": "transfer"
+        }
+      ],
+      "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n"
+    },
+    {
+      "type": "inner",
+      "hash": "a7c5512b661949fe8323fc530a893eb822c361e658096c91a50f64c359d08f00",
+      "nonce": 16,
+      "value": "5000000000000000000",
+      "receiver": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+      "sender": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+      "gasPrice": 1000000000,
+      "gasLimit": 60000000,
+      "data": "aXNzdWVOb25GdW5naWJsZUA0ZDU5NGU0NjU0QDQxNGM0NTU4QDYzNjE2ZTQ2NzI2NTY1N2E2NUA3NDcyNzU2NUA2MzYxNmU1NzY5NzA2NUA3NDcyNzU2NUA2MzYxNmU1MDYxNzU3MzY1QDc0NzI3NTY1QDYzNjE2RTU0NzI2MTZFNzM2NjY1NzI0RTQ2NTQ0MzcyNjU2MTc0NjU1MjZGNkM2NUA3NDcyNzU2NQ==",
+      "smartContractResults": [
+        {
+          "hash": "ffdf2a00e1d34065b7aaf4cdfcc85dbb83c75abd390a3eeaee61af79850868b4",
+          "nonce": 1,
+          "value": 0,
+          "receiver": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqsl6e366",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTSetTokenType@414c45582d333765636131@4e6f6e46756e6769626c65455344547632",
+          "prevTxHash": "2524facd8af05eee9714ba16b32339e7eae67c0135501e9404cbe21fe7b8e7de",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "logs": {
+            "address": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqsl6e366",
+            "events": [
+              {
+                "address": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqsl6e366",
+                "identifier": "completedTxEvent",
+                "topics": [
+                  "JST6zYrwXu6XFLoWsyM55+rmfAE1UB6UBMviH+e4594="
+                ],
+                "data": null,
+                "additionalData": null
+              }
+            ]
+          },
+          "operation": "ESDTSetTokenType"
+        },
+        {
+          "hash": "4d51196e7c911c8486fed2a50eaa771e7e3bf86ebd3f04e2d13087f204f38fb2",
+          "nonce": 0,
+          "value": 0,
+          "receiver": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqsl6e366",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTSetBurnRoleForAll@414c45582d333765636131",
+          "prevTxHash": "2524facd8af05eee9714ba16b32339e7eae67c0135501e9404cbe21fe7b8e7de",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "logs": {
+            "address": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqsl6e366",
+            "events": [
+              {
+                "address": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqsl6e366",
+                "identifier": "completedTxEvent",
+                "topics": [
+                  "JST6zYrwXu6XFLoWsyM55+rmfAE1UB6UBMviH+e4594="
+                ],
+                "data": null,
+                "additionalData": null
+              }
+            ]
+          },
+          "operation": "transfer"
+        },
+        {
+          "hash": "d0690fc92d1f9ad2ad3f8140d7400b0795382aa9f427b7206a2a54a7eda3eafc",
+          "nonce": 0,
+          "value": 0,
+          "receiver": "erd1lllllllllllllllllllllllllllllllllllllllllllllllllupq9x7ny0",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTSetBurnRoleForAll@414c45582d333765636131",
+          "prevTxHash": "2524facd8af05eee9714ba16b32339e7eae67c0135501e9404cbe21fe7b8e7de",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "operation": "transfer"
+        },
+        {
+          "hash": "50b212f61af4908a102e6b6896cb794ee3721efe4643b5a4cf3a60a4f88dc0d1",
+          "nonce": 17,
+          "value": 96920000000000,
+          "receiver": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "prevTxHash": "2524facd8af05eee9714ba16b32339e7eae67c0135501e9404cbe21fe7b8e7de",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "returnMessage": "gas refund for relayer",
+          "logs": {
+            "address": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+            "events": [
+              {
+                "address": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+                "identifier": "completedTxEvent",
+                "topics": [
+                  "JST6zYrwXu6XFLoWsyM55+rmfAE1UB6UBMviH+e4594="
+                ],
+                "data": null,
+                "additionalData": null
+              }
+            ]
+          },
+          "operation": "transfer",
+          "isRefund": true
+        },
+        {
+          "hash": "2524facd8af05eee9714ba16b32339e7eae67c0135501e9404cbe21fe7b8e7de",
+          "nonce": 16,
+          "value": 5000000000000000000,
+          "receiver": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "sender": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "issueNonFungible@4d594e4654@414c4558@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616E5472616E736665724E4654437265617465526F6C65@74727565",
+          "prevTxHash": "a7c5512b661949fe8323fc530a893eb822c361e658096c91a50f64c359d08f00",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 59692000,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "logs": {
+            "address": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+            "events": [
+              {
+                "address": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+                "identifier": "upgradeProperties",
+                "topics": [
+                  "QUxFWC0zN2VjYTE=",
+                  "",
+                  "Y2FuRnJlZXpl",
+                  "dHJ1ZQ==",
+                  "Y2FuV2lwZQ==",
+                  "dHJ1ZQ==",
+                  "Y2FuUGF1c2U=",
+                  "dHJ1ZQ==",
+                  "Y2FuVHJhbnNmZXJORlRDcmVhdGVSb2xl",
+                  "dHJ1ZQ==",
+                  "Y2FuVXBncmFkZQ==",
+                  "dHJ1ZQ==",
+                  "Y2FuQWRkU3BlY2lhbFJvbGVz",
+                  "dHJ1ZQ=="
+                ],
+                "data": null,
+                "additionalData": null
+              },
+              {
+                "address": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+                "identifier": "ESDTSetBurnRoleForAll",
+                "topics": [
+                  "QUxFWC0zN2VjYTE=",
+                  "",
+                  "",
+                  "RVNEVFJvbGVCdXJuRm9yQWxs"
+                ],
+                "data": null,
+                "additionalData": null
+              },
+              {
+                "address": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+                "identifier": "ESDTSetTokenType",
+                "topics": [
+                  "QUxFWC0zN2VjYTE=",
+                  "Tm9uRnVuZ2libGVFU0RUdjI="
+                ],
+                "data": null,
+                "additionalData": null
+              },
+              {
+                "address": "erd19yrjty2l4ytl6d3jynp5mqfekq4uf2x93akz60w7l3cp6qzny3psnfyerw",
+                "identifier": "issueNonFungible",
+                "topics": [
+                  "QUxFWC0zN2VjYTE=",
+                  "TVlORlQ=",
+                  "QUxFWA==",
+                  "Tm9uRnVuZ2libGVFU0RUdjI=",
+                  ""
+                ],
+                "data": null,
+                "additionalData": null
+              },
+              {
+                "address": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+                "identifier": "writeLog",
+                "topics": [
+                  "KQclkV+pF/02MiTDTYE5sCvEqMWPbC093vxwHQBTJEM="
+                ],
+                "data": "QDZmNmJANDE0YzQ1NTgyZDMzMzc2NTYzNjEzMQ==",
+                "additionalData": [
+                  "QDZmNmJANDE0YzQ1NTgyZDMzMzc2NTYzNjEzMQ=="
+                ]
+              }
+            ]
+          },
+          "operation": "transfer",
+          "function": "issueNonFungible"
+        },
+        {
+          "hash": "76a53f1fef3ed830e6c0a0d13a6eb22bde6d3e9e012badc647aeb4920f61c326",
+          "nonce": 0,
+          "value": 0,
+          "receiver": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqq2m3f0f",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTSetBurnRoleForAll@414c45582d333765636131",
+          "prevTxHash": "2524facd8af05eee9714ba16b32339e7eae67c0135501e9404cbe21fe7b8e7de",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "operation": "transfer"
+        },
+        {
+          "hash": "9c4aefdc190c3e24a3dc8b6aea3bab00d113d35cc68f9ee771a4129f18f7418f",
+          "nonce": 1,
+          "value": 0,
+          "receiver": "erd1llllllllllllllllllllllllllllllllllllllllllllllllluqq2m3f0f",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTSetTokenType@414c45582d333765636131@4e6f6e46756e6769626c65455344547632",
+          "prevTxHash": "2524facd8af05eee9714ba16b32339e7eae67c0135501e9404cbe21fe7b8e7de",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "operation": "ESDTSetTokenType"
+        },
+        {
+          "hash": "c1bf11e58cd047f116514198b218001a82ae951c69166f36b391277cf0700b9e",
+          "nonce": 1,
+          "value": 0,
+          "receiver": "erd1lllllllllllllllllllllllllllllllllllllllllllllllllupq9x7ny0",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "ESDTSetTokenType@414c45582d333765636131@4e6f6e46756e6769626c65455344547632",
+          "prevTxHash": "2524facd8af05eee9714ba16b32339e7eae67c0135501e9404cbe21fe7b8e7de",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "operation": "ESDTSetTokenType"
+        }
+      ],
+      "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n"
+    },
+    {
+      "type": "inner",
+      "hash": "6ae9c096b35ff7c62e47d3fcc38fd5fcc9c91a6b19db450aa7805017d54290ba",
+      "nonce": 1,
+      "value": "50000000000000000",
+      "receiver": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+      "sender": "erd136rl878j09mev24gzpy70k2wfm3xmvj5ucwxffs9v5t5sk3kshtszz25z9",
+      "gasPrice": 1000000000,
+      "gasLimit": 60000000,
+      "data": "aXNzdWVOb25GdW5naWJsZUA0ZDU5NGU0NjU0QDQxNGM0NTU4QDYzNjE2ZTQ2NzI2NTY1N2E2NUA3NDcyNzU2NUA2MzYxNmU1NzY5NzA2NUA3NDcyNzU2NUA2MzYxNmU1MDYxNzU3MzY1QDc0NzI3NTY1QDYzNjE2RTU0NzI2MTZFNzM2NjY1NzI0RTQ2NTQ0MzcyNjU2MTc0NjU1MjZGNkM2NUA3NDcyNzU2NQ==",
+      "smartContractResults": [
+        {
+          "hash": "f1bca8643524bee2451253bb390cf9b805fd06baea04513423d5fdbf2ab01bf8",
+          "nonce": 1,
+          "value": 50000000000000000,
+          "receiver": "erd136rl878j09mev24gzpy70k2wfm3xmvj5ucwxffs9v5t5sk3kshtszz25z9",
+          "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "data": "@6f7574206f662066756e6473",
+          "prevTxHash": "e05b22281de80469629d5fbfa50362d7ac7f44e31bd66cb420f2409e8569b69a",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 0,
+          "gasPrice": 0,
+          "callType": 0,
+          "returnMessage": "callValue not equals with baseIssuingCost",
+          "originalSender": "erd136rl878j09mev24gzpy70k2wfm3xmvj5ucwxffs9v5t5sk3kshtszz25z9",
+          "operation": "transfer"
+        },
+        {
+          "hash": "e05b22281de80469629d5fbfa50362d7ac7f44e31bd66cb420f2409e8569b69a",
+          "nonce": 1,
+          "value": 50000000000000000,
+          "receiver": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+          "sender": "erd136rl878j09mev24gzpy70k2wfm3xmvj5ucwxffs9v5t5sk3kshtszz25z9",
+          "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n",
+          "relayedValue": 0,
+          "data": "issueNonFungible@4d594e4654@414c4558@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616E5472616E736665724E4654437265617465526F6C65@74727565",
+          "prevTxHash": "6ae9c096b35ff7c62e47d3fcc38fd5fcc9c91a6b19db450aa7805017d54290ba",
+          "originalTxHash": "5c5cdb939473e76ee85af17eb02dbeca5d879bd19c7c050d0be6d2c901b9f6ae",
+          "gasLimit": 59692000,
+          "gasPrice": 1000000000,
+          "callType": 0,
+          "logs": {
+            "address": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+            "events": [
+              {
+                "address": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+                "identifier": "signalError",
+                "topics": [
+                  "jofz+PJ5d5YqqBBJ59lOTuJtslTmHGSmBWUXSFo2hdc=",
+                  "Y2FsbFZhbHVlIG5vdCBlcXVhbHMgd2l0aCBiYXNlSXNzdWluZ0Nvc3Q="
+                ],
+                "data": "QDZmNzU3NDIwNmY2NjIwNjY3NTZlNjQ3Mw==",
+                "additionalData": [
+                  "QDZmNzU3NDIwNmY2NjIwNjY3NTZlNjQ3Mw=="
+                ]
+              },
+              {
+                "address": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+                "identifier": "signalError",
+                "topics": [
+                  "9NowIif4EqFJGQM/krxwmXMhtLwJj5ZYjLny/dDfDek=",
+                  "Y2FsbFZhbHVlIG5vdCBlcXVhbHMgd2l0aCBiYXNlSXNzdWluZ0Nvc3Q="
+                ],
+                "data": null,
+                "additionalData": [
+                  ""
+                ]
+              }
+            ]
+          },
+          "operation": "transfer",
+          "function": "issueNonFungible"
+        }
+      ],
+      "relayerAddress": "erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n"
+    }
+  ]
+}

--- a/outport/mock/economicsDataMock.go
+++ b/outport/mock/economicsDataMock.go
@@ -31,7 +31,7 @@ func (e *EconomicsHandlerMock) ComputeRelayedTxFees(_ coreData.TransactionWithFe
 }
 
 // ComputeGasUnitsFromRefundValue -
-func (e *EconomicsHandlerMock) ComputeGasUnitsFromRefundValue(_ coreData.TransactionWithFeeHandler, _ *big.Int) uint64 {
+func (e *EconomicsHandlerMock) ComputeGasUnitsFromRefundValue(_ coreData.TransactionWithFeeHandler, _ *big.Int, _ uint32) uint64 {
 	return 0
 }
 

--- a/outport/mock/economicsDataMock.go
+++ b/outport/mock/economicsDataMock.go
@@ -20,6 +20,21 @@ const (
 type EconomicsHandlerMock struct {
 }
 
+// ComputeRelayedTxV3GasUnits -
+func (e *EconomicsHandlerMock) ComputeRelayedTxV3GasUnits(_ coreData.TransactionWithFeeHandler, _ uint32) uint64 {
+	return 0
+}
+
+// ComputeRelayedTxFees -
+func (e *EconomicsHandlerMock) ComputeRelayedTxFees(_ coreData.TransactionWithFeeHandler) (*big.Int, *big.Int, error) {
+	return nil, nil, nil
+}
+
+// ComputeGasUnitsFromRefundValue -
+func (e *EconomicsHandlerMock) ComputeGasUnitsFromRefundValue(_ coreData.TransactionWithFeeHandler, _ *big.Int) uint64 {
+	return 0
+}
+
 // MaxGasLimitPerBlock -
 func (e *EconomicsHandlerMock) MaxGasLimitPerBlock(_ uint32) uint64 {
 	return 0

--- a/outport/process/interface.go
+++ b/outport/process/interface.go
@@ -34,7 +34,7 @@ type GasConsumedProvider interface {
 type EconomicsDataHandler interface {
 	ComputeRelayedTxV3GasUnits(tx data.TransactionWithFeeHandler, epoch uint32) uint64
 	ComputeRelayedTxFees(tx data.TransactionWithFeeHandler) (*big.Int, *big.Int, error)
-	ComputeGasUnitsFromRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int) uint64
+	ComputeGasUnitsFromRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int, epoch uint32) uint64
 	ComputeGasUsedAndFeeBasedOnRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int) (uint64, *big.Int)
 	ComputeTxFeeBasedOnGasUsed(tx data.TransactionWithFeeHandler, gasUsed uint64) *big.Int
 	ComputeTxFee(tx data.TransactionWithFeeHandler) *big.Int

--- a/outport/process/interface.go
+++ b/outport/process/interface.go
@@ -32,6 +32,9 @@ type GasConsumedProvider interface {
 
 // EconomicsDataHandler defines the functionality needed for economics data
 type EconomicsDataHandler interface {
+	ComputeRelayedTxV3GasUnits(tx data.TransactionWithFeeHandler, epoch uint32) uint64
+	ComputeRelayedTxFees(tx data.TransactionWithFeeHandler) (*big.Int, *big.Int, error)
+	ComputeGasUnitsFromRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int) uint64
 	ComputeGasUsedAndFeeBasedOnRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int) (uint64, *big.Int)
 	ComputeTxFeeBasedOnGasUsed(tx data.TransactionWithFeeHandler, gasUsed uint64) *big.Int
 	ComputeTxFee(tx data.TransactionWithFeeHandler) *big.Int

--- a/outport/process/transactionsfee/interface.go
+++ b/outport/process/transactionsfee/interface.go
@@ -12,7 +12,7 @@ import (
 type FeesProcessorHandler interface {
 	ComputeRelayedTxV3GasUnits(tx data.TransactionWithFeeHandler, epoch uint32) uint64
 	ComputeRelayedTxFees(tx data.TransactionWithFeeHandler) (*big.Int, *big.Int, error)
-	ComputeGasUnitsFromRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int) uint64
+	ComputeGasUnitsFromRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int, epoch uint32) uint64
 	ComputeGasUsedAndFeeBasedOnRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int) (uint64, *big.Int)
 	ComputeTxFeeBasedOnGasUsed(tx data.TransactionWithFeeHandler, gasUsed uint64) *big.Int
 	ComputeTxFee(tx data.TransactionWithFeeHandler) *big.Int

--- a/outport/process/transactionsfee/interface.go
+++ b/outport/process/transactionsfee/interface.go
@@ -10,6 +10,9 @@ import (
 
 // FeesProcessorHandler defines the interface for the transaction fees processor
 type FeesProcessorHandler interface {
+	ComputeRelayedTxV3GasUnits(tx data.TransactionWithFeeHandler, epoch uint32) uint64
+	ComputeRelayedTxFees(tx data.TransactionWithFeeHandler) (*big.Int, *big.Int, error)
+	ComputeGasUnitsFromRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int) uint64
 	ComputeGasUsedAndFeeBasedOnRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int) (uint64, *big.Int)
 	ComputeTxFeeBasedOnGasUsed(tx data.TransactionWithFeeHandler, gasUsed uint64) *big.Int
 	ComputeTxFee(tx data.TransactionWithFeeHandler) *big.Int

--- a/outport/process/transactionsfee/transactionsFeeProcessor.go
+++ b/outport/process/transactionsfee/transactionsFeeProcessor.go
@@ -102,7 +102,7 @@ func (tep *transactionsFeeProcessor) PutFeeAndGasUsed(pool *outportcore.Transact
 	txsWithResultsMap := prepareTransactionsAndScrs(pool)
 	tep.prepareNormalTxs(txsWithResultsMap, epoch)
 
-	return tep.prepareScrsNoTx(txsWithResultsMap)
+	return tep.prepareScrsNoTx(txsWithResultsMap, epoch)
 }
 
 func (tep *transactionsFeeProcessor) prepareInvalidTxs(pool *outportcore.TransactionPool) {
@@ -317,7 +317,7 @@ func (tep *transactionsFeeProcessor) prepareTxWithResultsBasedOnLogs(
 
 }
 
-func (tep *transactionsFeeProcessor) prepareScrsNoTx(transactionsAndScrs *transactionsAndScrsHolder) error {
+func (tep *transactionsFeeProcessor) prepareScrsNoTx(transactionsAndScrs *transactionsAndScrsHolder, epoch uint32) error {
 	for _, scrHandler := range transactionsAndScrs.scrsNoTx {
 		scr, ok := scrHandler.GetTxHandler().(*smartContractResult.SmartContractResult)
 		if !ok {
@@ -346,7 +346,7 @@ func (tep *transactionsFeeProcessor) prepareScrsNoTx(transactionsAndScrs *transa
 
 		isRelayedV3 := len(txFromStorage.InnerTransactions) > 0
 		if isRelayedV3 {
-			gasUnits := tep.txFeeCalculator.ComputeGasUnitsFromRefundValue(txFromStorage, scr.Value)
+			gasUnits := tep.txFeeCalculator.ComputeGasUnitsFromRefundValue(txFromStorage, scr.Value, epoch)
 
 			scrHandler.GetFeeInfo().SetForRelayed()
 			scrHandler.GetFeeInfo().SetGasUsed(gasUnits)

--- a/process/economics/economicsData.go
+++ b/process/economics/economicsData.go
@@ -592,9 +592,8 @@ func (ed *economicsData) ComputeGasUsedAndFeeBasedOnRefundValue(tx data.Transact
 }
 
 // ComputeGasUnitsFromRefundValue will compute the gas unit based on the refund value
-func (ed *economicsData) ComputeGasUnitsFromRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int) uint64 {
-	currentEpoch := ed.enableEpochsHandler.GetCurrentEpoch()
-	gasPrice := ed.GasPriceForProcessingInEpoch(tx, currentEpoch)
+func (ed *economicsData) ComputeGasUnitsFromRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int, epoch uint32) uint64 {
+	gasPrice := ed.GasPriceForProcessingInEpoch(tx, epoch)
 	refund := big.NewInt(0).Set(refundValue)
 	gasUnits := refund.Div(refund, big.NewInt(int64(gasPrice)))
 

--- a/process/economics/economicsData_test.go
+++ b/process/economics/economicsData_test.go
@@ -1827,6 +1827,6 @@ func TestEconomicsData_ComputeGasUnitsFromRefundValue(t *testing.T) {
 		},
 	}
 
-	gasUnits := economicsData.ComputeGasUnitsFromRefundValue(tx, big.NewInt(1074000000000000))
+	gasUnits := economicsData.ComputeGasUnitsFromRefundValue(tx, big.NewInt(1074000000000000), 0)
 	require.Equal(t, uint64(107_400_000), gasUnits)
 }

--- a/process/interface.go
+++ b/process/interface.go
@@ -700,6 +700,8 @@ type feeHandler interface {
 	ComputeGasUsedAndFeeBasedOnRefundValueInEpoch(tx data.TransactionWithFeeHandler, refundValue *big.Int, epoch uint32) (uint64, *big.Int)
 	ComputeTxFeeBasedOnGasUsedInEpoch(tx data.TransactionWithFeeHandler, gasUsed uint64, epoch uint32) *big.Int
 	ComputeRelayedTxFees(tx data.TransactionWithFeeHandler) (*big.Int, *big.Int, error)
+	ComputeRelayedTxV3GasUnits(tx data.TransactionWithFeeHandler, epoch uint32) uint64
+	ComputeGasUnitsFromRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int) uint64
 }
 
 // TxGasHandler handles a transaction gas and gas cost

--- a/process/interface.go
+++ b/process/interface.go
@@ -701,7 +701,7 @@ type feeHandler interface {
 	ComputeTxFeeBasedOnGasUsedInEpoch(tx data.TransactionWithFeeHandler, gasUsed uint64, epoch uint32) *big.Int
 	ComputeRelayedTxFees(tx data.TransactionWithFeeHandler) (*big.Int, *big.Int, error)
 	ComputeRelayedTxV3GasUnits(tx data.TransactionWithFeeHandler, epoch uint32) uint64
-	ComputeGasUnitsFromRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int) uint64
+	ComputeGasUnitsFromRefundValue(tx data.TransactionWithFeeHandler, refundValue *big.Int, epoch uint32) uint64
 }
 
 // TxGasHandler handles a transaction gas and gas cost

--- a/testscommon/economicsmocks/economicsDataHandlerStub.go
+++ b/testscommon/economicsmocks/economicsDataHandlerStub.go
@@ -52,6 +52,16 @@ type EconomicsHandlerStub struct {
 	ComputeMoveBalanceFeeInEpochCalled                  func(tx data.TransactionWithFeeHandler, epoch uint32) *big.Int
 }
 
+// ComputeRelayedTxV3GasUnits -
+func (e *EconomicsHandlerStub) ComputeRelayedTxV3GasUnits(_ data.TransactionWithFeeHandler, _ uint32) uint64 {
+	return 0
+}
+
+// ComputeGasUnitsFromRefundValue -
+func (e *EconomicsHandlerStub) ComputeGasUnitsFromRefundValue(_ data.TransactionWithFeeHandler, _ *big.Int) uint64 {
+	return 0
+}
+
 // ComputeFeeForProcessing -
 func (e *EconomicsHandlerStub) ComputeFeeForProcessing(tx data.TransactionWithFeeHandler, gasToUse uint64) *big.Int {
 	if e.ComputeFeeForProcessingCalled != nil {

--- a/testscommon/economicsmocks/economicsDataHandlerStub.go
+++ b/testscommon/economicsmocks/economicsDataHandlerStub.go
@@ -50,15 +50,25 @@ type EconomicsHandlerStub struct {
 	ComputeRelayedTxFeesCalled                          func(tx data.TransactionWithFeeHandler) (*big.Int, *big.Int, error)
 	SetTxTypeHandlerCalled                              func(txTypeHandler process.TxTypeHandler) error
 	ComputeMoveBalanceFeeInEpochCalled                  func(tx data.TransactionWithFeeHandler, epoch uint32) *big.Int
+	ComputeRelayedTxV3GasUnitsCalled                    func(tx data.TransactionWithFeeHandler, epoch uint32) uint64
+	ComputeGasUnitsFromRefundValueCalled                func(tx data.TransactionWithFeeHandler, value *big.Int, epoch uint32) uint64
 }
 
 // ComputeRelayedTxV3GasUnits -
-func (e *EconomicsHandlerStub) ComputeRelayedTxV3GasUnits(_ data.TransactionWithFeeHandler, _ uint32) uint64 {
+func (e *EconomicsHandlerStub) ComputeRelayedTxV3GasUnits(tx data.TransactionWithFeeHandler, epoch uint32) uint64 {
+	if e.ComputeRelayedTxV3GasUnitsCalled != nil {
+		return e.ComputeRelayedTxV3GasUnitsCalled(tx, epoch)
+	}
+
 	return 0
 }
 
 // ComputeGasUnitsFromRefundValue -
-func (e *EconomicsHandlerStub) ComputeGasUnitsFromRefundValue(_ data.TransactionWithFeeHandler, _ *big.Int, _ uint32) uint64 {
+func (e *EconomicsHandlerStub) ComputeGasUnitsFromRefundValue(tx data.TransactionWithFeeHandler, value *big.Int, epoch uint32) uint64 {
+	if e.ComputeGasUnitsFromRefundValueCalled != nil {
+		return e.ComputeGasUnitsFromRefundValueCalled(tx, value, epoch)
+	}
+
 	return 0
 }
 

--- a/testscommon/economicsmocks/economicsDataHandlerStub.go
+++ b/testscommon/economicsmocks/economicsDataHandlerStub.go
@@ -58,7 +58,7 @@ func (e *EconomicsHandlerStub) ComputeRelayedTxV3GasUnits(_ data.TransactionWith
 }
 
 // ComputeGasUnitsFromRefundValue -
-func (e *EconomicsHandlerStub) ComputeGasUnitsFromRefundValue(_ data.TransactionWithFeeHandler, _ *big.Int) uint64 {
+func (e *EconomicsHandlerStub) ComputeGasUnitsFromRefundValue(_ data.TransactionWithFeeHandler, _ *big.Int, _ uint32) uint64 {
 	return 0
 }
 

--- a/testscommon/economicsmocks/economicsHandlerMock.go
+++ b/testscommon/economicsmocks/economicsHandlerMock.go
@@ -52,6 +52,16 @@ type EconomicsHandlerMock struct {
 	SetTxTypeHandlerCalled                              func(txTypeHandler process.TxTypeHandler) error
 }
 
+// ComputeRelayedTxV3GasUnits -
+func (ehm *EconomicsHandlerMock) ComputeRelayedTxV3GasUnits(_ data.TransactionWithFeeHandler, _ uint32) uint64 {
+	return 0
+}
+
+// ComputeGasUnitsFromRefundValue -
+func (ehm *EconomicsHandlerMock) ComputeGasUnitsFromRefundValue(_ data.TransactionWithFeeHandler, _ *big.Int) uint64 {
+	return 0
+}
+
 // LeaderPercentage -
 func (ehm *EconomicsHandlerMock) LeaderPercentage() float64 {
 	return ehm.LeaderPercentageCalled()

--- a/testscommon/economicsmocks/economicsHandlerMock.go
+++ b/testscommon/economicsmocks/economicsHandlerMock.go
@@ -50,15 +50,25 @@ type EconomicsHandlerMock struct {
 	ComputeTxFeeBasedOnGasUsedInEpochCalled             func(tx data.TransactionWithFeeHandler, gasUsed uint64, epoch uint32) *big.Int
 	ComputeRelayedTxFeesCalled                          func(tx data.TransactionWithFeeHandler) (*big.Int, *big.Int, error)
 	SetTxTypeHandlerCalled                              func(txTypeHandler process.TxTypeHandler) error
+	ComputeRelayedTxV3GasUnitsCalled                    func(tx data.TransactionWithFeeHandler, epoch uint32) uint64
+	ComputeGasUnitsFromRefundValueCalled                func(tx data.TransactionWithFeeHandler, value *big.Int, epoch uint32) uint64
 }
 
 // ComputeRelayedTxV3GasUnits -
-func (ehm *EconomicsHandlerMock) ComputeRelayedTxV3GasUnits(_ data.TransactionWithFeeHandler, _ uint32) uint64 {
+func (ehm *EconomicsHandlerMock) ComputeRelayedTxV3GasUnits(tx data.TransactionWithFeeHandler, epoch uint32) uint64 {
+	if ehm.ComputeRelayedTxV3GasUnitsCalled != nil {
+		return ehm.ComputeRelayedTxV3GasUnitsCalled(tx, epoch)
+	}
+
 	return 0
 }
 
 // ComputeGasUnitsFromRefundValue -
-func (ehm *EconomicsHandlerMock) ComputeGasUnitsFromRefundValue(_ data.TransactionWithFeeHandler, _ *big.Int, _ uint32) uint64 {
+func (ehm *EconomicsHandlerMock) ComputeGasUnitsFromRefundValue(tx data.TransactionWithFeeHandler, value *big.Int, epoch uint32) uint64 {
+	if ehm.ComputeGasUnitsFromRefundValueCalled != nil {
+		return ehm.ComputeGasUnitsFromRefundValueCalled(tx, value, epoch)
+	}
+
 	return 0
 }
 

--- a/testscommon/economicsmocks/economicsHandlerMock.go
+++ b/testscommon/economicsmocks/economicsHandlerMock.go
@@ -58,7 +58,7 @@ func (ehm *EconomicsHandlerMock) ComputeRelayedTxV3GasUnits(_ data.TransactionWi
 }
 
 // ComputeGasUnitsFromRefundValue -
-func (ehm *EconomicsHandlerMock) ComputeGasUnitsFromRefundValue(_ data.TransactionWithFeeHandler, _ *big.Int) uint64 {
+func (ehm *EconomicsHandlerMock) ComputeGasUnitsFromRefundValue(_ data.TransactionWithFeeHandler, _ *big.Int, _ uint32) uint64 {
 	return 0
 }
 

--- a/testscommon/feeComputerStub.go
+++ b/testscommon/feeComputerStub.go
@@ -13,6 +13,15 @@ type FeeComputerStub struct {
 	ComputeTxFeeBasedOnGasUsedCalled             func(tx *transaction.ApiTransactionResult, gasUsed uint64) *big.Int
 	ComputeGasLimitCalled                        func(tx *transaction.ApiTransactionResult) uint64
 	ComputeMoveBalanceFeeCalled                  func(tx *transaction.ApiTransactionResult) *big.Int
+	ComputeGasUnitForRelayedV3Called             func(tx *transaction.ApiTransactionResult) uint64
+}
+
+func (stub *FeeComputerStub) ComputeGasUnitForRelayedV3(tx *transaction.ApiTransactionResult) uint64 {
+	if stub.ComputeGasUnitForRelayedV3Called != nil {
+		return stub.ComputeGasUnitForRelayedV3Called(tx)
+	}
+
+	return 0
 }
 
 // ComputeTransactionFee -

--- a/testscommon/feeComputerStub.go
+++ b/testscommon/feeComputerStub.go
@@ -16,6 +16,7 @@ type FeeComputerStub struct {
 	ComputeGasUnitForRelayedV3Called             func(tx *transaction.ApiTransactionResult) uint64
 }
 
+// ComputeGasUnitForRelayedV3 -
 func (stub *FeeComputerStub) ComputeGasUnitForRelayedV3(tx *transaction.ApiTransactionResult) uint64 {
 	if stub.ComputeGasUnitForRelayedV3Called != nil {
 		return stub.ComputeGasUnitForRelayedV3Called(tx)


### PR DESCRIPTION
## Reasoning behind the pull request
- Fixed how is calculated `gasUsed` and `fee` fields for `relayed v3` transactions  
## Proposed changes
- Implemented new functions that will calculate the gas used and fee filed for the API transactions and for the indexer transactions
- Changed the version of the `mx-chain-core-go` : https://github.com/multiversx/mx-chain-core-go/pull/330
- Changed the version of the `mx-chain-es-indexer-go`: https://github.com/multiversx/mx-chain-es-indexer-go/pull/298
## Testing procedure
- Do a system test and check if the gas used and the fee is set correctly for the API transactions and the indexed transactions

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
