### PR TITLE
[sovereign] Get extended header from storage

### DIFF
--- a/process/common.go
+++ b/process/common.go
@@ -285,6 +285,51 @@ func GetMetaHeaderFromStorage(
 	return hdr, nil
 }
 
+// GetExtendedShardHeaderFromStorage gets the extended shard header, which is associated with the given hash, from storage
+func GetExtendedShardHeaderFromStorage(
+	hash []byte,
+	marshaller marshal.Marshalizer,
+	storageService dataRetriever.StorageService,
+) (*block.ShardHeaderExtended, error) {
+	buffHdr, err := GetMarshalizedHeaderFromStorage(dataRetriever.ExtendedShardHeadersUnit, hash, marshaller, storageService)
+	if err != nil {
+		return nil, err
+	}
+
+	hdr := &block.ShardHeaderExtended{}
+	err = marshaller.Unmarshal(hdr, buffHdr)
+	if err != nil {
+		return nil, ErrUnmarshalWithoutSuccess
+	}
+
+	return hdr, nil
+}
+
+// GetExtendedHeaderFromStorageWithNonce method returns an extended block header from storage with a given nonce
+func GetExtendedHeaderFromStorageWithNonce(
+	nonce uint64,
+	storageService dataRetriever.StorageService,
+	uint64Converter typeConverters.Uint64ByteSliceConverter,
+	marshaller marshal.Marshalizer,
+) (*block.ShardHeaderExtended, []byte, error) {
+	hash, err := GetHeaderHashFromStorageWithNonce(
+		nonce,
+		storageService,
+		uint64Converter,
+		marshaller,
+		dataRetriever.ExtendedShardHeadersNonceHashDataUnit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hdr, err := GetExtendedShardHeaderFromStorage(hash, marshaller, storageService)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return hdr, hash, nil
+}
+
 // GetMarshalizedHeaderFromStorage gets the marshalized header, which is associated with the given hash, from storage
 func GetMarshalizedHeaderFromStorage(
 	blockUnit dataRetriever.UnitType,

--- a/process/common_test.go
+++ b/process/common_test.go
@@ -2460,5 +2460,4 @@ func TestGetExtendedHeaderFromStorageWithNonce(t *testing.T) {
 		require.Nil(t, headerHash)
 		require.Nil(t, header)
 	})
-
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- Utility function to get extended header from storage
  
## Proposed changes
- 
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
