### PR TITLE
Mempool: completely handle fees and transferred balances within "detectWillFeeExceedBalance()"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/multiversx/mx-chain-es-indexer-go v1.7.10
 	github.com/multiversx/mx-chain-logger-go v1.0.15
 	github.com/multiversx/mx-chain-scenario-go v1.4.4
-	github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241127074354-d1b4205add9f
+	github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241127074704-cde9ed9f1a4b
 	github.com/multiversx/mx-chain-vm-common-go v1.5.16
 	github.com/multiversx/mx-chain-vm-go v1.5.37
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.68

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/multiversx/mx-chain-es-indexer-go v1.7.10
 	github.com/multiversx/mx-chain-logger-go v1.0.15
 	github.com/multiversx/mx-chain-scenario-go v1.4.4
-	github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241128102604-90581ee84b60
+	github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241128110709-156b1244e04f
 	github.com/multiversx/mx-chain-vm-common-go v1.5.16
 	github.com/multiversx/mx-chain-vm-go v1.5.37
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.68

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/multiversx/mx-chain-logger-go v1.0.15 h1:HlNdK8etyJyL9NQ+6mIXyKPEBo+w
 github.com/multiversx/mx-chain-logger-go v1.0.15/go.mod h1:t3PRKaWB1M+i6gUfD27KXgzLJJC+mAQiN+FLlL1yoGQ=
 github.com/multiversx/mx-chain-scenario-go v1.4.4 h1:DVE2V+FPeyD/yWoC+KEfPK3jsFzHeruelESfpTlf460=
 github.com/multiversx/mx-chain-scenario-go v1.4.4/go.mod h1:kI+TWR3oIEgUkbwkHCPo2CQ3VjIge+ezGTibiSGwMxo=
-github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241128102604-90581ee84b60 h1:XFO7MbjpdSJE/mC8wv3937iIWoAQC9YL2vwzO0bvmMg=
-github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241128102604-90581ee84b60/go.mod h1:eFDEOrG7Wiyk5I/ObpwcN2eoBlOnnfeEMTvTer1cymk=
+github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241128110709-156b1244e04f h1:sRPekt5fzNr+c7w2IzwufOeqANTT3Du6ciD3FX5mCvI=
+github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241128110709-156b1244e04f/go.mod h1:eFDEOrG7Wiyk5I/ObpwcN2eoBlOnnfeEMTvTer1cymk=
 github.com/multiversx/mx-chain-vm-common-go v1.5.16 h1:g1SqYjxl7K66Y1O/q6tvDJ37fzpzlxCSfRzSm/woQQY=
 github.com/multiversx/mx-chain-vm-common-go v1.5.16/go.mod h1:1rSkXreUZNXyPTTdhj47M+Fy62yjxbu3aAsXEtKN3UY=
 github.com/multiversx/mx-chain-vm-go v1.5.37 h1:Iy3KCvM+DOq1f9UPA7uYK/rI3ZbBOXc2CVNO2/vm5zw=

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/multiversx/mx-chain-logger-go v1.0.15 h1:HlNdK8etyJyL9NQ+6mIXyKPEBo+w
 github.com/multiversx/mx-chain-logger-go v1.0.15/go.mod h1:t3PRKaWB1M+i6gUfD27KXgzLJJC+mAQiN+FLlL1yoGQ=
 github.com/multiversx/mx-chain-scenario-go v1.4.4 h1:DVE2V+FPeyD/yWoC+KEfPK3jsFzHeruelESfpTlf460=
 github.com/multiversx/mx-chain-scenario-go v1.4.4/go.mod h1:kI+TWR3oIEgUkbwkHCPo2CQ3VjIge+ezGTibiSGwMxo=
-github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241127074354-d1b4205add9f h1:neI7W8hMHlCfhK1UIb2+jf3SwkpymmCb6BG/0OS7yfI=
-github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241127074354-d1b4205add9f/go.mod h1:eFDEOrG7Wiyk5I/ObpwcN2eoBlOnnfeEMTvTer1cymk=
+github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241127074704-cde9ed9f1a4b h1:hLbvchGiCZOieZloc20GLvJcs1s2/evx6hkuqRtZKcg=
+github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241127074704-cde9ed9f1a4b/go.mod h1:eFDEOrG7Wiyk5I/ObpwcN2eoBlOnnfeEMTvTer1cymk=
 github.com/multiversx/mx-chain-vm-common-go v1.5.16 h1:g1SqYjxl7K66Y1O/q6tvDJ37fzpzlxCSfRzSm/woQQY=
 github.com/multiversx/mx-chain-vm-common-go v1.5.16/go.mod h1:1rSkXreUZNXyPTTdhj47M+Fy62yjxbu3aAsXEtKN3UY=
 github.com/multiversx/mx-chain-vm-go v1.5.37 h1:Iy3KCvM+DOq1f9UPA7uYK/rI3ZbBOXc2CVNO2/vm5zw=

--- a/process/block/preprocess/selectionSession.go
+++ b/process/block/preprocess/selectionSession.go
@@ -1,32 +1,58 @@
 package preprocess
 
 import (
+	"bytes"
 	"errors"
+	"math/big"
 
+	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/storage/txcache"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+	"github.com/multiversx/mx-chain-vm-common-go/parsers"
 )
 
 type selectionSession struct {
 	accountsAdapter       state.AccountsAdapter
 	transactionsProcessor process.TransactionProcessor
+	callArgumentsParser   process.CallArgumentsParser
+	esdtTransferParser    vmcommon.ESDTTransferParser
 }
 
-func newSelectionSession(accountsAdapter state.AccountsAdapter, transactionsProcessor process.TransactionProcessor) (*selectionSession, error) {
-	if check.IfNil(accountsAdapter) {
+type argsSelectionSession struct {
+	accountsAdapter       state.AccountsAdapter
+	transactionsProcessor process.TransactionProcessor
+	marshalizer           marshal.Marshalizer
+}
+
+func newSelectionSession(args argsSelectionSession) (*selectionSession, error) {
+	if check.IfNil(args.accountsAdapter) {
 		return nil, process.ErrNilAccountsAdapter
 	}
-	if check.IfNil(transactionsProcessor) {
+	if check.IfNil(args.transactionsProcessor) {
 		return nil, process.ErrNilTxProcessor
+	}
+	if check.IfNil(args.marshalizer) {
+		return nil, process.ErrNilMarshalizer
+	}
+
+	argsParser := parsers.NewCallArgsParser()
+
+	esdtTransferParser, err := parsers.NewESDTTransferParser(args.marshalizer)
+	if err != nil {
+		return nil, err
 	}
 
 	return &selectionSession{
-		accountsAdapter:       accountsAdapter,
-		transactionsProcessor: transactionsProcessor,
+		accountsAdapter:       args.accountsAdapter,
+		transactionsProcessor: args.transactionsProcessor,
+		callArgumentsParser:   argsParser,
+		esdtTransferParser:    esdtTransferParser,
 	}, nil
 }
 
@@ -70,6 +96,57 @@ func (session *selectionSession) IsBadlyGuarded(tx data.TransactionHandler) bool
 
 	err = session.transactionsProcessor.VerifyGuardian(txTyped, userAccount)
 	return errors.Is(err, process.ErrTransactionNotExecutable)
+}
+
+// GetTransferredValue returns the value transferred by a transaction.
+func (session *selectionSession) GetTransferredValue(tx data.TransactionHandler) *big.Int {
+	hasValue := tx.GetValue() != nil && tx.GetValue().Sign() != 0
+	if hasValue {
+		// Early exit (optimization): a transaction can either bear a regular value or be a "MultiESDTNFTTransfer".
+		return tx.GetValue()
+	}
+
+	hasData := len(tx.GetData()) > 0
+	if !hasData {
+		// Early exit (optimization): no "MultiESDTNFTTransfer" to parse.
+		return tx.GetValue()
+	}
+
+	maybeMultiTransfer := bytes.HasPrefix(tx.GetData(), []byte(core.BuiltInFunctionMultiESDTNFTTransfer))
+	if !maybeMultiTransfer {
+		// Early exit (optimization).
+		return nil
+	}
+
+	function, args, err := session.callArgumentsParser.ParseData(string(tx.GetData()))
+	if err != nil {
+		return nil
+	}
+
+	if function != core.BuiltInFunctionMultiESDTNFTTransfer {
+		// Early exit (optimization).
+		return nil
+	}
+
+	esdtTransfers, err := session.esdtTransferParser.ParseESDTTransfers(tx.GetSndAddr(), tx.GetRcvAddr(), function, args)
+	if err != nil {
+		return nil
+	}
+
+	accumulatedNativeValue := big.NewInt(0)
+
+	for _, transfer := range esdtTransfers.ESDTTransfers {
+		if transfer.ESDTTokenNonce != 0 {
+			continue
+		}
+		if string(transfer.ESDTTokenName) != vmcommon.EGLDIdentifier {
+			continue
+		}
+
+		_ = accumulatedNativeValue.Add(accumulatedNativeValue, transfer.ESDTValue)
+	}
+
+	return accumulatedNativeValue
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/block/preprocess/selectionSession.go
+++ b/process/block/preprocess/selectionSession.go
@@ -140,6 +140,7 @@ func (session *selectionSession) GetTransferredValue(tx data.TransactionHandler)
 			continue
 		}
 		if string(transfer.ESDTTokenName) != vmcommon.EGLDIdentifier {
+			// We only care about native transfers.
 			continue
 		}
 

--- a/process/block/preprocess/selectionSession_test.go
+++ b/process/block/preprocess/selectionSession_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/state"
 	"github.com/multiversx/mx-chain-go/testscommon"
@@ -17,15 +18,27 @@ import (
 func TestNewSelectionSession(t *testing.T) {
 	t.Parallel()
 
-	session, err := newSelectionSession(nil, &testscommon.TxProcessorStub{})
+	session, err := newSelectionSession(argsSelectionSession{
+		accountsAdapter:       nil,
+		transactionsProcessor: &testscommon.TxProcessorStub{},
+		marshalizer:           &marshal.GogoProtoMarshalizer{},
+	})
 	require.Nil(t, session)
 	require.ErrorIs(t, err, process.ErrNilAccountsAdapter)
 
-	session, err = newSelectionSession(&stateMock.AccountsStub{}, nil)
+	session, err = newSelectionSession(argsSelectionSession{
+		accountsAdapter:       &stateMock.AccountsStub{},
+		transactionsProcessor: nil,
+		marshalizer:           &marshal.GogoProtoMarshalizer{},
+	})
 	require.Nil(t, session)
 	require.ErrorIs(t, err, process.ErrNilTxProcessor)
 
-	session, err = newSelectionSession(&stateMock.AccountsStub{}, &testscommon.TxProcessorStub{})
+	session, err = newSelectionSession(argsSelectionSession{
+		accountsAdapter:       &stateMock.AccountsStub{},
+		transactionsProcessor: &testscommon.TxProcessorStub{},
+		marshalizer:           &marshal.GogoProtoMarshalizer{},
+	})
 	require.NoError(t, err)
 	require.NotNil(t, session)
 }
@@ -57,7 +70,11 @@ func TestSelectionSession_GetAccountState(t *testing.T) {
 		return nil, fmt.Errorf("account not found: %s", address)
 	}
 
-	session, err := newSelectionSession(accounts, processor)
+	session, err := newSelectionSession(argsSelectionSession{
+		accountsAdapter:       accounts,
+		transactionsProcessor: processor,
+		marshalizer:           &marshal.GogoProtoMarshalizer{},
+	})
 	require.NoError(t, err)
 	require.NotNil(t, session)
 
@@ -95,7 +112,11 @@ func TestSelectionSession_IsBadlyGuarded(t *testing.T) {
 		return nil
 	}
 
-	session, err := newSelectionSession(accounts, processor)
+	session, err := newSelectionSession(argsSelectionSession{
+		accountsAdapter:       accounts,
+		transactionsProcessor: processor,
+		marshalizer:           &marshal.GogoProtoMarshalizer{},
+	})
 	require.NoError(t, err)
 	require.NotNil(t, session)
 

--- a/process/block/preprocess/selectionSession_test.go
+++ b/process/block/preprocess/selectionSession_test.go
@@ -3,6 +3,7 @@ package preprocess
 import (
 	"bytes"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
@@ -128,4 +129,49 @@ func TestSelectionSession_IsBadlyGuarded(t *testing.T) {
 
 	isBadlyGuarded = session.IsBadlyGuarded(&transaction.Transaction{Nonce: 44, SndAddr: []byte("alice")})
 	require.False(t, isBadlyGuarded)
+}
+
+func TestSelectionSession_GetTransferredValue(t *testing.T) {
+	t.Parallel()
+
+	session, err := newSelectionSession(argsSelectionSession{
+		accountsAdapter:       &stateMock.AccountsStub{},
+		transactionsProcessor: &testscommon.TxProcessorStub{},
+		marshalizer:           &marshal.GogoProtoMarshalizer{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	t.Run("with value", func(t *testing.T) {
+		value := session.GetTransferredValue(&transaction.Transaction{
+			Value: big.NewInt(1000000000000000000),
+		})
+		require.Equal(t, big.NewInt(1000000000000000000), value)
+	})
+
+	t.Run("with value and data", func(t *testing.T) {
+		value := session.GetTransferredValue(&transaction.Transaction{
+			Value: big.NewInt(1000000000000000000),
+			Data:  []byte("data"),
+		})
+		require.Equal(t, big.NewInt(1000000000000000000), value)
+	})
+
+	t.Run("native transfer within MultiESDTNFTTransfer", func(t *testing.T) {
+		value := session.GetTransferredValue(&transaction.Transaction{
+			SndAddr: testscommon.TestPubKeyAlice,
+			RcvAddr: testscommon.TestPubKeyAlice,
+			Data:    []byte("MultiESDTNFTTransfer@8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8@03@4e46542d313233343536@0a@01@544553542d393837363534@01@01@45474c442d303030303030@@0de0b6b3a7640000"),
+		})
+		require.Equal(t, big.NewInt(1000000000000000000), value)
+	})
+
+	t.Run("native transfer within MultiESDTNFTTransfer; transfer & execute", func(t *testing.T) {
+		value := session.GetTransferredValue(&transaction.Transaction{
+			SndAddr: testscommon.TestPubKeyAlice,
+			RcvAddr: testscommon.TestPubKeyAlice,
+			Data:    []byte("MultiESDTNFTTransfer@00000000000000000500b9353fe8407f87310c87e12fa1ac807f0485da39d152@03@4e46542d313233343536@01@01@4e46542d313233343536@2a@01@45474c442d303030303030@@0de0b6b3a7640000@64756d6d79@07"),
+		})
+		require.Equal(t, big.NewInt(1000000000000000000), value)
+	})
 }

--- a/process/block/preprocess/transactions.go
+++ b/process/block/preprocess/transactions.go
@@ -1411,7 +1411,11 @@ func (txs *transactions) computeSortedTxs(
 	sortedTransactionsProvider := createSortedTransactionsProvider(txShardPool)
 	log.Debug("computeSortedTxs.GetSortedTransactions")
 
-	session, err := newSelectionSession(txs.basePreProcess.accounts, txs.txProcessor)
+	session, err := newSelectionSession(argsSelectionSession{
+		accountsAdapter:       txs.accounts,
+		transactionsProcessor: txs.txProcessor,
+		marshalizer:           txs.marshalizer,
+	})
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- This is an improvement upon https://github.com/multiversx/mx-chain-go/pull/6603.
- We should have no / as little as possible not-executable transactions in the bulk of selected transactions.
  
## Proposed changes
- https://github.com/multiversx/mx-chain-storage-go/pull/59
- Inform selection about the value transferred within a transaction, so that it can stop selecting transactions from a sender that consumes all the balance (no more balance remaining for fees).

## Testing procedure
- Standard testing
- Craft sequences of transactions that also hold not-executable ones (balance consumed by the first of them).

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
