### PR TITLE
Mempool: handle not-executable transactions related to guardians

### DIFF
--- a/factory/disabled/txProcessor.go
+++ b/factory/disabled/txProcessor.go
@@ -2,6 +2,7 @@ package disabled
 
 import (
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-go/state"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
@@ -16,6 +17,11 @@ func (txProc *TxProcessor) ProcessTransaction(_ *transaction.Transaction) (vmcom
 
 // VerifyTransaction does nothing as it is disabled
 func (txProc *TxProcessor) VerifyTransaction(_ *transaction.Transaction) error {
+	return nil
+}
+
+// VerifyGuardian does nothing as it is disabled
+func (txProc *TxProcessor) VerifyGuardian(_ *transaction.Transaction, _ state.UserAccountHandler) error {
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/multiversx/mx-chain-es-indexer-go v1.7.10
 	github.com/multiversx/mx-chain-logger-go v1.0.15
 	github.com/multiversx/mx-chain-scenario-go v1.4.4
-	github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241124204157-65f62077d29d
+	github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241125101954-3a7e72740a16
 	github.com/multiversx/mx-chain-vm-common-go v1.5.16
 	github.com/multiversx/mx-chain-vm-go v1.5.37
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.68

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/multiversx/mx-chain-es-indexer-go v1.7.10
 	github.com/multiversx/mx-chain-logger-go v1.0.15
 	github.com/multiversx/mx-chain-scenario-go v1.4.4
-	github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241121073828-1b8274da896a
+	github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241124204157-65f62077d29d
 	github.com/multiversx/mx-chain-vm-common-go v1.5.16
 	github.com/multiversx/mx-chain-vm-go v1.5.37
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.68

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/multiversx/mx-chain-es-indexer-go v1.7.10
 	github.com/multiversx/mx-chain-logger-go v1.0.15
 	github.com/multiversx/mx-chain-scenario-go v1.4.4
-	github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241127074354-d1b4205add9f
+	github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241128102604-90581ee84b60
 	github.com/multiversx/mx-chain-vm-common-go v1.5.16
 	github.com/multiversx/mx-chain-vm-go v1.5.37
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.68

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/multiversx/mx-chain-logger-go v1.0.15 h1:HlNdK8etyJyL9NQ+6mIXyKPEBo+w
 github.com/multiversx/mx-chain-logger-go v1.0.15/go.mod h1:t3PRKaWB1M+i6gUfD27KXgzLJJC+mAQiN+FLlL1yoGQ=
 github.com/multiversx/mx-chain-scenario-go v1.4.4 h1:DVE2V+FPeyD/yWoC+KEfPK3jsFzHeruelESfpTlf460=
 github.com/multiversx/mx-chain-scenario-go v1.4.4/go.mod h1:kI+TWR3oIEgUkbwkHCPo2CQ3VjIge+ezGTibiSGwMxo=
-github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241121073828-1b8274da896a h1:IFyDLwwVKkbvPZYUu/3JQ8Wv/H888ZkU3HnNLRWqx2c=
-github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241121073828-1b8274da896a/go.mod h1:eFDEOrG7Wiyk5I/ObpwcN2eoBlOnnfeEMTvTer1cymk=
+github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241124204157-65f62077d29d h1:C4EfaDJa74hmusFVSozcptrkE91nBL9L1ITZ7Zlk/Zw=
+github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241124204157-65f62077d29d/go.mod h1:eFDEOrG7Wiyk5I/ObpwcN2eoBlOnnfeEMTvTer1cymk=
 github.com/multiversx/mx-chain-vm-common-go v1.5.16 h1:g1SqYjxl7K66Y1O/q6tvDJ37fzpzlxCSfRzSm/woQQY=
 github.com/multiversx/mx-chain-vm-common-go v1.5.16/go.mod h1:1rSkXreUZNXyPTTdhj47M+Fy62yjxbu3aAsXEtKN3UY=
 github.com/multiversx/mx-chain-vm-go v1.5.37 h1:Iy3KCvM+DOq1f9UPA7uYK/rI3ZbBOXc2CVNO2/vm5zw=

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/multiversx/mx-chain-logger-go v1.0.15 h1:HlNdK8etyJyL9NQ+6mIXyKPEBo+w
 github.com/multiversx/mx-chain-logger-go v1.0.15/go.mod h1:t3PRKaWB1M+i6gUfD27KXgzLJJC+mAQiN+FLlL1yoGQ=
 github.com/multiversx/mx-chain-scenario-go v1.4.4 h1:DVE2V+FPeyD/yWoC+KEfPK3jsFzHeruelESfpTlf460=
 github.com/multiversx/mx-chain-scenario-go v1.4.4/go.mod h1:kI+TWR3oIEgUkbwkHCPo2CQ3VjIge+ezGTibiSGwMxo=
-github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241124204157-65f62077d29d h1:C4EfaDJa74hmusFVSozcptrkE91nBL9L1ITZ7Zlk/Zw=
-github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241124204157-65f62077d29d/go.mod h1:eFDEOrG7Wiyk5I/ObpwcN2eoBlOnnfeEMTvTer1cymk=
+github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241125101954-3a7e72740a16 h1:EB2c4hEU7oqAOkeaJFY7yzGlZ75UKrSkxPmvB9d/zb0=
+github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241125101954-3a7e72740a16/go.mod h1:eFDEOrG7Wiyk5I/ObpwcN2eoBlOnnfeEMTvTer1cymk=
 github.com/multiversx/mx-chain-vm-common-go v1.5.16 h1:g1SqYjxl7K66Y1O/q6tvDJ37fzpzlxCSfRzSm/woQQY=
 github.com/multiversx/mx-chain-vm-common-go v1.5.16/go.mod h1:1rSkXreUZNXyPTTdhj47M+Fy62yjxbu3aAsXEtKN3UY=
 github.com/multiversx/mx-chain-vm-go v1.5.37 h1:Iy3KCvM+DOq1f9UPA7uYK/rI3ZbBOXc2CVNO2/vm5zw=

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/multiversx/mx-chain-logger-go v1.0.15 h1:HlNdK8etyJyL9NQ+6mIXyKPEBo+w
 github.com/multiversx/mx-chain-logger-go v1.0.15/go.mod h1:t3PRKaWB1M+i6gUfD27KXgzLJJC+mAQiN+FLlL1yoGQ=
 github.com/multiversx/mx-chain-scenario-go v1.4.4 h1:DVE2V+FPeyD/yWoC+KEfPK3jsFzHeruelESfpTlf460=
 github.com/multiversx/mx-chain-scenario-go v1.4.4/go.mod h1:kI+TWR3oIEgUkbwkHCPo2CQ3VjIge+ezGTibiSGwMxo=
-github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241127074354-d1b4205add9f h1:neI7W8hMHlCfhK1UIb2+jf3SwkpymmCb6BG/0OS7yfI=
-github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241127074354-d1b4205add9f/go.mod h1:eFDEOrG7Wiyk5I/ObpwcN2eoBlOnnfeEMTvTer1cymk=
+github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241128102604-90581ee84b60 h1:XFO7MbjpdSJE/mC8wv3937iIWoAQC9YL2vwzO0bvmMg=
+github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241128102604-90581ee84b60/go.mod h1:eFDEOrG7Wiyk5I/ObpwcN2eoBlOnnfeEMTvTer1cymk=
 github.com/multiversx/mx-chain-vm-common-go v1.5.16 h1:g1SqYjxl7K66Y1O/q6tvDJ37fzpzlxCSfRzSm/woQQY=
 github.com/multiversx/mx-chain-vm-common-go v1.5.16/go.mod h1:1rSkXreUZNXyPTTdhj47M+Fy62yjxbu3aAsXEtKN3UY=
 github.com/multiversx/mx-chain-vm-go v1.5.37 h1:Iy3KCvM+DOq1f9UPA7uYK/rI3ZbBOXc2CVNO2/vm5zw=

--- a/process/block/preprocess/accountStateProvider_test.go
+++ b/process/block/preprocess/accountStateProvider_test.go
@@ -1,84 +1,26 @@
 package preprocess
 
 import (
-	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/process"
-	"github.com/multiversx/mx-chain-go/testscommon/guardianMocks"
+	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/state"
-	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewAccountStateProvider(t *testing.T) {
 	t.Parallel()
 
-	provider, err := newAccountStateProvider(nil, &guardianMocks.GuardedAccountHandlerStub{})
+	provider, err := newAccountStateProvider(nil, &testscommon.TxProcessorStub{})
 	require.Nil(t, provider)
 	require.ErrorIs(t, err, process.ErrNilAccountsAdapter)
 
 	provider, err = newAccountStateProvider(&state.AccountsStub{}, nil)
 	require.Nil(t, provider)
-	require.ErrorIs(t, err, process.ErrNilGuardianChecker)
+	require.ErrorIs(t, err, process.ErrNilTxProcessor)
 
-	provider, err = newAccountStateProvider(&state.AccountsStub{}, &guardianMocks.GuardedAccountHandlerStub{})
+	provider, err = newAccountStateProvider(&state.AccountsStub{}, &testscommon.TxProcessorStub{})
 	require.NoError(t, err)
 	require.NotNil(t, provider)
-}
-
-func TestAccountStateProvider_GetAccountState(t *testing.T) {
-	t.Parallel()
-
-	accounts := &state.AccountsStub{}
-	accounts.GetExistingAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
-		// Alice has no guardian
-		if bytes.Equal(address, []byte("alice")) {
-			return &state.UserAccountStub{
-				Address: []byte("alice"),
-				Nonce:   42,
-			}, nil
-		}
-
-		// Bob has Heidi as guardian
-		if bytes.Equal(address, []byte("bob")) {
-			return &state.UserAccountStub{
-				Address: []byte("bob"),
-				Nonce:   7,
-				IsGuardedCalled: func() bool {
-					return true
-				},
-			}, nil
-		}
-
-		return nil, fmt.Errorf("account not found: %s", address)
-	}
-
-	guardianChecker := &guardianMocks.GuardedAccountHandlerStub{}
-	guardianChecker.GetActiveGuardianCalled = func(userAccount vmcommon.UserAccountHandler) ([]byte, error) {
-		if bytes.Equal(userAccount.AddressBytes(), []byte("bob")) {
-			return []byte("heidi"), nil
-		}
-
-		return nil, nil
-	}
-
-	provider, err := newAccountStateProvider(accounts, guardianChecker)
-	require.NoError(t, err)
-	require.NotNil(t, provider)
-
-	state, err := provider.GetAccountState([]byte("alice"))
-	require.NoError(t, err)
-	require.Equal(t, uint64(42), state.Nonce)
-	require.Nil(t, state.Guardian)
-
-	state, err = provider.GetAccountState([]byte("bob"))
-	require.NoError(t, err)
-	require.Equal(t, uint64(7), state.Nonce)
-	require.Equal(t, []byte("heidi"), state.Guardian)
-
-	state, err = provider.GetAccountState([]byte("carol"))
-	require.ErrorContains(t, err, "account not found: carol")
-	require.Nil(t, state)
 }

--- a/process/block/preprocess/accountStateProvider_test.go
+++ b/process/block/preprocess/accountStateProvider_test.go
@@ -1,11 +1,16 @@
 package preprocess
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
+	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-go/process"
+	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/testscommon"
-	"github.com/multiversx/mx-chain-go/testscommon/state"
+	stateMock "github.com/multiversx/mx-chain-go/testscommon/state"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,11 +21,90 @@ func TestNewAccountStateProvider(t *testing.T) {
 	require.Nil(t, provider)
 	require.ErrorIs(t, err, process.ErrNilAccountsAdapter)
 
-	provider, err = newAccountStateProvider(&state.AccountsStub{}, nil)
+	provider, err = newAccountStateProvider(&stateMock.AccountsStub{}, nil)
 	require.Nil(t, provider)
 	require.ErrorIs(t, err, process.ErrNilTxProcessor)
 
-	provider, err = newAccountStateProvider(&state.AccountsStub{}, &testscommon.TxProcessorStub{})
+	provider, err = newAccountStateProvider(&stateMock.AccountsStub{}, &testscommon.TxProcessorStub{})
 	require.NoError(t, err)
 	require.NotNil(t, provider)
+}
+
+func TestAccountStateProvider_GetAccountState(t *testing.T) {
+	t.Parallel()
+
+	accounts := &stateMock.AccountsStub{}
+	processor := &testscommon.TxProcessorStub{}
+
+	accounts.GetExistingAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
+		if bytes.Equal(address, []byte("alice")) {
+			return &stateMock.UserAccountStub{
+				Address: []byte("alice"),
+				Nonce:   42,
+			}, nil
+		}
+
+		if bytes.Equal(address, []byte("bob")) {
+			return &stateMock.UserAccountStub{
+				Address: []byte("bob"),
+				Nonce:   7,
+				IsGuardedCalled: func() bool {
+					return true
+				},
+			}, nil
+		}
+
+		return nil, fmt.Errorf("account not found: %s", address)
+	}
+
+	provider, err := newAccountStateProvider(accounts, processor)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	state, err := provider.GetAccountState([]byte("alice"))
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), state.Nonce)
+
+	state, err = provider.GetAccountState([]byte("bob"))
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), state.Nonce)
+
+	state, err = provider.GetAccountState([]byte("carol"))
+	require.ErrorContains(t, err, "account not found: carol")
+	require.Nil(t, state)
+}
+
+func TestAccountStateProvider_IsBadlyGuarded(t *testing.T) {
+	t.Parallel()
+
+	accounts := &stateMock.AccountsStub{}
+	processor := &testscommon.TxProcessorStub{}
+
+	accounts.GetExistingAccountCalled = func(address []byte) (vmcommon.AccountHandler, error) {
+		return &stateMock.UserAccountStub{}, nil
+	}
+
+	processor.VerifyGuardianCalled = func(tx *transaction.Transaction, account state.UserAccountHandler) error {
+		if tx.Nonce == 43 {
+			return process.ErrTransactionNotExecutable
+		}
+		if tx.Nonce == 44 {
+			return fmt.Errorf("arbitrary processing error")
+		}
+
+		return nil
+	}
+
+	provider, err := newAccountStateProvider(accounts, processor)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	isBadlyGuarded := provider.IsBadlyGuarded(&transaction.Transaction{Nonce: 42, SndAddr: []byte("alice")})
+	require.False(t, isBadlyGuarded)
+
+	isBadlyGuarded = provider.IsBadlyGuarded(&transaction.Transaction{Nonce: 43, SndAddr: []byte("alice")})
+	require.True(t, isBadlyGuarded)
+
+	isBadlyGuarded = provider.IsBadlyGuarded(&transaction.Transaction{Nonce: 44, SndAddr: []byte("alice")})
+	require.False(t, isBadlyGuarded)
 }

--- a/process/block/preprocess/basePreProcess.go
+++ b/process/block/preprocess/basePreProcess.go
@@ -120,7 +120,6 @@ type basePreProcess struct {
 	blockSizeComputation       BlockSizeComputationHandler
 	balanceComputation         BalanceComputationHandler
 	accounts                   state.AccountsAdapter
-	accountStateProvider       *accountStateProvider
 	pubkeyConverter            core.PubkeyConverter
 	processedMiniBlocksTracker process.ProcessedMiniBlocksTracker
 	enableEpochsHandler        common.EnableEpochsHandler

--- a/process/block/preprocess/interfaces.go
+++ b/process/block/preprocess/interfaces.go
@@ -9,13 +9,13 @@ import (
 
 // SortedTransactionsProvider defines the public API of the transactions cache
 type SortedTransactionsProvider interface {
-	GetSortedTransactions(accountStateProvider txcache.AccountStateProvider) []*txcache.WrappedTransaction
+	GetSortedTransactions(session txcache.SelectionSession) []*txcache.WrappedTransaction
 	IsInterfaceNil() bool
 }
 
 // TxCache defines the functionality for the transactions cache
 type TxCache interface {
-	SelectTransactions(accountStateProvider txcache.AccountStateProvider, gasRequested uint64, maxNum int, selectionLoopMaximumDuration time.Duration) ([]*txcache.WrappedTransaction, uint64)
+	SelectTransactions(session txcache.SelectionSession, gasRequested uint64, maxNum int, selectionLoopMaximumDuration time.Duration) ([]*txcache.WrappedTransaction, uint64)
 	IsInterfaceNil() bool
 }
 

--- a/process/block/preprocess/selectionSession.go
+++ b/process/block/preprocess/selectionSession.go
@@ -49,9 +49,9 @@ func (session *selectionSession) GetAccountState(address []byte) (*txcache.Accou
 	}, nil
 }
 
-// IsBadlyGuarded checks if a transaction is badly guarded (not executable).
+// IsIncorrectlyGuarded checks if a transaction is incorrectly guarded (not executable).
 // Will be called by mempool during transaction selection.
-func (session *selectionSession) IsBadlyGuarded(tx data.TransactionHandler) bool {
+func (session *selectionSession) IsIncorrectlyGuarded(tx data.TransactionHandler) bool {
 	address := tx.GetSndAddr()
 	account, err := session.accountsAdapter.GetExistingAccount(address)
 	if err != nil {
@@ -60,7 +60,8 @@ func (session *selectionSession) IsBadlyGuarded(tx data.TransactionHandler) bool
 
 	userAccount, ok := account.(state.UserAccountHandler)
 	if !ok {
-		return false
+		// On this branch, we are (approximately) mirroring the behavior of "transactionsProcessor.VerifyGuardian()".
+		return true
 	}
 
 	txTyped, ok := tx.(*transaction.Transaction)

--- a/process/block/preprocess/selectionSession.go
+++ b/process/block/preprocess/selectionSession.go
@@ -11,12 +11,12 @@ import (
 	"github.com/multiversx/mx-chain-go/storage/txcache"
 )
 
-type accountStateProvider struct {
+type selectionSession struct {
 	accountsAdapter       state.AccountsAdapter
 	transactionsProcessor process.TransactionProcessor
 }
 
-func newAccountStateProvider(accountsAdapter state.AccountsAdapter, transactionsProcessor process.TransactionProcessor) (*accountStateProvider, error) {
+func newSelectionSession(accountsAdapter state.AccountsAdapter, transactionsProcessor process.TransactionProcessor) (*selectionSession, error) {
 	if check.IfNil(accountsAdapter) {
 		return nil, process.ErrNilAccountsAdapter
 	}
@@ -24,7 +24,7 @@ func newAccountStateProvider(accountsAdapter state.AccountsAdapter, transactions
 		return nil, process.ErrNilTxProcessor
 	}
 
-	return &accountStateProvider{
+	return &selectionSession{
 		accountsAdapter:       accountsAdapter,
 		transactionsProcessor: transactionsProcessor,
 	}, nil
@@ -32,8 +32,8 @@ func newAccountStateProvider(accountsAdapter state.AccountsAdapter, transactions
 
 // GetAccountState returns the state of an account.
 // Will be called by mempool during transaction selection.
-func (provider *accountStateProvider) GetAccountState(address []byte) (*txcache.AccountState, error) {
-	account, err := provider.accountsAdapter.GetExistingAccount(address)
+func (session *selectionSession) GetAccountState(address []byte) (*txcache.AccountState, error) {
+	account, err := session.accountsAdapter.GetExistingAccount(address)
 	if err != nil {
 		return nil, err
 	}
@@ -49,9 +49,10 @@ func (provider *accountStateProvider) GetAccountState(address []byte) (*txcache.
 	}, nil
 }
 
-func (provider *accountStateProvider) IsBadlyGuarded(tx data.TransactionHandler) bool {
+// IsBadlyGuarded checks if a transaction is badly guarded (not executable).
+func (session *selectionSession) IsBadlyGuarded(tx data.TransactionHandler) bool {
 	address := tx.GetSndAddr()
-	account, err := provider.accountsAdapter.GetExistingAccount(address)
+	account, err := session.accountsAdapter.GetExistingAccount(address)
 	if err != nil {
 		return false
 	}
@@ -66,11 +67,11 @@ func (provider *accountStateProvider) IsBadlyGuarded(tx data.TransactionHandler)
 		return false
 	}
 
-	err = provider.transactionsProcessor.VerifyGuardian(txTyped, userAccount)
+	err = session.transactionsProcessor.VerifyGuardian(txTyped, userAccount)
 	return errors.Is(err, process.ErrTransactionNotExecutable)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface
-func (provider *accountStateProvider) IsInterfaceNil() bool {
-	return provider == nil
+func (session *selectionSession) IsInterfaceNil() bool {
+	return session == nil
 }

--- a/process/block/preprocess/selectionSession_test.go
+++ b/process/block/preprocess/selectionSession_test.go
@@ -14,23 +14,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewAccountStateProvider(t *testing.T) {
+func TestNewSelectionSession(t *testing.T) {
 	t.Parallel()
 
-	provider, err := newAccountStateProvider(nil, &testscommon.TxProcessorStub{})
-	require.Nil(t, provider)
+	session, err := newSelectionSession(nil, &testscommon.TxProcessorStub{})
+	require.Nil(t, session)
 	require.ErrorIs(t, err, process.ErrNilAccountsAdapter)
 
-	provider, err = newAccountStateProvider(&stateMock.AccountsStub{}, nil)
-	require.Nil(t, provider)
+	session, err = newSelectionSession(&stateMock.AccountsStub{}, nil)
+	require.Nil(t, session)
 	require.ErrorIs(t, err, process.ErrNilTxProcessor)
 
-	provider, err = newAccountStateProvider(&stateMock.AccountsStub{}, &testscommon.TxProcessorStub{})
+	session, err = newSelectionSession(&stateMock.AccountsStub{}, &testscommon.TxProcessorStub{})
 	require.NoError(t, err)
-	require.NotNil(t, provider)
+	require.NotNil(t, session)
 }
 
-func TestAccountStateProvider_GetAccountState(t *testing.T) {
+func TestSelectionSession_GetAccountState(t *testing.T) {
 	t.Parallel()
 
 	accounts := &stateMock.AccountsStub{}
@@ -57,24 +57,24 @@ func TestAccountStateProvider_GetAccountState(t *testing.T) {
 		return nil, fmt.Errorf("account not found: %s", address)
 	}
 
-	provider, err := newAccountStateProvider(accounts, processor)
+	session, err := newSelectionSession(accounts, processor)
 	require.NoError(t, err)
-	require.NotNil(t, provider)
+	require.NotNil(t, session)
 
-	state, err := provider.GetAccountState([]byte("alice"))
+	state, err := session.GetAccountState([]byte("alice"))
 	require.NoError(t, err)
 	require.Equal(t, uint64(42), state.Nonce)
 
-	state, err = provider.GetAccountState([]byte("bob"))
+	state, err = session.GetAccountState([]byte("bob"))
 	require.NoError(t, err)
 	require.Equal(t, uint64(7), state.Nonce)
 
-	state, err = provider.GetAccountState([]byte("carol"))
+	state, err = session.GetAccountState([]byte("carol"))
 	require.ErrorContains(t, err, "account not found: carol")
 	require.Nil(t, state)
 }
 
-func TestAccountStateProvider_IsBadlyGuarded(t *testing.T) {
+func TestSelectionSession_IsBadlyGuarded(t *testing.T) {
 	t.Parallel()
 
 	accounts := &stateMock.AccountsStub{}
@@ -95,16 +95,16 @@ func TestAccountStateProvider_IsBadlyGuarded(t *testing.T) {
 		return nil
 	}
 
-	provider, err := newAccountStateProvider(accounts, processor)
+	session, err := newSelectionSession(accounts, processor)
 	require.NoError(t, err)
-	require.NotNil(t, provider)
+	require.NotNil(t, session)
 
-	isBadlyGuarded := provider.IsBadlyGuarded(&transaction.Transaction{Nonce: 42, SndAddr: []byte("alice")})
+	isBadlyGuarded := session.IsBadlyGuarded(&transaction.Transaction{Nonce: 42, SndAddr: []byte("alice")})
 	require.False(t, isBadlyGuarded)
 
-	isBadlyGuarded = provider.IsBadlyGuarded(&transaction.Transaction{Nonce: 43, SndAddr: []byte("alice")})
+	isBadlyGuarded = session.IsBadlyGuarded(&transaction.Transaction{Nonce: 43, SndAddr: []byte("alice")})
 	require.True(t, isBadlyGuarded)
 
-	isBadlyGuarded = provider.IsBadlyGuarded(&transaction.Transaction{Nonce: 44, SndAddr: []byte("alice")})
+	isBadlyGuarded = session.IsBadlyGuarded(&transaction.Transaction{Nonce: 44, SndAddr: []byte("alice")})
 	require.False(t, isBadlyGuarded)
 }

--- a/process/block/preprocess/sortedTransactionsProvider.go
+++ b/process/block/preprocess/sortedTransactionsProvider.go
@@ -32,8 +32,8 @@ func newAdapterTxCacheToSortedTransactionsProvider(txCache TxCache) *adapterTxCa
 }
 
 // GetSortedTransactions gets the transactions from the cache
-func (adapter *adapterTxCacheToSortedTransactionsProvider) GetSortedTransactions(accountStateProvider txcache.AccountStateProvider) []*txcache.WrappedTransaction {
-	txs, _ := adapter.txCache.SelectTransactions(accountStateProvider, process.TxCacheSelectionGasRequested, process.TxCacheSelectionMaxNumTxs, process.TxCacheSelectionLoopMaximumDuration)
+func (adapter *adapterTxCacheToSortedTransactionsProvider) GetSortedTransactions(session txcache.SelectionSession) []*txcache.WrappedTransaction {
+	txs, _ := adapter.txCache.SelectTransactions(session, process.TxCacheSelectionGasRequested, process.TxCacheSelectionMaxNumTxs, process.TxCacheSelectionLoopMaximumDuration)
 	return txs
 }
 
@@ -47,7 +47,7 @@ type disabledSortedTransactionsProvider struct {
 }
 
 // GetSortedTransactions returns an empty slice
-func (adapter *disabledSortedTransactionsProvider) GetSortedTransactions(_ txcache.AccountStateProvider) []*txcache.WrappedTransaction {
+func (adapter *disabledSortedTransactionsProvider) GetSortedTransactions(_ txcache.SelectionSession) []*txcache.WrappedTransaction {
 	return make([]*txcache.WrappedTransaction, 0)
 }
 

--- a/process/block/preprocess/transactions.go
+++ b/process/block/preprocess/transactions.go
@@ -159,7 +159,7 @@ func NewTransactionPreprocessor(
 		return nil, process.ErrNilGuardianChecker
 	}
 
-	accountStateProvider, err := newAccountStateProvider(args.Accounts, args.GuardianChecker)
+	accountStateProvider, err := newAccountStateProvider(args.Accounts, args.TxProcessor)
 	if err != nil {
 		return nil, err
 	}

--- a/process/interface.go
+++ b/process/interface.go
@@ -39,6 +39,7 @@ import (
 type TransactionProcessor interface {
 	ProcessTransaction(transaction *transaction.Transaction) (vmcommon.ReturnCode, error)
 	VerifyTransaction(transaction *transaction.Transaction) error
+	VerifyGuardian(tx *transaction.Transaction, account state.UserAccountHandler) error
 	IsInterfaceNil() bool
 }
 

--- a/process/transaction/baseProcess.go
+++ b/process/transaction/baseProcess.go
@@ -119,7 +119,7 @@ func (txProc *baseTxProcessor) checkTxValues(
 	acntSnd, acntDst state.UserAccountHandler,
 	isUserTxOfRelayed bool,
 ) error {
-	err := txProc.verifyGuardian(tx, acntSnd)
+	err := txProc.VerifyGuardian(tx, acntSnd)
 	if err != nil {
 		return err
 	}
@@ -288,7 +288,7 @@ func (txProc *baseTxProcessor) checkGuardedAccountUnguardedTxPermission(tx *tran
 	return nil
 }
 
-func (txProc *baseTxProcessor) verifyGuardian(tx *transaction.Transaction, account state.UserAccountHandler) error {
+func (txProc *baseTxProcessor) VerifyGuardian(tx *transaction.Transaction, account state.UserAccountHandler) error {
 	if check.IfNil(account) {
 		return nil
 	}

--- a/process/transaction/baseProcess_test.go
+++ b/process/transaction/baseProcess_test.go
@@ -231,7 +231,7 @@ func TestBaseTxProcessor_VerifyGuardian(t *testing.T) {
 		t.Parallel()
 
 		localBaseProc := baseProc
-		err := localBaseProc.verifyGuardian(&transaction.Transaction{}, nil)
+		err := localBaseProc.VerifyGuardian(&transaction.Transaction{}, nil)
 		assert.Nil(t, err)
 	})
 	t.Run("guarded account with a not guarded transaction should error", func(t *testing.T) {
@@ -244,7 +244,7 @@ func TestBaseTxProcessor_VerifyGuardian(t *testing.T) {
 			},
 		}
 
-		err := localBaseProc.verifyGuardian(&transaction.Transaction{}, guardedAccount)
+		err := localBaseProc.VerifyGuardian(&transaction.Transaction{}, guardedAccount)
 		assert.ErrorIs(t, err, process.ErrTransactionNotExecutable)
 		assert.Contains(t, err.Error(), "not allowed to bypass guardian")
 	})
@@ -258,7 +258,7 @@ func TestBaseTxProcessor_VerifyGuardian(t *testing.T) {
 			},
 		}
 
-		err := localBaseProc.verifyGuardian(&transaction.Transaction{}, notGuardedAccount)
+		err := localBaseProc.VerifyGuardian(&transaction.Transaction{}, notGuardedAccount)
 		assert.ErrorIs(t, err, process.ErrTransactionNotExecutable)
 		assert.Contains(t, err.Error(), process.ErrGuardedTransactionNotExpected.Error())
 	})
@@ -272,7 +272,7 @@ func TestBaseTxProcessor_VerifyGuardian(t *testing.T) {
 			},
 		}
 
-		err := localBaseProc.verifyGuardian(&transaction.Transaction{}, notGuardedAccount)
+		err := localBaseProc.VerifyGuardian(&transaction.Transaction{}, notGuardedAccount)
 		assert.Nil(t, err)
 	})
 	t.Run("get active guardian fails should error", func(t *testing.T) {
@@ -290,7 +290,7 @@ func TestBaseTxProcessor_VerifyGuardian(t *testing.T) {
 			},
 		}
 
-		err := localBaseProc.verifyGuardian(&transaction.Transaction{}, guardedAccount)
+		err := localBaseProc.VerifyGuardian(&transaction.Transaction{}, guardedAccount)
 		assert.ErrorIs(t, err, process.ErrTransactionNotExecutable)
 		assert.Contains(t, err.Error(), expectedErr.Error())
 	})
@@ -309,7 +309,7 @@ func TestBaseTxProcessor_VerifyGuardian(t *testing.T) {
 			},
 		}
 
-		err := localBaseProc.verifyGuardian(tx, guardedAccount)
+		err := localBaseProc.VerifyGuardian(tx, guardedAccount)
 		assert.ErrorIs(t, err, process.ErrTransactionNotExecutable)
 		assert.Contains(t, err.Error(), process.ErrTransactionAndAccountGuardianMismatch.Error())
 	})
@@ -328,7 +328,7 @@ func TestBaseTxProcessor_VerifyGuardian(t *testing.T) {
 			},
 		}
 
-		err := localBaseProc.verifyGuardian(tx, guardedAccount)
+		err := localBaseProc.VerifyGuardian(tx, guardedAccount)
 		assert.Nil(t, err)
 	})
 }

--- a/process/transaction/export_test.go
+++ b/process/transaction/export_test.go
@@ -100,11 +100,6 @@ func (inTx *InterceptedTransaction) CheckMaxGasPrice() error {
 	return inTx.checkMaxGasPrice()
 }
 
-// VerifyGuardian calls the un-exported method verifyGuardian
-func (txProc *txProcessor) VerifyGuardian(tx *transaction.Transaction, account state.UserAccountHandler) error {
-	return txProc.VerifyGuardian(tx, account)
-}
-
 // ShouldIncreaseNonce calls the un-exported method shouldIncreaseNonce
 func (txProc *txProcessor) ShouldIncreaseNonce(executionErr error) bool {
 	return txProc.shouldIncreaseNonce(executionErr)

--- a/process/transaction/export_test.go
+++ b/process/transaction/export_test.go
@@ -102,7 +102,7 @@ func (inTx *InterceptedTransaction) CheckMaxGasPrice() error {
 
 // VerifyGuardian calls the un-exported method verifyGuardian
 func (txProc *txProcessor) VerifyGuardian(tx *transaction.Transaction, account state.UserAccountHandler) error {
-	return txProc.verifyGuardian(tx, account)
+	return txProc.VerifyGuardian(tx, account)
 }
 
 // ShouldIncreaseNonce calls the un-exported method shouldIncreaseNonce

--- a/storage/txcache/txcache.go
+++ b/storage/txcache/txcache.go
@@ -14,8 +14,8 @@ type AccountState = types.AccountState
 // TxGasHandler handles a transaction gas and gas cost
 type TxGasHandler = txcache.TxGasHandler
 
-// AccountStateProvider provides the state of an account (as seen by the mempool)
-type AccountStateProvider = txcache.AccountStateProvider
+// SelectionSession provides provides blockchain information for transaction selection
+type SelectionSession = txcache.SelectionSession
 
 // ForEachTransaction is an iterator callback
 type ForEachTransaction = txcache.ForEachTransaction

--- a/testscommon/txProcessorMock.go
+++ b/testscommon/txProcessorMock.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-go/state"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
@@ -12,6 +13,7 @@ import (
 type TxProcessorMock struct {
 	ProcessTransactionCalled         func(transaction *transaction.Transaction) (vmcommon.ReturnCode, error)
 	VerifyTransactionCalled          func(tx *transaction.Transaction) error
+	VerifyGuardianCalled             func(tx *transaction.Transaction, account state.UserAccountHandler) error
 	SetBalancesToTrieCalled          func(accBalance map[string]*big.Int) (rootHash []byte, err error)
 	ProcessSmartContractResultCalled func(scr *smartContractResult.SmartContractResult) (vmcommon.ReturnCode, error)
 }
@@ -29,6 +31,15 @@ func (etm *TxProcessorMock) ProcessTransaction(transaction *transaction.Transact
 func (etm *TxProcessorMock) VerifyTransaction(tx *transaction.Transaction) error {
 	if etm.VerifyTransactionCalled != nil {
 		return etm.VerifyTransactionCalled(tx)
+	}
+
+	return nil
+}
+
+// VerifyGuardian -
+func (etm *TxProcessorMock) VerifyGuardian(tx *transaction.Transaction, account state.UserAccountHandler) error {
+	if etm.VerifyGuardianCalled != nil {
+		return etm.VerifyGuardianCalled(tx, account)
 	}
 
 	return nil

--- a/testscommon/txProcessorStub.go
+++ b/testscommon/txProcessorStub.go
@@ -2,6 +2,7 @@ package testscommon
 
 import (
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-go/state"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
@@ -9,6 +10,7 @@ import (
 type TxProcessorStub struct {
 	ProcessTransactionCalled func(transaction *transaction.Transaction) (vmcommon.ReturnCode, error)
 	VerifyTransactionCalled  func(tx *transaction.Transaction) error
+	VerifyGuardianCalled     func(tx *transaction.Transaction, account state.UserAccountHandler) error
 }
 
 // ProcessTransaction -
@@ -24,6 +26,15 @@ func (tps *TxProcessorStub) ProcessTransaction(transaction *transaction.Transact
 func (tps *TxProcessorStub) VerifyTransaction(tx *transaction.Transaction) error {
 	if tps.VerifyTransactionCalled != nil {
 		return tps.VerifyTransactionCalled(tx)
+	}
+
+	return nil
+}
+
+// VerifyGuardian -
+func (tps *TxProcessorStub) VerifyGuardian(tx *transaction.Transaction, account state.UserAccountHandler) error {
+	if tps.VerifyGuardianCalled != nil {
+		return tps.VerifyGuardianCalled(tx, account)
 	}
 
 	return nil


### PR DESCRIPTION
## Reasoning behind the pull request
- This is an improvement upon https://github.com/multiversx/mx-chain-go/pull/6603.
- We should have no / as little as possible not-executable transactions in the bulk of selected transactions.
  
## Proposed changes
- https://github.com/multiversx/mx-chain-storage-go/pull/58
- Inform selection about not-executable transactions related to guardians, through exporting & using the `VerifyGuardian` function.

## Testing procedure
- Standard testing
- Send not-executable transactions (related to guardians). Inspect the logs and assert they aren't selected.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
