### PR TITLE
updated communication-go dependency

### DIFF
--- a/cmd/node/config/external.toml
+++ b/cmd/node/config/external.toml
@@ -51,7 +51,7 @@
 
     # URL for the WebSocket client/server connection
     # This value represents the IP address and port number that the WebSocket client or server will use to establish a connection.
-    URL = "127.0.0.1:22111"
+    URL = "ws://127.0.0.1:22111"
 
     # After a message will be sent it will wait for an ack message if this flag is enabled
     WithAcknowledge = true

--- a/cmd/sovereignnode/config/sovereignConfig.toml
+++ b/cmd/sovereignnode/config/sovereignConfig.toml
@@ -50,7 +50,7 @@
         { Identifier = "execute", Addresses = ["erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"] }
     ]
     [NotifierConfig.WebSocket]
-        Url = "localhost:22111"
+        Url = "ws://localhost:22111"
         # Possible values: json, gogo protobuf. Should be compatible with mx-chain-node outport driver config
         MarshallerType = "gogo protobuf"
         # Retry duration (receive/send ack signal) in seconds

--- a/cmd/sovereignnode/go.mod
+++ b/cmd/sovereignnode/go.mod
@@ -118,7 +118,7 @@ require (
 	github.com/multiformats/go-multistream v0.4.1 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/multiversx/concurrent-map v0.1.4 // indirect
-	github.com/multiversx/mx-chain-communication-go v1.1.0 // indirect
+	github.com/multiversx/mx-chain-communication-go v1.1.1 // indirect
 	github.com/multiversx/mx-chain-crypto-go v1.2.12 // indirect
 	github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241009093024-7b5c180a61ea // indirect
 	github.com/multiversx/mx-chain-scenario-go v1.4.4 // indirect

--- a/cmd/sovereignnode/go.sum
+++ b/cmd/sovereignnode/go.sum
@@ -383,8 +383,8 @@ github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/n
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
 github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUYwbO0993uPI=
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
-github.com/multiversx/mx-chain-communication-go v1.1.0 h1:J7bX6HoN3HiHY7cUeEjG8AJWgQDDPcY+OPDOsSUOkRE=
-github.com/multiversx/mx-chain-communication-go v1.1.0/go.mod h1:WK6bP4pGEHGDDna/AYRIMtl6G9OA0NByI1Lw8PmOnRM=
+github.com/multiversx/mx-chain-communication-go v1.1.1 h1:y4DoQeQOJTaSUsRzczQFazf8JYQmInddypApqA3AkwM=
+github.com/multiversx/mx-chain-communication-go v1.1.1/go.mod h1:WK6bP4pGEHGDDna/AYRIMtl6G9OA0NByI1Lw8PmOnRM=
 github.com/multiversx/mx-chain-core-go v1.2.23-0.20241007113300-50ac1ae23824 h1:OHYcWOeTNwSaTMRAfusu6/1zoTWGEtHKPBig4dbRAwM=
 github.com/multiversx/mx-chain-core-go v1.2.23-0.20241007113300-50ac1ae23824/go.mod h1:P/YBoFnt25XUaCQ7Q/SD15vhnc9yV5JDhHxyFO9P8Z0=
 github.com/multiversx/mx-chain-crypto-go v1.2.12 h1:zWip7rpUS4CGthJxfKn5MZfMfYPjVjIiCID6uX5BSOk=

--- a/cmd/sovereignnode/systemTestDemo/mockNotifier/vars.go
+++ b/cmd/sovereignnode/systemTestDemo/mockNotifier/vars.go
@@ -18,7 +18,7 @@ var (
 	marshaller, _      = factory.NewMarshalizer("gogo protobuf")
 	pubKeyConverter, _ = pubkeyConverter.NewBech32PubkeyConverter(addressLen, "erd")
 
-	wsURL             = "localhost:22111"
+	wsURL             = "ws://localhost:22111"
 	grpcAddress       = ":8085"
 	subscribedAddress = "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
 )

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/klauspost/cpuid/v2 v2.2.5
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/multiversx/mx-chain-communication-go v1.1.0
+	github.com/multiversx/mx-chain-communication-go v1.1.1
 	github.com/multiversx/mx-chain-core-go v1.2.23-0.20241007113300-50ac1ae23824
 	github.com/multiversx/mx-chain-crypto-go v1.2.12
 	github.com/multiversx/mx-chain-es-indexer-go v1.7.10-0.20241009093024-7b5c180a61ea

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/n
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
 github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUYwbO0993uPI=
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
-github.com/multiversx/mx-chain-communication-go v1.1.0 h1:J7bX6HoN3HiHY7cUeEjG8AJWgQDDPcY+OPDOsSUOkRE=
-github.com/multiversx/mx-chain-communication-go v1.1.0/go.mod h1:WK6bP4pGEHGDDna/AYRIMtl6G9OA0NByI1Lw8PmOnRM=
+github.com/multiversx/mx-chain-communication-go v1.1.1 h1:y4DoQeQOJTaSUsRzczQFazf8JYQmInddypApqA3AkwM=
+github.com/multiversx/mx-chain-communication-go v1.1.1/go.mod h1:WK6bP4pGEHGDDna/AYRIMtl6G9OA0NByI1Lw8PmOnRM=
 github.com/multiversx/mx-chain-core-go v1.2.23-0.20241007113300-50ac1ae23824 h1:OHYcWOeTNwSaTMRAfusu6/1zoTWGEtHKPBig4dbRAwM=
 github.com/multiversx/mx-chain-core-go v1.2.23-0.20241007113300-50ac1ae23824/go.mod h1:P/YBoFnt25XUaCQ7Q/SD15vhnc9yV5JDhHxyFO9P8Z0=
 github.com/multiversx/mx-chain-crypto-go v1.2.12 h1:zWip7rpUS4CGthJxfKn5MZfMfYPjVjIiCID6uX5BSOk=

--- a/outport/factory/hostDriverFactory_test.go
+++ b/outport/factory/hostDriverFactory_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-communication-go/websocket/data"
+	"github.com/stretchr/testify/require"
+
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCreateHostDriver(t *testing.T) {
@@ -15,7 +16,7 @@ func TestCreateHostDriver(t *testing.T) {
 
 	args := ArgsHostDriverFactory{
 		HostConfig: config.HostDriversConfig{
-			URL:                "localhost",
+			URL:                "ws://localhost",
 			RetryDurationInSec: 1,
 			MarshallerType:     "json",
 			Mode:               data.ModeClient,

--- a/outport/factory/outportFactory_test.go
+++ b/outport/factory/outportFactory_test.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/multiversx/mx-chain-communication-go/websocket/data"
 	indexerFactory "github.com/multiversx/mx-chain-es-indexer-go/process/factory"
+	"github.com/multiversx/mx-chain-storage-go/testscommon"
+	"github.com/stretchr/testify/require"
+
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/outport"
 	"github.com/multiversx/mx-chain-go/outport/factory"
 	notifierFactory "github.com/multiversx/mx-chain-go/outport/factory"
 	"github.com/multiversx/mx-chain-go/process/mock"
-	"github.com/multiversx/mx-chain-storage-go/testscommon"
-	"github.com/stretchr/testify/require"
 )
 
 func createMockArgsOutportHandler(indexerEnabled, notifierEnabled bool) *factory.OutportFactoryArgs {
@@ -122,7 +123,7 @@ func TestCreateOutport_SubscribeMultipleHostDrivers(t *testing.T) {
 				Marshaller: &testscommon.MarshalizerMock{},
 				HostConfig: config.HostDriversConfig{
 					Enabled:            true,
-					URL:                "localhost",
+					URL:                "ws://localhost",
 					RetryDurationInSec: 1,
 					MarshallerType:     "json",
 					Mode:               data.ModeClient,
@@ -132,7 +133,7 @@ func TestCreateOutport_SubscribeMultipleHostDrivers(t *testing.T) {
 				Marshaller: &testscommon.MarshalizerMock{},
 				HostConfig: config.HostDriversConfig{
 					Enabled:            false,
-					URL:                "localhost",
+					URL:                "ws://localhost",
 					RetryDurationInSec: 1,
 					MarshallerType:     "json",
 					Mode:               data.ModeClient,
@@ -142,7 +143,7 @@ func TestCreateOutport_SubscribeMultipleHostDrivers(t *testing.T) {
 				Marshaller: &testscommon.MarshalizerMock{},
 				HostConfig: config.HostDriversConfig{
 					Enabled:            true,
-					URL:                "localhost",
+					URL:                "ws://localhost",
 					RetryDurationInSec: 1,
 					MarshallerType:     "json",
 					Mode:               data.ModeClient,

--- a/scripts/testnet/sovereignBridge/observer/deployObserver.sh
+++ b/scripts/testnet/sovereignBridge/observer/deployObserver.sh
@@ -4,8 +4,9 @@ CONTAINER_NAME="sov-observer"
 prepareObserver() {
     manualUpdateConfigFile #update config file
 
-    local DOCKER_IMAGE=""
+    docker rmi $IMAGE_NAME # remove old docker image
 
+    local DOCKER_IMAGE=""
     if [ -n "$1" ]; then
         DOCKER_IMAGE=$1
     else

--- a/scripts/testnet/sovereignBridge/observer/shard-observer
+++ b/scripts/testnet/sovereignBridge/observer/shard-observer
@@ -5,7 +5,7 @@ RUN sed -i '/\[DbLookupExtensions\]/!b;n;c\\tEnabled = true' ./config/config.tom
 RUN sed -i '/\[HostDriversConfig\]/,/^\[/ s/Enabled = false/Enabled = true/' ./config/external.toml
 RUN sed -i '/\[HostDriversConfig\]/,/^\[/ s/MarshallerType = "json"/MarshallerType = "gogo protobuf"/' ./config/external.toml
 RUN sed -i '/\[HostDriversConfig\]/,/^\[/ s/Mode = "client"/Mode = "server"/' ./config/external.toml
-RUN sed -i -E '/\[HostDriversConfig\]/,/^\[/ s|URL = "ws://127.0.0.1:22111"|URL = "ws://0.0.0.0:22111"|g' ./config/external.toml
+RUN sed -i -E '/\[HostDriversConfig\]/,/^\[/ s|URL = "ws://127.0.0.1:22111"|URL = "0.0.0.0:22111"|g' ./config/external.toml
 
 EXPOSE 8080
 EXPOSE 22111

--- a/scripts/testnet/sovereignBridge/observer/shard-observer
+++ b/scripts/testnet/sovereignBridge/observer/shard-observer
@@ -1,11 +1,11 @@
-FROM multiversx/chain-testnet:T1.7.12.0
+FROM multiversx/chain-testnet:latest
 
 WORKDIR /go/mx-chain-go/cmd/node/
 RUN sed -i '/\[DbLookupExtensions\]/!b;n;c\\tEnabled = true' ./config/config.toml
 RUN sed -i '/\[HostDriversConfig\]/,/^\[/ s/Enabled = false/Enabled = true/' ./config/external.toml
 RUN sed -i '/\[HostDriversConfig\]/,/^\[/ s/MarshallerType = "json"/MarshallerType = "gogo protobuf"/' ./config/external.toml
 RUN sed -i '/\[HostDriversConfig\]/,/^\[/ s/Mode = "client"/Mode = "server"/' ./config/external.toml
-RUN sed -i '/\[HostDriversConfig\]/,/^\[/ s/URL = "127.0.0.1:22111"/URL = "0.0.0.0:22111"/' ./config/external.toml
+RUN sed -i -E '/\[HostDriversConfig\]/,/^\[/ s|URL = "ws://127.0.0.1:22111"|URL = "ws://0.0.0.0:22111"|g' ./config/external.toml
 
 EXPOSE 8080
 EXPOSE 22111

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -842,7 +842,7 @@ func GetStatusComponentsFactoryArgsAndProcessComponents(shardCoordinator shardin
 				{
 					MarshallerType:     "json",
 					Mode:               "client",
-					URL:                "localhost:12345",
+					URL:                "ws://localhost:12345",
 					RetryDurationInSec: 1,
 				},
 			},


### PR DESCRIPTION
## Reasoning behind the pull request
- sovereign could not connect to testnet observer because mx-communication-go needs to be updated
- 
- 
  
## Proposed changes
- update dependency mx-communication-go
- fix in configs (similar to [this](https://github.com/multiversx/mx-chain-go/pull/6550/files))
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
