### PR TITLE
[sovereign] FIX: disabled accounts db in epoch start interceptor

### DIFF
--- a/epochStart/bootstrap/bootStrapSovereignShardProcessor.go
+++ b/epochStart/bootstrap/bootStrapSovereignShardProcessor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/typeConverters/uint64ByteSlice"
+
 	"github.com/multiversx/mx-chain-go/dataRetriever/factory/containers"
 	requesterscontainer "github.com/multiversx/mx-chain-go/dataRetriever/factory/requestersContainer"
 	"github.com/multiversx/mx-chain-go/dataRetriever/requestHandlers"

--- a/epochStart/bootstrap/bootStrapSovereignShardProcessor_test.go
+++ b/epochStart/bootstrap/bootStrapSovereignShardProcessor_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/stretchr/testify/require"
+
 	"github.com/multiversx/mx-chain-go/common"
 	factoryInterceptors "github.com/multiversx/mx-chain-go/epochStart/bootstrap/factory"
 	"github.com/multiversx/mx-chain-go/process"
@@ -20,7 +22,6 @@ import (
 	epochStartMocks "github.com/multiversx/mx-chain-go/testscommon/bootstrapMocks/epochStart"
 	dataRetrieverMock "github.com/multiversx/mx-chain-go/testscommon/dataRetriever"
 	"github.com/multiversx/mx-chain-go/testscommon/shardingMocks"
-	"github.com/stretchr/testify/require"
 )
 
 func createSovBootStrapProc() *sovereignBootStrapShardProcessor {
@@ -264,6 +265,7 @@ func TestBootStrapSovereignShardProcessor_createEpochStartInterceptorsContainers
 		RequestHandler:          sovProc.requestHandler,
 		SignaturesHandler:       sovProc.mainMessenger,
 		NodeOperationMode:       sovProc.nodeOperationMode,
+		AccountFactory:          sovProc.runTypeComponents.AccountsCreator(),
 	}
 	mainContainer, fullContainer, err := sovProc.createEpochStartInterceptorsContainers(args)
 	require.Nil(t, err)

--- a/epochStart/bootstrap/common.go
+++ b/epochStart/bootstrap/common.go
@@ -7,6 +7,7 @@ import (
 	"github.com/multiversx/mx-chain-go/epochStart"
 	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/sharding/nodesCoordinator"
+	"github.com/multiversx/mx-chain-go/state"
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
 )
@@ -148,6 +149,9 @@ func checkArguments(args ArgsEpochStartBootstrap) error {
 	}
 	if check.IfNil(args.RunTypeComponents.ShardRequestersContainerCreatorHandler()) {
 		return fmt.Errorf("%s: %w", baseErrorMessage, errors.ErrNilShardRequestersContainerCreatorHandler)
+	}
+	if check.IfNil(args.RunTypeComponents.AccountsCreator()) {
+		return fmt.Errorf("%s: %w", baseErrorMessage, state.ErrNilAccountFactory)
 	}
 
 	return nil

--- a/epochStart/bootstrap/disabled/disabledAccountsAdapter.go
+++ b/epochStart/bootstrap/disabled/disabledAccountsAdapter.go
@@ -3,17 +3,26 @@ package disabled
 import (
 	"context"
 
+	"github.com/multiversx/mx-chain-core-go/core/check"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/state"
-	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
 type accountsAdapter struct {
+	accountFactory state.AccountFactory
 }
 
 // NewAccountsAdapter returns a nil implementation of accountsAdapter
-func NewAccountsAdapter() *accountsAdapter {
-	return &accountsAdapter{}
+func NewAccountsAdapter(accountFactory state.AccountFactory) (*accountsAdapter, error) {
+	if check.IfNil(accountFactory) {
+		return nil, state.ErrNilAccountFactory
+	}
+
+	return &accountsAdapter{
+		accountFactory: accountFactory,
+	}, nil
 }
 
 // SetSyncer -
@@ -37,8 +46,8 @@ func (a *accountsAdapter) GetCode(_ []byte) []byte {
 }
 
 // LoadAccount -
-func (a *accountsAdapter) LoadAccount(_ []byte) (vmcommon.AccountHandler, error) {
-	return nil, nil
+func (a *accountsAdapter) LoadAccount(address []byte) (vmcommon.AccountHandler, error) {
+	return a.accountFactory.CreateAccount(address)
 }
 
 // SaveAccount -
@@ -51,13 +60,13 @@ func (a *accountsAdapter) PruneTrie(_ []byte, _ state.TriePruningIdentifier, _ s
 }
 
 // GetExistingAccount -
-func (a *accountsAdapter) GetExistingAccount(_ []byte) (vmcommon.AccountHandler, error) {
-	return nil, nil
+func (a *accountsAdapter) GetExistingAccount(address []byte) (vmcommon.AccountHandler, error) {
+	return a.accountFactory.CreateAccount(address)
 }
 
 // GetAccountFromBytes -
-func (a *accountsAdapter) GetAccountFromBytes(_ []byte, _ []byte) (vmcommon.AccountHandler, error) {
-	return nil, nil
+func (a *accountsAdapter) GetAccountFromBytes(address []byte, _ []byte) (vmcommon.AccountHandler, error) {
+	return a.accountFactory.CreateAccount(address)
 }
 
 // RemoveAccount -

--- a/epochStart/bootstrap/disabled/disabledAccountsAdapter_test.go
+++ b/epochStart/bootstrap/disabled/disabledAccountsAdapter_test.go
@@ -1,0 +1,53 @@
+package disabled
+
+import (
+	"testing"
+
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multiversx/mx-chain-go/state"
+	testState "github.com/multiversx/mx-chain-go/testscommon/state"
+)
+
+func TestNewAccountsAdapter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil input", func(t *testing.T) {
+		accAdapter, err := NewAccountsAdapter(nil)
+		require.Nil(t, accAdapter)
+		require.Equal(t, state.ErrNilAccountFactory, err)
+	})
+	t.Run("should work", func(t *testing.T) {
+		accAdapter, err := NewAccountsAdapter(&testState.AccountsFactoryStub{})
+		require.Nil(t, err)
+		require.False(t, accAdapter.IsInterfaceNil())
+	})
+}
+
+func TestAccountsAdapter_LoadAccount_GetExistingAccount_GetAccountFromBytes(t *testing.T) {
+	t.Parallel()
+
+	accMock := &testState.AccountWrapMock{
+		Address: []byte("addr"),
+	}
+	accFactory := &testState.AccountsFactoryStub{
+		CreateAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
+			accMock.Address = address
+			return accMock, nil
+		},
+	}
+	accAdapter, _ := NewAccountsAdapter(accFactory)
+
+	loadedAcc, err := accAdapter.LoadAccount([]byte("addr1"))
+	require.Nil(t, err)
+	require.Equal(t, accMock, loadedAcc)
+
+	loadedAcc, err = accAdapter.GetExistingAccount([]byte("addr2"))
+	require.Nil(t, err)
+	require.Equal(t, accMock, loadedAcc)
+
+	loadedAcc, err = accAdapter.GetAccountFromBytes([]byte("addr3"), nil)
+	require.Nil(t, err)
+	require.Equal(t, accMock, loadedAcc)
+}

--- a/epochStart/bootstrap/factory/epochStartInterceptorsContainerFactory_test.go
+++ b/epochStart/bootstrap/factory/epochStartInterceptorsContainerFactory_test.go
@@ -1,0 +1,63 @@
+package factory
+
+import (
+	"testing"
+
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multiversx/mx-chain-go/config"
+	"github.com/multiversx/mx-chain-go/epochStart/mock"
+	processMock "github.com/multiversx/mx-chain-go/process/mock"
+	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/dataRetriever"
+	"github.com/multiversx/mx-chain-go/testscommon/state"
+)
+
+func createArgs() ArgsEpochStartInterceptorContainer {
+	pubKeyConv := &testscommon.PubkeyConverterMock{}
+	return ArgsEpochStartInterceptorContainer{
+		CoreComponents: &mock.CoreComponentsMock{
+			AddrPubKeyConv: pubKeyConv,
+		},
+		CryptoComponents:        &mock.CryptoComponentsMock{},
+		Config:                  config.Config{},
+		ShardCoordinator:        &mock.ShardCoordinatorStub{},
+		MainMessenger:           &processMock.TopicHandlerStub{},
+		FullArchiveMessenger:    &processMock.TopicHandlerStub{},
+		DataPool:                &dataRetriever.PoolsHolderStub{},
+		WhiteListHandler:        &testscommon.WhiteListHandlerStub{},
+		WhiteListerVerifiedTxs:  &testscommon.WhiteListHandlerStub{},
+		AddressPubkeyConv:       pubKeyConv,
+		NonceConverter:          &testscommon.Uint64ByteSliceConverterStub{},
+		ChainID:                 []byte{1},
+		ArgumentsParser:         &testscommon.ArgumentParserMock{},
+		HeaderIntegrityVerifier: &processMock.HeaderIntegrityVerifierStub{},
+		RequestHandler:          &testscommon.RequestHandlerStub{},
+		SignaturesHandler:       &processMock.SignaturesHandlerStub{},
+		NodeOperationMode:       "normal",
+		AccountFactory:          &state.AccountsFactoryStub{},
+	}
+}
+
+func TestCreateEpochStartContainerFactoryArgs(t *testing.T) {
+	args := createArgs()
+
+	accMock := &state.AccountWrapMock{
+		Address: []byte("addr"),
+	}
+	accFactory := &state.AccountsFactoryStub{
+		CreateAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
+			return accMock, nil
+		},
+	}
+
+	args.AccountFactory = accFactory
+	createdArgs, err := CreateEpochStartContainerFactoryArgs(args)
+	require.Nil(t, err)
+	require.NotNil(t, createdArgs)
+
+	acc, err := createdArgs.Accounts.LoadAccount([]byte("addr"))
+	require.Nil(t, err)
+	require.Equal(t, accMock, acc)
+}

--- a/epochStart/bootstrap/interface.go
+++ b/epochStart/bootstrap/interface.go
@@ -15,6 +15,7 @@ import (
 	"github.com/multiversx/mx-chain-go/process/block/sovereign"
 	"github.com/multiversx/mx-chain-go/sharding"
 	"github.com/multiversx/mx-chain-go/sharding/nodesCoordinator"
+	"github.com/multiversx/mx-chain-go/state"
 	syncerFactory "github.com/multiversx/mx-chain-go/state/syncer/factory"
 	updateSync "github.com/multiversx/mx-chain-go/update/sync"
 
@@ -98,6 +99,7 @@ type RunTypeComponentsHolder interface {
 	OutGoingOperationsPoolHandler() sovereignBlock.OutGoingOperationsPool
 	DataCodecHandler() sovereign.DataCodecHandler
 	TopicsCheckerHandler() sovereign.TopicsCheckerHandler
+	AccountsCreator() state.AccountFactory
 	IsInterfaceNil() bool
 }
 

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -567,6 +567,7 @@ func (e *epochStartBootstrap) createSyncers() error {
 		RequestHandler:          e.requestHandler,
 		SignaturesHandler:       e.mainMessenger,
 		NodeOperationMode:       e.nodeOperationMode,
+		AccountFactory:          e.runTypeComponents.AccountsCreator(),
 	}
 
 	e.mainInterceptorContainer, e.fullArchiveInterceptorContainer, err = e.bootStrapShardProcessor.createEpochStartInterceptorsContainers(args)

--- a/epochStart/bootstrap/process_test.go
+++ b/epochStart/bootstrap/process_test.go
@@ -733,6 +733,18 @@ func TestNewEpochStartBootstrap_NilArgsChecks(t *testing.T) {
 		require.Nil(t, epochStartProvider)
 		require.True(t, errors.Is(err, errorsMx.ErrNilShardRequestersContainerCreatorHandler))
 	})
+	t.Run("nil AccountFactory, should error", func(t *testing.T) {
+		t.Parallel()
+
+		coreComp, cryptoComp := createComponentsForEpochStart()
+		args := createMockEpochStartBootstrapArgs(coreComp, cryptoComp)
+		rtMock := processMocks.NewRunTypeComponentsStub()
+		rtMock.AccountCreator = nil
+		args.RunTypeComponents = rtMock
+		epochStartProvider, err := NewEpochStartBootstrap(args)
+		require.Nil(t, epochStartProvider)
+		require.True(t, errors.Is(err, state.ErrNilAccountFactory))
+	})
 }
 
 func TestNewEpochStartBootstrap(t *testing.T) {


### PR DESCRIPTION
## Reasoning behind the pull request
- When starting a node in epoch, we create args for interceptors using disabled components
  
## Proposed changes
- One of the disabled component, was the accounts db, which returned a nil acount, which was later being used, causing nil pointer dereference.
- Injected accounts creator from runTypeComps into disabled epoch start accounts db to return dummy/empty accounts

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
