### PR TITLE
fix metrics on ProcessBlock

### DIFF
--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -727,10 +727,14 @@ func (scbp *sovereignChainBlockProcessor) ProcessBlock(headerHandler data.Header
 		return nil, nil, process.ErrWrongTypeAssertion
 	}
 
+	getMetricsFromBlockBody(body, scbp.marshalizer, scbp.appStatusHandler)
+
 	txCounts, rewardCounts, unsignedCounts := scbp.txCounter.getPoolCounts(scbp.dataPool)
 	log.Debug("total txs in pool", "counts", txCounts.String())
 	log.Debug("total txs in rewards pool", "counts", rewardCounts.String())
 	log.Debug("total txs in unsigned pool", "counts", unsignedCounts.String())
+
+	getMetricsFromHeader(headerHandler.ShallowClone(), uint64(txCounts.GetTotal()), scbp.marshalizer, scbp.appStatusHandler)
 
 	err = scbp.createBlockStarted()
 	if err != nil {
@@ -788,12 +792,6 @@ func (scbp *sovereignChainBlockProcessor) ProcessBlock(headerHandler data.Header
 		return nil, nil, err
 	}
 
-	newBody := body
-	defer func() {
-		go getMetricsFromHeader(shardHeader.ShallowClone(), uint64(txCounts.GetTotal()), scbp.marshalizer, scbp.appStatusHandler)
-		go getMetricsFromBlockBody(newBody, scbp.marshalizer, scbp.appStatusHandler)
-	}()
-
 	if shardHeader.IsStartOfEpochBlock() {
 		err = scbp.processEpochStartMetaBlock(shardHeader, body)
 		if err != nil {
@@ -809,7 +807,7 @@ func (scbp *sovereignChainBlockProcessor) ProcessBlock(headerHandler data.Header
 		}
 	}()
 
-	newBody, err = scbp.processSovereignBlockTransactions(headerHandler, body, haveTime)
+	newBody, err := scbp.processSovereignBlockTransactions(headerHandler, body, haveTime)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- ProcessBlock metrics sometimes returned pointer error because were using go routines
- 
- 
  
## Proposed changes
- use metrics without go routine
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
