### PR TITLE
fix spamming warnings from apiTransactionProcessor

### DIFF
--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -401,8 +401,11 @@ func (atp *apiTransactionProcessor) getFieldGettersForTx(wrappedTx *txcache.Wrap
 	guardedTx, isGuardedTx := wrappedTx.Tx.(data.GuardedTransactionHandler)
 	if isGuardedTx {
 		fieldGetters[signatureField] = hex.EncodeToString(guardedTx.GetSignature())
-		fieldGetters[guardianField] = atp.addressPubKeyConverter.SilentEncode(guardedTx.GetGuardianAddr(), log)
-		fieldGetters[guardianSignatureField] = hex.EncodeToString(guardedTx.GetGuardianSignature())
+
+		if len(guardedTx.GetGuardianAddr()) > 0 {
+			fieldGetters[guardianField] = atp.addressPubKeyConverter.SilentEncode(guardedTx.GetGuardianAddr(), log)
+			fieldGetters[guardianSignatureField] = hex.EncodeToString(guardedTx.GetGuardianSignature())
+		}
 	}
 
 	return fieldGetters


### PR DESCRIPTION
## Reasoning behind the pull request
- SilentEncode prints a Warn log due to empty guardian address. The proper fix should be inside SilentEncode method, a simple check if len of pkBytes is 0 to return an empty string. Will be fixed in a next release.
  
## Proposed changes
- added a length check for guardian address to avoid SilentEncode on empty string

## Testing procedure
- standard system test, call either /transaction/pool/by-sender with some txs in pool, either /transaction/pool and check for warn like: `bech32PubkeyConverter.SilentEncode       hex buff =  error = wrong size when encoding address, expected length 32, received 0`

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
