### PR TITLE
RelayedV3 fixes

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -2,7 +2,7 @@ package common
 
 import "github.com/multiversx/mx-chain-core-go/data"
 
-// IsValidRelayedTxV3 returns true if the provided transaction a valid transaction of type relayed v3
+// IsValidRelayedTxV3 returns true if the provided transaction is a valid transaction of type relayed v3
 func IsValidRelayedTxV3(tx data.TransactionHandler) bool {
 	relayedTx, isRelayedV3 := tx.(data.RelayedTransactionHandler)
 	if !isRelayedV3 {
@@ -11,4 +11,16 @@ func IsValidRelayedTxV3(tx data.TransactionHandler) bool {
 	hasValidRelayer := len(relayedTx.GetRelayerAddr()) == len(tx.GetSndAddr()) && len(relayedTx.GetRelayerAddr()) > 0
 	hasValidRelayerSignature := len(relayedTx.GetRelayerSignature()) == len(relayedTx.GetSignature()) && len(relayedTx.GetRelayerSignature()) > 0
 	return hasValidRelayer && hasValidRelayerSignature
+}
+
+// IsRelayedTxV3 returns true if the provided transaction is a transaction of type relayed v3, without any further checks
+func IsRelayedTxV3(tx data.TransactionHandler) bool {
+	relayedTx, isRelayedV3 := tx.(data.RelayedTransactionHandler)
+	if !isRelayedV3 {
+		return false
+	}
+
+	hasRelayer := len(relayedTx.GetRelayerAddr()) > 0
+	hasRelayerSignature := len(relayedTx.GetRelayerSignature()) > 0
+	return hasRelayer || hasRelayerSignature
 }

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsRelayedTxV3(t *testing.T) {
+func TestIsValidRelayedTxV3(t *testing.T) {
 	t.Parallel()
 
 	scr := &smartContractResult.SmartContractResult{}
 	require.False(t, IsValidRelayedTxV3(scr))
+	require.False(t, IsRelayedTxV3(scr))
 
 	notRelayedTxV3 := &transaction.Transaction{
 		Nonce:     1,
@@ -25,6 +26,33 @@ func TestIsRelayedTxV3(t *testing.T) {
 		Signature: []byte("signature"),
 	}
 	require.False(t, IsValidRelayedTxV3(notRelayedTxV3))
+	require.False(t, IsRelayedTxV3(notRelayedTxV3))
+
+	invalidRelayedTxV3 := &transaction.Transaction{
+		Nonce:       1,
+		Value:       big.NewInt(100),
+		RcvAddr:     []byte("receiver"),
+		SndAddr:     []byte("sender0"),
+		GasPrice:    100,
+		GasLimit:    10,
+		Signature:   []byte("signature"),
+		RelayerAddr: []byte("relayer"),
+	}
+	require.False(t, IsValidRelayedTxV3(invalidRelayedTxV3))
+	require.True(t, IsRelayedTxV3(invalidRelayedTxV3))
+
+	invalidRelayedTxV3 = &transaction.Transaction{
+		Nonce:            1,
+		Value:            big.NewInt(100),
+		RcvAddr:          []byte("receiver"),
+		SndAddr:          []byte("sender0"),
+		GasPrice:         100,
+		GasLimit:         10,
+		Signature:        []byte("signature"),
+		RelayerSignature: []byte("signature"),
+	}
+	require.False(t, IsValidRelayedTxV3(invalidRelayedTxV3))
+	require.True(t, IsRelayedTxV3(invalidRelayedTxV3))
 
 	relayedTxV3 := &transaction.Transaction{
 		Nonce:            1,
@@ -38,4 +66,5 @@ func TestIsRelayedTxV3(t *testing.T) {
 		RelayerSignature: []byte("signature"),
 	}
 	require.True(t, IsValidRelayedTxV3(relayedTxV3))
+	require.True(t, IsRelayedTxV3(relayedTxV3))
 }

--- a/factory/disabled/txCoordinator.go
+++ b/factory/disabled/txCoordinator.go
@@ -25,8 +25,8 @@ func (txCoordinator *TxCoordinator) CreateReceiptsHash() ([]byte, error) {
 }
 
 // ComputeTransactionType does nothing as it is disabled
-func (txCoordinator *TxCoordinator) ComputeTransactionType(_ data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-	return 0, 0
+func (txCoordinator *TxCoordinator) ComputeTransactionType(_ data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+	return 0, 0, false
 }
 
 // RequestMiniBlocksAndTransactions does nothing as it is disabled

--- a/integrationTests/chainSimulator/relayedTx/relayedTx_test.go
+++ b/integrationTests/chainSimulator/relayedTx/relayedTx_test.go
@@ -544,11 +544,11 @@ func testRelayedV3MetaInteraction() func(t *testing.T) {
 		err = cs.GenerateBlocks(1)
 		require.NoError(t, err)
 
-		// send relayed tx with invalid value
-		txDataAdd := "createNewDelegationContract@00@00"
+		// send createNewDelegationContract transaction
+		txData := "createNewDelegationContract@00@00"
 		gasLimit := uint64(60000000)
 		value := big.NewInt(0).Mul(oneEGLD, big.NewInt(1250))
-		relayedTx := generateRelayedV3Transaction(sender.Bytes, 0, vm.DelegationManagerSCAddress, relayer.Bytes, value, txDataAdd, gasLimit)
+		relayedTx := generateRelayedV3Transaction(sender.Bytes, 0, vm.DelegationManagerSCAddress, relayer.Bytes, value, txData, gasLimit)
 
 		relayerBefore := getBalance(t, cs, relayer)
 		senderBefore := getBalance(t, cs, sender)
@@ -565,7 +565,7 @@ func testRelayedV3MetaInteraction() func(t *testing.T) {
 		refund := getRefundValue(result.SmartContractResults)
 		consumedFee := big.NewInt(0).Sub(relayerBefore, relayerAfter)
 
-		gasForFullPrice := uint64(len(txDataAdd)*gasPerDataByte + minGasLimit + minGasLimit)
+		gasForFullPrice := uint64(len(txData)*gasPerDataByte + minGasLimit + minGasLimit)
 		gasForDeductedPrice := gasLimit - gasForFullPrice
 		deductedGasPrice := uint64(minGasPrice / deductionFactor)
 		initialFee := gasForFullPrice*minGasPrice + gasForDeductedPrice*deductedGasPrice

--- a/integrationTests/mock/transactionCoordinatorMock.go
+++ b/integrationTests/mock/transactionCoordinatorMock.go
@@ -12,7 +12,7 @@ import (
 
 // TransactionCoordinatorMock -
 type TransactionCoordinatorMock struct {
-	ComputeTransactionTypeCalled                         func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType)
+	ComputeTransactionTypeCalled                         func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool)
 	RequestMiniBlocksAndTransactionsCalled               func(header data.HeaderHandler)
 	RequestBlockTransactionsCalled                       func(body *block.Body)
 	IsDataPreparedForProcessingCalled                    func(haveTime func() time.Duration) error
@@ -55,9 +55,9 @@ func (tcm *TransactionCoordinatorMock) CreateReceiptsHash() ([]byte, error) {
 }
 
 // ComputeTransactionType -
-func (tcm *TransactionCoordinatorMock) ComputeTransactionType(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
+func (tcm *TransactionCoordinatorMock) ComputeTransactionType(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
 	if tcm.ComputeTransactionTypeCalled == nil {
-		return process.MoveBalance, process.MoveBalance
+		return process.MoveBalance, process.MoveBalance, false
 	}
 
 	return tcm.ComputeTransactionTypeCalled(tx)

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -183,7 +183,11 @@ func (atp *apiTransactionProcessor) PopulateComputedFields(tx *transaction.ApiTr
 }
 
 func (atp *apiTransactionProcessor) populateComputedFieldsProcessingType(tx *transaction.ApiTransactionResult) {
-	typeOnSource, typeOnDestination := atp.txTypeHandler.ComputeTransactionType(tx.Tx)
+	typeOnSource, typeOnDestination, isRelayedV3 := atp.txTypeHandler.ComputeTransactionType(tx.Tx)
+	if isRelayedV3 {
+		typeOnSource = process.RelayedTxV3
+		typeOnDestination = process.RelayedTxV3
+	}
 	tx.ProcessingTypeOnSource = typeOnSource.String()
 	tx.ProcessingTypeOnDestination = typeOnDestination.String()
 }

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -1303,8 +1303,8 @@ func TestApiTransactionProcessor_GetTransactionPopulatesComputedFields(t *testin
 	})
 
 	t.Run("ProcessingType", func(t *testing.T) {
-		txTypeHandler.ComputeTransactionTypeCalled = func(data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.MoveBalance, process.SCDeployment
+		txTypeHandler.ComputeTransactionTypeCalled = func(data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.MoveBalance, process.SCDeployment, false
 		}
 
 		dataPool.Transactions().AddData([]byte{0, 2}, &transaction.Transaction{Nonce: 7, SndAddr: []byte("alice"), RcvAddr: []byte("bob")}, 42, "1")
@@ -1347,8 +1347,8 @@ func TestApiTransactionProcessor_PopulateComputedFields(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, processor)
 
-	txTypeHandler.ComputeTransactionTypeCalled = func(data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-		return process.MoveBalance, process.SCDeployment
+	txTypeHandler.ComputeTransactionTypeCalled = func(data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+		return process.MoveBalance, process.SCDeployment, false
 	}
 
 	feeComputer.ComputeTransactionFeeCalled = func(tx *transaction.ApiTransactionResult) *big.Int {

--- a/node/node.go
+++ b/node/node.go
@@ -798,6 +798,7 @@ func (n *Node) commonTransactionValidation(
 		enableSignWithTxHash,
 		n.coreComponents.TxSignHasher(),
 		n.coreComponents.TxVersionChecker(),
+		n.coreComponents.EnableEpochsHandler(),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/node/node.go
+++ b/node/node.go
@@ -723,7 +723,7 @@ func (n *Node) ValidateTransaction(tx *transaction.Transaction) error {
 	if errors.Is(err, process.ErrAccountNotFound) {
 		return fmt.Errorf("%w for address %s",
 			process.ErrInsufficientFunds,
-			n.coreComponents.AddressPubKeyConverter().SilentEncode(tx.SndAddr, log),
+			n.getFeePayer(tx),
 		)
 	}
 
@@ -1543,6 +1543,14 @@ func (n *Node) getKeyBytes(key string) ([]byte, error) {
 	}
 
 	return hex.DecodeString(key)
+}
+
+func (n *Node) getFeePayer(tx *transaction.Transaction) string {
+	if common.IsValidRelayedTxV3(tx) {
+		return n.coreComponents.AddressPubKeyConverter().SilentEncode(tx.GetRelayerAddr(), log)
+	}
+
+	return n.coreComponents.AddressPubKeyConverter().SilentEncode(tx.GetSndAddr(), log)
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -3004,15 +3004,31 @@ func TestValidateTransaction_ShouldAdaptAccountNotFoundError(t *testing.T) {
 		node.WithCryptoComponents(getDefaultCryptoComponents()),
 	)
 
-	tx := &transaction.Transaction{
-		SndAddr:   bytes.Repeat([]byte("1"), 32),
-		RcvAddr:   bytes.Repeat([]byte("1"), 32),
-		Value:     big.NewInt(37),
-		Signature: []byte("signature"),
-		ChainID:   []byte("chainID"),
-	}
-	err := n.ValidateTransaction(tx)
-	require.Equal(t, "insufficient funds for address erd1xycnzvf3xycnzvf3xycnzvf3xycnzvf3xycnzvf3xycnzvf3xycspcqad6", err.Error())
+	t.Run("normal tx", func(t *testing.T) {
+		tx := &transaction.Transaction{
+			SndAddr:   bytes.Repeat([]byte("1"), 32),
+			RcvAddr:   bytes.Repeat([]byte("1"), 32),
+			Value:     big.NewInt(37),
+			Signature: []byte("signature"),
+			ChainID:   []byte("chainID"),
+		}
+
+		err := n.ValidateTransaction(tx)
+		require.Equal(t, "insufficient funds for address erd1xycnzvf3xycnzvf3xycnzvf3xycnzvf3xycnzvf3xycnzvf3xycspcqad6", err.Error())
+	})
+	t.Run("relayed tx v3", func(t *testing.T) {
+		tx := &transaction.Transaction{
+			SndAddr:          bytes.Repeat([]byte("1"), 32),
+			RcvAddr:          bytes.Repeat([]byte("1"), 32),
+			Value:            big.NewInt(37),
+			Signature:        []byte("sSignature"),
+			RelayerAddr:      bytes.Repeat([]byte("2"), 32),
+			RelayerSignature: []byte("rSignature"),
+			ChainID:          []byte("chainID"),
+		}
+		err := n.ValidateTransaction(tx)
+		require.Equal(t, "insufficient funds for address erd1xgeryv3jxgeryv3jxgeryv3jxgeryv3jxgeryv3jxgeryv3jxgeqvw86cj", err.Error())
+	})
 }
 
 func TestCreateShardedStores_NilShardCoordinatorShouldError(t *testing.T) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -5307,7 +5307,7 @@ func getDefaultCoreComponents() *nodeMockFactory.CoreComponentsMock {
 		StartTime:                time.Time{},
 		EpochChangeNotifier:      &epochNotifier.EpochNotifierStub{},
 		TxVersionCheckHandler:    versioning.NewTxVersionChecker(0),
-		EnableEpochsHandlerField: &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
+		EnableEpochsHandlerField: enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.RelayedTransactionsV3Flag),
 	}
 }
 

--- a/outport/process/transactionsfee/transactionsFeeProcessor.go
+++ b/outport/process/transactionsfee/transactionsFeeProcessor.go
@@ -272,7 +272,7 @@ func (tep *transactionsFeeProcessor) setGasUsedAndFeeBasedOnRefundValue(
 	epoch uint32,
 ) {
 	isValidUserTxAfterBaseCostActivation := !check.IfNil(userTx) && tep.enableEpochsHandler.IsFlagEnabledInEpoch(common.FixRelayedBaseCostFlag, epoch)
-	if isValidUserTxAfterBaseCostActivation && !common.IsValidRelayedTxV3(txWithResults.GetTxHandler()) {
+	if isValidUserTxAfterBaseCostActivation && !common.IsRelayedTxV3(txWithResults.GetTxHandler()) {
 		gasUsed, fee := tep.txFeeCalculator.ComputeGasUsedAndFeeBasedOnRefundValue(userTx, refund)
 
 		tx := txWithResults.GetTxHandler()

--- a/process/block/preprocess/gasComputation.go
+++ b/process/block/preprocess/gasComputation.go
@@ -374,7 +374,7 @@ func (gc *gasComputation) ComputeGasProvidedByTx(
 		return txHandler.GetGasLimit(), txHandler.GetGasLimit(), nil
 	}
 
-	txTypeSndShard, txTypeDstShard := gc.txTypeHandler.ComputeTransactionType(txHandler)
+	txTypeSndShard, txTypeDstShard, _ := gc.txTypeHandler.ComputeTransactionType(txHandler)
 	isSCCall := txTypeDstShard == process.SCDeployment ||
 		txTypeDstShard == process.SCInvoking ||
 		txTypeDstShard == process.BuiltInFunctionCall
@@ -403,7 +403,7 @@ func (gc *gasComputation) computeGasProvidedByTxV1(
 ) (uint64, uint64, error) {
 	moveBalanceConsumption := gc.economicsFee.ComputeGasLimit(txHandler)
 
-	txTypeInShard, _ := gc.txTypeHandler.ComputeTransactionType(txHandler)
+	txTypeInShard, _, _ := gc.txTypeHandler.ComputeTransactionType(txHandler)
 	isSCCall := txTypeInShard == process.SCDeployment ||
 		txTypeInShard == process.SCInvoking ||
 		txTypeInShard == process.BuiltInFunctionCall ||

--- a/process/block/preprocess/gasComputation_test.go
+++ b/process/block/preprocess/gasComputation_test.go
@@ -214,8 +214,8 @@ func TestComputeGasProvidedByTx_ShouldWorkWhenTxReceiverAddressIsASmartContractI
 			},
 		},
 		&testscommon.TxTypeHandlerMock{
-			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-				return process.SCInvoking, process.SCInvoking
+			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+				return process.SCInvoking, process.SCInvoking, false
 			}},
 		createEnableEpochsHandler(),
 	)
@@ -237,8 +237,8 @@ func TestComputeGasProvidedByTx_ShouldWorkWhenTxReceiverAddressIsASmartContractC
 			},
 		},
 		&testscommon.TxTypeHandlerMock{
-			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-				return process.MoveBalance, process.SCInvoking
+			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+				return process.MoveBalance, process.SCInvoking, false
 			}},
 		createEnableEpochsHandler(),
 	)
@@ -260,8 +260,8 @@ func TestComputeGasProvidedByTx_ShouldReturnZeroIf0GasLimit(t *testing.T) {
 			},
 		},
 		&testscommon.TxTypeHandlerMock{
-			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-				return process.MoveBalance, process.SCInvoking
+			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+				return process.MoveBalance, process.SCInvoking, false
 			}},
 		createEnableEpochsHandler(),
 	)
@@ -283,8 +283,8 @@ func TestComputeGasProvidedByTx_ShouldReturnGasLimitIfLessThanMoveBalance(t *tes
 			},
 		},
 		&testscommon.TxTypeHandlerMock{
-			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-				return process.MoveBalance, process.SCInvoking
+			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+				return process.MoveBalance, process.SCInvoking, false
 			}},
 		createEnableEpochsHandler(),
 	)
@@ -306,8 +306,8 @@ func TestComputeGasProvidedByTx_ShouldReturnGasLimitWhenRelayed(t *testing.T) {
 			},
 		},
 		&testscommon.TxTypeHandlerMock{
-			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-				return process.RelayedTx, process.RelayedTx
+			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+				return process.RelayedTx, process.RelayedTx, false
 			}},
 		createEnableEpochsHandler(),
 	)
@@ -329,8 +329,8 @@ func TestComputeGasProvidedByTx_ShouldReturnGasLimitWhenRelayedV2(t *testing.T) 
 			},
 		},
 		&testscommon.TxTypeHandlerMock{
-			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-				return process.RelayedTxV2, process.RelayedTxV2
+			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+				return process.RelayedTxV2, process.RelayedTxV2, false
 			}},
 		createEnableEpochsHandler(),
 	)
@@ -413,11 +413,11 @@ func TestComputeGasProvidedByMiniBlock_ShouldWork(t *testing.T) {
 			},
 		},
 		&testscommon.TxTypeHandlerMock{
-			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
+			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
 				if core.IsSmartContractAddress(tx.GetRcvAddr()) {
-					return process.MoveBalance, process.SCInvoking
+					return process.MoveBalance, process.SCInvoking, false
 				}
-				return process.MoveBalance, process.MoveBalance
+				return process.MoveBalance, process.MoveBalance, false
 			}},
 		createEnableEpochsHandler(),
 	)
@@ -453,11 +453,11 @@ func TestComputeGasProvidedByMiniBlock_ShouldWorkV1(t *testing.T) {
 			},
 		},
 		&testscommon.TxTypeHandlerMock{
-			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
+			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
 				if core.IsSmartContractAddress(tx.GetRcvAddr()) {
-					return process.SCInvoking, process.SCInvoking
+					return process.SCInvoking, process.SCInvoking, false
 				}
-				return process.MoveBalance, process.MoveBalance
+				return process.MoveBalance, process.MoveBalance, false
 			}},
 		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
@@ -513,8 +513,8 @@ func TestComputeGasProvidedByTx_ShouldWorkWhenTxReceiverAddressIsASmartContractI
 			},
 		},
 		&testscommon.TxTypeHandlerMock{
-			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-				return process.SCInvoking, process.SCInvoking
+			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+				return process.SCInvoking, process.SCInvoking, false
 			}},
 		createEnableEpochsHandler(),
 	)
@@ -536,8 +536,8 @@ func TestComputeGasProvidedByTx_ShouldWorkWhenTxReceiverAddressIsASmartContractC
 			},
 		},
 		&testscommon.TxTypeHandlerMock{
-			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-				return process.SCInvoking, process.SCInvoking
+			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+				return process.SCInvoking, process.SCInvoking, false
 			}},
 		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)

--- a/process/block/preprocess/transactionsV2.go
+++ b/process/block/preprocess/transactionsV2.go
@@ -561,7 +561,7 @@ func (txs *transactions) getTxAndMbInfo(
 	}
 	numNewTxs := 1
 
-	_, txTypeDstShard := txs.txTypeHandler.ComputeTransactionType(tx)
+	_, txTypeDstShard, _ := txs.txTypeHandler.ComputeTransactionType(tx)
 	isReceiverSmartContractAddress := txTypeDstShard == process.SCDeployment || txTypeDstShard == process.SCInvoking
 	isCrossShardScCallOrSpecialTx := receiverShardID != txs.shardCoordinator.SelfId() &&
 		(isReceiverSmartContractAddress || len(tx.RcvUserName) > 0)
@@ -695,7 +695,7 @@ func (txs *transactions) shouldContinueProcessingScheduledTx(
 
 	mbInfo.senderAddressToSkip = tx.GetSndAddr()
 
-	_, txTypeDstShard := txs.txTypeHandler.ComputeTransactionType(tx)
+	_, txTypeDstShard, _ := txs.txTypeHandler.ComputeTransactionType(tx)
 	isReceiverSmartContractAddress := txTypeDstShard == process.SCDeployment || txTypeDstShard == process.SCInvoking
 	if !isReceiverSmartContractAddress {
 		return nil, nil, false

--- a/process/block/preprocess/transactionsV2_test.go
+++ b/process/block/preprocess/transactionsV2_test.go
@@ -66,11 +66,11 @@ func createTransactionPreprocessor() *transactions {
 		},
 		EnableEpochsHandler: &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
 		TxTypeHandler: &testscommon.TxTypeHandlerMock{
-			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
+			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
 				if bytes.Equal(tx.GetRcvAddr(), []byte("smart contract address")) {
-					return process.MoveBalance, process.SCInvoking
+					return process.MoveBalance, process.SCInvoking, false
 				}
-				return process.MoveBalance, process.MoveBalance
+				return process.MoveBalance, process.MoveBalance, false
 			},
 		},
 		ScheduledTxsExecutionHandler: &testscommon.ScheduledTxsExecutionStub{},

--- a/process/coordinator/process.go
+++ b/process/coordinator/process.go
@@ -1622,7 +1622,7 @@ func (tc *transactionCoordinator) checkGasProvidedByMiniBlockInReceiverShard(
 			return process.ErrMissingTransaction
 		}
 
-		_, txTypeDstShard := tc.txTypeHandler.ComputeTransactionType(txHandler)
+		_, txTypeDstShard, _ := tc.txTypeHandler.ComputeTransactionType(txHandler)
 		moveBalanceGasLimit := tc.economicsFee.ComputeGasLimit(txHandler)
 		if txTypeDstShard == process.MoveBalance {
 			gasProvidedByTxInReceiverShard = moveBalanceGasLimit

--- a/process/coordinator/process_test.go
+++ b/process/coordinator/process_test.go
@@ -3245,8 +3245,8 @@ func TestTransactionCoordinator_CheckGasProvidedByMiniBlockInReceiverShardShould
 			},
 		},
 		TxTypeHandler: &testscommon.TxTypeHandlerMock{
-			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-				return process.MoveBalance, process.SCInvoking
+			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+				return process.MoveBalance, process.SCInvoking, false
 			},
 		},
 		TransactionsLogProcessor:     &mock.TxLogsProcessorStub{},
@@ -3302,8 +3302,8 @@ func TestTransactionCoordinator_CheckGasProvidedByMiniBlockInReceiverShardShould
 			},
 		},
 		TxTypeHandler: &testscommon.TxTypeHandlerMock{
-			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-				return process.MoveBalance, process.SCInvoking
+			ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+				return process.MoveBalance, process.SCInvoking, false
 			},
 		},
 		TransactionsLogProcessor:     &mock.TxLogsProcessorStub{},

--- a/process/coordinator/transactionType.go
+++ b/process/coordinator/transactionType.go
@@ -83,7 +83,7 @@ func (tth *txTypeHandler) ComputeTransactionType(tx data.TransactionHandler) (pr
 		return process.InvalidTransaction, process.InvalidTransaction, false
 	}
 
-	isRelayedV3 := common.IsValidRelayedTxV3(tx)
+	isRelayedV3 := common.IsRelayedTxV3(tx)
 
 	isEmptyAddress := tth.isDestAddressEmpty(tx)
 	if isEmptyAddress {

--- a/process/coordinator/transactionType.go
+++ b/process/coordinator/transactionType.go
@@ -77,63 +77,61 @@ func NewTxTypeHandler(
 }
 
 // ComputeTransactionType calculates the transaction type
-func (tth *txTypeHandler) ComputeTransactionType(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
+func (tth *txTypeHandler) ComputeTransactionType(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
 	err := tth.checkTxValidity(tx)
 	if err != nil {
-		return process.InvalidTransaction, process.InvalidTransaction
+		return process.InvalidTransaction, process.InvalidTransaction, false
 	}
 
-	if common.IsValidRelayedTxV3(tx) {
-		return process.RelayedTxV3, process.RelayedTxV3
-	}
+	isRelayedV3 := common.IsValidRelayedTxV3(tx)
 
 	isEmptyAddress := tth.isDestAddressEmpty(tx)
 	if isEmptyAddress {
 		if len(tx.GetData()) > 0 {
-			return process.SCDeployment, process.SCDeployment
+			return process.SCDeployment, process.SCDeployment, isRelayedV3
 		}
-		return process.InvalidTransaction, process.InvalidTransaction
+		return process.InvalidTransaction, process.InvalidTransaction, isRelayedV3
 	}
 	if len(tx.GetData()) == 0 {
-		return process.MoveBalance, process.MoveBalance
+		return process.MoveBalance, process.MoveBalance, isRelayedV3
 	}
 
 	funcName, args := tth.getFunctionFromArguments(tx.GetData())
 	isBuiltInFunction := tth.isBuiltInFunctionCall(funcName)
 	if isBuiltInFunction {
 		if tth.isSCCallAfterBuiltIn(funcName, args, tx) {
-			return process.BuiltInFunctionCall, process.SCInvoking
+			return process.BuiltInFunctionCall, process.SCInvoking, isRelayedV3
 		}
 
-		return process.BuiltInFunctionCall, process.BuiltInFunctionCall
+		return process.BuiltInFunctionCall, process.BuiltInFunctionCall, isRelayedV3
 	}
 
 	if isCallOfType(tx, vm.AsynchronousCallBack) {
-		return process.SCInvoking, process.SCInvoking
+		return process.SCInvoking, process.SCInvoking, isRelayedV3
 	}
 
 	if len(funcName) == 0 {
-		return process.MoveBalance, process.MoveBalance
+		return process.MoveBalance, process.MoveBalance, isRelayedV3
 	}
 
 	if tth.isRelayedTransactionV1(funcName) {
-		return process.RelayedTx, process.RelayedTx
+		return process.RelayedTx, process.RelayedTx, isRelayedV3 // this should never be reached with both relayed v1 and relayed v3
 	}
 
 	if tth.isRelayedTransactionV2(funcName) {
-		return process.RelayedTxV2, process.RelayedTxV2
+		return process.RelayedTxV2, process.RelayedTxV2, isRelayedV3 // this should never be reached with both relayed v2 and relayed v3
 	}
 
 	isDestInSelfShard := tth.isDestAddressInSelfShard(tx.GetRcvAddr())
 	if isDestInSelfShard && core.IsSmartContractAddress(tx.GetRcvAddr()) {
-		return process.SCInvoking, process.SCInvoking
+		return process.SCInvoking, process.SCInvoking, isRelayedV3
 	}
 
 	if core.IsSmartContractAddress(tx.GetRcvAddr()) {
-		return process.MoveBalance, process.SCInvoking
+		return process.MoveBalance, process.SCInvoking, isRelayedV3
 	}
 
-	return process.MoveBalance, process.MoveBalance
+	return process.MoveBalance, process.MoveBalance, isRelayedV3
 }
 
 func isCallOfType(tx data.TransactionHandler, callType vm.CallType) bool {

--- a/process/coordinator/transactionType_test.go
+++ b/process/coordinator/transactionType_test.go
@@ -124,9 +124,10 @@ func TestTxTypeHandler_ComputeTransactionTypeNil(t *testing.T) {
 	assert.NotNil(t, tth)
 	assert.Nil(t, err)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(nil)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(nil)
 	assert.Equal(t, process.InvalidTransaction, txTypeIn)
 	assert.Equal(t, process.InvalidTransaction, txTypeCross)
+	assert.False(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeNilTx(t *testing.T) {
@@ -145,9 +146,10 @@ func TestTxTypeHandler_ComputeTransactionTypeNilTx(t *testing.T) {
 	tx.Value = big.NewInt(45)
 
 	tx = nil
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
 	assert.Equal(t, process.InvalidTransaction, txTypeIn)
 	assert.Equal(t, process.InvalidTransaction, txTypeCross)
+	assert.False(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeErrWrongTransaction(t *testing.T) {
@@ -165,9 +167,10 @@ func TestTxTypeHandler_ComputeTransactionTypeErrWrongTransaction(t *testing.T) {
 	tx.RcvAddr = nil
 	tx.Value = big.NewInt(45)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
 	assert.Equal(t, process.InvalidTransaction, txTypeIn)
 	assert.Equal(t, process.InvalidTransaction, txTypeCross)
+	assert.False(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeScDeployment(t *testing.T) {
@@ -186,9 +189,10 @@ func TestTxTypeHandler_ComputeTransactionTypeScDeployment(t *testing.T) {
 	tx.Data = []byte("data")
 	tx.Value = big.NewInt(45)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
 	assert.Equal(t, process.SCDeployment, txTypeIn)
 	assert.Equal(t, process.SCDeployment, txTypeCross)
+	assert.False(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeBuiltInFunctionCallNftTransfer(t *testing.T) {
@@ -221,9 +225,10 @@ func TestTxTypeHandler_ComputeTransactionTypeBuiltInFunctionCallNftTransfer(t *t
 
 	tx.Value = big.NewInt(45)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
 	assert.Equal(t, process.BuiltInFunctionCall, txTypeIn)
 	assert.Equal(t, process.SCInvoking, txTypeCross)
+	assert.False(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeBuiltInFunctionCallEsdtTransfer(t *testing.T) {
@@ -250,9 +255,10 @@ func TestTxTypeHandler_ComputeTransactionTypeBuiltInFunctionCallEsdtTransfer(t *
 		"@" + hex.EncodeToString(big.NewInt(10).Bytes()))
 	tx.Value = big.NewInt(45)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
 	assert.Equal(t, process.BuiltInFunctionCall, txTypeIn)
 	assert.Equal(t, process.BuiltInFunctionCall, txTypeCross)
+	assert.False(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeRecv0AddressWrongTransaction(t *testing.T) {
@@ -271,9 +277,10 @@ func TestTxTypeHandler_ComputeTransactionTypeRecv0AddressWrongTransaction(t *tes
 	tx.Data = nil
 	tx.Value = big.NewInt(45)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
 	assert.Equal(t, process.InvalidTransaction, txTypeIn)
 	assert.Equal(t, process.InvalidTransaction, txTypeCross)
+	assert.False(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeScInvoking(t *testing.T) {
@@ -292,9 +299,10 @@ func TestTxTypeHandler_ComputeTransactionTypeScInvoking(t *testing.T) {
 	assert.NotNil(t, tth)
 	assert.Nil(t, err)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
 	assert.Equal(t, process.SCInvoking, txTypeIn)
 	assert.Equal(t, process.SCInvoking, txTypeCross)
+	assert.False(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeMoveBalance(t *testing.T) {
@@ -318,9 +326,10 @@ func TestTxTypeHandler_ComputeTransactionTypeMoveBalance(t *testing.T) {
 	assert.NotNil(t, tth)
 	assert.Nil(t, err)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
 	assert.Equal(t, process.MoveBalance, txTypeIn)
 	assert.Equal(t, process.MoveBalance, txTypeCross)
+	assert.False(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeBuiltInFunc(t *testing.T) {
@@ -347,9 +356,10 @@ func TestTxTypeHandler_ComputeTransactionTypeBuiltInFunc(t *testing.T) {
 	assert.NotNil(t, tth)
 	assert.Nil(t, err)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
 	assert.Equal(t, process.BuiltInFunctionCall, txTypeIn)
 	assert.Equal(t, process.BuiltInFunctionCall, txTypeCross)
+	assert.False(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeBuiltInFuncNotActiveMoveBalance(t *testing.T) {
@@ -378,9 +388,10 @@ func TestTxTypeHandler_ComputeTransactionTypeBuiltInFuncNotActiveMoveBalance(t *
 	assert.NotNil(t, tth)
 	assert.Nil(t, err)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
 	assert.Equal(t, process.MoveBalance, txTypeIn)
 	assert.Equal(t, process.MoveBalance, txTypeCross)
+	assert.False(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeBuiltInFuncNotActiveSCCall(t *testing.T) {
@@ -409,9 +420,10 @@ func TestTxTypeHandler_ComputeTransactionTypeBuiltInFuncNotActiveSCCall(t *testi
 	assert.NotNil(t, tth)
 	assert.Nil(t, err)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
 	assert.Equal(t, process.SCInvoking, txTypeIn)
 	assert.Equal(t, process.SCInvoking, txTypeCross)
+	assert.False(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeRelayedFunc(t *testing.T) {
@@ -435,9 +447,10 @@ func TestTxTypeHandler_ComputeTransactionTypeRelayedFunc(t *testing.T) {
 	assert.NotNil(t, tth)
 	assert.Nil(t, err)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
 	assert.Equal(t, process.RelayedTx, txTypeIn)
 	assert.Equal(t, process.RelayedTx, txTypeCross)
+	assert.False(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeRelayedV2Func(t *testing.T) {
@@ -461,9 +474,10 @@ func TestTxTypeHandler_ComputeTransactionTypeRelayedV2Func(t *testing.T) {
 	assert.NotNil(t, tth)
 	assert.Nil(t, err)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
 	assert.Equal(t, process.RelayedTxV2, txTypeIn)
 	assert.Equal(t, process.RelayedTxV2, txTypeCross)
+	assert.False(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeRelayedV3(t *testing.T) {
@@ -489,9 +503,10 @@ func TestTxTypeHandler_ComputeTransactionTypeRelayedV3(t *testing.T) {
 	assert.NotNil(t, tth)
 	assert.Nil(t, err)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
-	assert.Equal(t, process.RelayedTxV3, txTypeIn)
-	assert.Equal(t, process.RelayedTxV3, txTypeCross)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
+	assert.Equal(t, process.MoveBalance, txTypeIn)
+	assert.Equal(t, process.MoveBalance, txTypeCross)
+	assert.True(t, isRelayedV3)
 }
 
 func TestTxTypeHandler_ComputeTransactionTypeForSCRCallBack(t *testing.T) {
@@ -516,7 +531,8 @@ func TestTxTypeHandler_ComputeTransactionTypeForSCRCallBack(t *testing.T) {
 	assert.NotNil(t, tth)
 	assert.Nil(t, err)
 
-	txTypeIn, txTypeCross := tth.ComputeTransactionType(tx)
+	txTypeIn, txTypeCross, isRelayedV3 := tth.ComputeTransactionType(tx)
 	assert.Equal(t, process.SCInvoking, txTypeIn)
 	assert.Equal(t, process.SCInvoking, txTypeCross)
+	assert.False(t, isRelayedV3)
 }

--- a/process/dataValidators/txValidator.go
+++ b/process/dataValidators/txValidator.go
@@ -109,7 +109,7 @@ func (txv *txValidator) getFeePayerAccount(
 	payerAccount := accountHandler
 
 	tx := interceptedTx.Transaction()
-	if common.IsValidRelayedTxV3(tx) {
+	if common.IsRelayedTxV3(tx) {
 		relayedTx := tx.(data.RelayedTransactionHandler)
 		payerAddress = relayedTx.GetRelayerAddr()
 		relayerAccount, err := txv.accounts.GetExistingAccount(payerAddress)

--- a/process/disabled/txTypeHandler.go
+++ b/process/disabled/txTypeHandler.go
@@ -17,9 +17,9 @@ func NewTxTypeHandler() *txTypeHandler {
 }
 
 // ComputeTransactionType always returns invalid transaction as it is disabled
-func (handler *txTypeHandler) ComputeTransactionType(_ data.TransactionHandler) (process.TransactionType, process.TransactionType) {
+func (handler *txTypeHandler) ComputeTransactionType(_ data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
 	log.Warn("disabled txTypeHandler ComputeTransactionType always returns invalid transaction")
-	return process.InvalidTransaction, process.InvalidTransaction
+	return process.InvalidTransaction, process.InvalidTransaction, false
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/economics/economicsData.go
+++ b/process/economics/economicsData.go
@@ -611,7 +611,7 @@ func (ed *economicsData) ComputeGasLimitBasedOnBalanceInEpoch(tx data.Transactio
 
 // getExtraGasLimitRelayedTx returns extra gas limit for relayed tx in a specific epoch
 func (ed *economicsData) getExtraGasLimitRelayedTx(txInstance *transaction.Transaction, epoch uint32) uint64 {
-	if common.IsValidRelayedTxV3(txInstance) {
+	if common.IsRelayedTxV3(txInstance) {
 		return ed.MinGasLimitInEpoch(epoch)
 	}
 

--- a/process/errors.go
+++ b/process/errors.go
@@ -1235,3 +1235,6 @@ var ErrRelayedTxV3Disabled = errors.New("relayed tx v3 are disabled")
 
 // ErrGuardedRelayerNotAllowed signals that the provided relayer is guarded
 var ErrGuardedRelayerNotAllowed = errors.New("guarded relayer not allowed")
+
+// ErrRelayedByGuardianNotAllowed signals that the provided guardian is also the relayer
+var ErrRelayedByGuardianNotAllowed = errors.New("relayed by guardian not allowed")

--- a/process/errors.go
+++ b/process/errors.go
@@ -1238,3 +1238,6 @@ var ErrGuardedRelayerNotAllowed = errors.New("guarded relayer not allowed")
 
 // ErrRelayedByGuardianNotAllowed signals that the provided guardian is also the relayer
 var ErrRelayedByGuardianNotAllowed = errors.New("relayed by guardian not allowed")
+
+// ErrInvalidRelayedTxV3 signals that an invalid relayed tx v3 has been provided
+var ErrInvalidRelayedTxV3 = errors.New("invalid relayed transaction")

--- a/process/interceptors/factory/interceptedTxDataFactory.go
+++ b/process/interceptors/factory/interceptedTxDataFactory.go
@@ -130,6 +130,7 @@ func (itdf *interceptedTxDataFactory) Create(buff []byte) (process.InterceptedDa
 		itdf.enableEpochsHandler.IsFlagEnabled(common.TransactionSignedWithTxHashFlag),
 		itdf.txSignHasher,
 		itdf.txVersionChecker,
+		itdf.enableEpochsHandler,
 	)
 }
 

--- a/process/interface.go
+++ b/process/interface.go
@@ -68,7 +68,7 @@ type SmartContractProcessorFacade interface {
 
 // TxTypeHandler is an interface to calculate the transaction type
 type TxTypeHandler interface {
-	ComputeTransactionType(tx data.TransactionHandler) (TransactionType, TransactionType)
+	ComputeTransactionType(tx data.TransactionHandler) (TransactionType, TransactionType, bool)
 	IsInterfaceNil() bool
 }
 

--- a/process/mock/multipleShardsCoordinatorMock.go
+++ b/process/mock/multipleShardsCoordinatorMock.go
@@ -6,6 +6,7 @@ import (
 
 type multipleShardsCoordinatorMock struct {
 	ComputeIdCalled func(address []byte) uint32
+	SameShardCalled func(firstAddress, secondAddress []byte) bool
 	noShards        uint32
 	CurrentShard    uint32
 }
@@ -44,7 +45,10 @@ func (scm *multipleShardsCoordinatorMock) SetSelfId(_ uint32) error {
 }
 
 // SameShard -
-func (scm *multipleShardsCoordinatorMock) SameShard(_, _ []byte) bool {
+func (scm *multipleShardsCoordinatorMock) SameShard(firstAddress, secondAddress []byte) bool {
+	if scm.SameShardCalled != nil {
+		return scm.SameShardCalled(firstAddress, secondAddress)
+	}
 	return true
 }
 

--- a/process/smartContract/process.go
+++ b/process/smartContract/process.go
@@ -955,7 +955,7 @@ func (sc *scProcessor) doExecuteBuiltInFunction(
 		return sc.finishSCExecution(make([]data.TransactionHandler, 0), txHash, tx, vmOutput, 0)
 	}
 
-	_, txTypeOnDst := sc.txTypeHandler.ComputeTransactionType(tx)
+	_, txTypeOnDst, _ := sc.txTypeHandler.ComputeTransactionType(tx)
 	builtInFuncGasUsed, err := sc.computeBuiltInFuncGasUsed(txTypeOnDst, vmInput.Function, vmInput.GasProvided, vmOutput.GasRemaining, check.IfNil(acntSnd))
 	log.LogIfError(err, "function", "ExecuteBuiltInFunction.computeBuiltInFuncGasUsed")
 
@@ -1473,7 +1473,7 @@ func (sc *scProcessor) processIfErrorWithAddedLogs(
 		Logs:          processIfErrorLogs,
 	}, 0)
 
-	txType, _ := sc.txTypeHandler.ComputeTransactionType(tx)
+	txType, _, _ := sc.txTypeHandler.ComputeTransactionType(tx)
 	isCrossShardMoveBalance := txType == process.MoveBalance && check.IfNil(acntSnd)
 	if isCrossShardMoveBalance && sc.enableEpochsHandler.IsFlagEnabled(common.SCDeployFlag) {
 		// move balance was already consumed in sender shard
@@ -2808,7 +2808,7 @@ func (sc *scProcessor) ProcessSmartContractResult(scr *smartContractResult.Smart
 
 	gasLocked := sc.getGasLockedFromSCR(scr)
 
-	txType, _ := sc.txTypeHandler.ComputeTransactionType(scr)
+	txType, _, _ := sc.txTypeHandler.ComputeTransactionType(scr)
 	switch txType {
 	case process.MoveBalance:
 		err = sc.processSimpleSCR(scr, txHash, dstAcc)

--- a/process/smartContract/process_test.go
+++ b/process/smartContract/process_test.go
@@ -3196,8 +3196,8 @@ func TestScProcessor_ProcessSmartContractResultDeploySCShouldError(t *testing.T)
 	arguments.AccountsDB = accountsDB
 	arguments.ShardCoordinator = shardCoordinator
 	arguments.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.SCDeployment, process.SCDeployment
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.SCDeployment, process.SCDeployment, false
 		},
 	}
 	sc, err := NewSmartContractProcessor(arguments)
@@ -3257,8 +3257,8 @@ func TestScProcessor_ProcessSmartContractResultExecuteSC(t *testing.T) {
 		},
 	}
 	arguments.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.SCInvoking, process.SCInvoking
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.SCInvoking, process.SCInvoking, false
 		},
 	}
 	sc, err := NewSmartContractProcessor(arguments)
@@ -3320,8 +3320,8 @@ func TestScProcessor_ProcessSmartContractResultExecuteSCIfMetaAndBuiltIn(t *test
 		},
 	}
 	arguments.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.BuiltInFunctionCall, process.BuiltInFunctionCall
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.BuiltInFunctionCall, process.BuiltInFunctionCall, false
 		},
 	}
 	enableEpochsHandlerStub := enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.SCDeployFlag)
@@ -3394,8 +3394,8 @@ func TestScProcessor_ProcessRelayedSCRValueBackToRelayer(t *testing.T) {
 		},
 	}
 	arguments.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.SCInvoking, process.SCInvoking
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.SCInvoking, process.SCInvoking, false
 		},
 	}
 	sc, err := NewSmartContractProcessor(arguments)

--- a/process/smartContract/processorV2/processV2.go
+++ b/process/smartContract/processorV2/processV2.go
@@ -1685,7 +1685,7 @@ func getRelayedValues(tx data.TransactionHandler) ([]byte, *big.Int) {
 		return relayedTx.RelayerAddr, big.NewInt(0)
 	}
 
-	if common.IsValidRelayedTxV3(tx) {
+	if common.IsRelayedTxV3(tx) {
 		relayedTx := tx.(data.RelayedTransactionHandler)
 		return relayedTx.GetRelayerAddr(), big.NewInt(0)
 	}
@@ -1962,7 +1962,7 @@ func (sc *scProcessor) processSCPayment(tx data.TransactionHandler, acntSnd stat
 }
 
 func (sc *scProcessor) getFeePayer(tx data.TransactionHandler, acntSnd state.UserAccountHandler) (state.UserAccountHandler, error) {
-	if !common.IsValidRelayedTxV3(tx) {
+	if !common.IsRelayedTxV3(tx) {
 		return acntSnd, nil
 	}
 
@@ -2654,7 +2654,7 @@ func (sc *scProcessor) createRefundGasToRelayerSCRIfNeeded(
 			gasRefund)
 	}
 
-	isRelayedV3 := common.IsValidRelayedTxV3(tx)
+	isRelayedV3 := common.IsRelayedTxV3(tx)
 	shouldRefundGasToRelayerSCR = isRelayedV3 && callType != vmData.AsynchronousCall && gasRefund.Cmp(zero) > 0
 	if shouldRefundGasToRelayerSCR {
 		relayedTx := tx.(data.RelayedTransactionHandler)

--- a/process/smartContract/processorV2/processV2.go
+++ b/process/smartContract/processorV2/processV2.go
@@ -603,9 +603,6 @@ func (sc *scProcessor) updateDeveloperRewards(
 	}
 
 	moveBalanceGasLimit := sc.economicsFee.ComputeGasLimit(tx)
-	if common.IsValidRelayedTxV3(tx) {
-		moveBalanceGasLimit -= sc.economicsFee.MinGasLimit() // this was already consumed from the relayer
-	}
 	if !isSmartContractResult(tx) {
 		usedGasByMainSC, err = core.SafeSubUint64(usedGasByMainSC, moveBalanceGasLimit)
 		if err != nil {
@@ -747,9 +744,6 @@ func (sc *scProcessor) computeTotalConsumedFeeAndDevRwd(
 	}
 
 	moveBalanceGasLimit := sc.economicsFee.ComputeGasLimit(tx)
-	if common.IsValidRelayedTxV3(tx) {
-		moveBalanceGasLimit -= sc.economicsFee.MinGasLimit() // this was already consumed from the relayer
-	}
 	if !isSmartContractResult(tx) {
 		displayConsumedGas := consumedGas
 		consumedGas, err = core.SafeSubUint64(consumedGas, moveBalanceGasLimit)
@@ -811,15 +805,17 @@ func (sc *scProcessor) deleteSCRsWithValueZeroGoingToMeta(scrs []data.Transactio
 }
 
 func (sc *scProcessor) saveAccounts(acntSnd, acntDst vmcommon.AccountHandler) error {
-	if !check.IfNil(acntSnd) {
-		err := sc.accounts.SaveAccount(acntSnd)
-		if err != nil {
-			return err
-		}
+	err := sc.saveAccount(acntSnd)
+	if err != nil {
+		return err
 	}
 
-	if !check.IfNil(acntDst) {
-		err := sc.accounts.SaveAccount(acntDst)
+	return sc.saveAccount(acntDst)
+}
+
+func (sc *scProcessor) saveAccount(account vmcommon.AccountHandler) error {
+	if !check.IfNil(account) {
+		err := sc.accounts.SaveAccount(account)
 		if err != nil {
 			return err
 		}
@@ -937,7 +933,7 @@ func (sc *scProcessor) doExecuteBuiltInFunctionWithoutFailureProcessing(
 		return sc.finishSCExecution(make([]data.TransactionHandler, 0), txHash, tx, vmOutput, 0)
 	}
 
-	_, txTypeOnDst := sc.txTypeHandler.ComputeTransactionType(tx)
+	_, txTypeOnDst, _ := sc.txTypeHandler.ComputeTransactionType(tx)
 	builtInFuncGasUsed, err := sc.computeBuiltInFuncGasUsed(txTypeOnDst, vmInput.Function, vmInput.GasProvided, vmOutput.GasRemaining, check.IfNil(acntSnd))
 	log.LogIfError(err, "function", "ExecuteBuiltInFunction.computeBuiltInFuncGasUsed")
 
@@ -1521,7 +1517,7 @@ func (sc *scProcessor) processIfErrorWithAddedLogs(acntSnd state.UserAccountHand
 		log.Debug("scProcessor.ProcessIfError() save log", "error", ignorableError.Error())
 	}
 
-	txType, _ := sc.txTypeHandler.ComputeTransactionType(tx)
+	txType, _, _ := sc.txTypeHandler.ComputeTransactionType(tx)
 	isCrossShardMoveBalance := txType == process.MoveBalance && check.IfNil(acntSnd)
 	if isCrossShardMoveBalance {
 		// move balance was already consumed in sender shard
@@ -1681,6 +1677,20 @@ func isRelayedSCR(tx data.TransactionHandler) (*smartContractResult.SmartContrac
 	}
 
 	return nil, false
+}
+
+func getRelayedValues(tx data.TransactionHandler) ([]byte, *big.Int) {
+	relayedTx, isRelayed := isRelayedSCR(tx)
+	if isRelayed {
+		return relayedTx.RelayerAddr, big.NewInt(0)
+	}
+
+	if common.IsValidRelayedTxV3(tx) {
+		relayedTx := tx.(data.RelayedTransactionHandler)
+		return relayedTx.GetRelayerAddr(), big.NewInt(0)
+	}
+
+	return nil, nil
 }
 
 // refunds the transaction values minus the relayed value to the sender account
@@ -1927,24 +1937,46 @@ func (sc *scProcessor) processSCPayment(tx data.TransactionHandler, acntSnd stat
 		return err
 	}
 
-	cost := sc.economicsFee.ComputeTxFee(tx)
-	cost = cost.Add(cost, tx.GetValue())
-
-	if common.IsValidRelayedTxV3(tx) {
-		// for relayed v3, fee was consumed from relayer
-		cost = tx.GetValue()
+	feePayer, err := sc.getFeePayer(tx, acntSnd)
+	if err != nil {
+		return err
 	}
 
-	if cost.Cmp(big.NewInt(0)) == 0 {
-		return nil
+	fee := sc.economicsFee.ComputeTxFee(tx)
+	err = feePayer.SubFromBalance(fee)
+	if err != nil {
+		return err
 	}
 
-	err = acntSnd.SubFromBalance(cost)
+	err = sc.saveAccount(feePayer)
+	if err != nil {
+		return err
+	}
+
+	err = acntSnd.SubFromBalance(tx.GetValue())
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (sc *scProcessor) getFeePayer(tx data.TransactionHandler, acntSnd state.UserAccountHandler) (state.UserAccountHandler, error) {
+	if !common.IsValidRelayedTxV3(tx) {
+		return acntSnd, nil
+	}
+
+	relayedTx, ok := tx.(data.RelayedTransactionHandler)
+	if !ok {
+		return acntSnd, nil
+	}
+
+	account, err := sc.getAccountFromAddress(relayedTx.GetRelayerAddr())
+	if err != nil {
+		return nil, err
+	}
+
+	return account, nil
 }
 
 func (sc *scProcessor) processVMOutput(
@@ -2268,17 +2300,7 @@ func createBaseSCR(
 	result.CallType = vmData.DirectCall
 	setOriginalTxHash(result, txHash, tx)
 
-	relayedTx, isRelayed := isRelayedSCR(tx)
-	if isRelayed {
-		result.RelayedValue = big.NewInt(0)
-		result.RelayerAddr = relayedTx.RelayerAddr
-	}
-
-	if common.IsValidRelayedTxV3(tx) {
-		relayedTx := tx.(data.RelayedTransactionHandler)
-		result.RelayedValue = big.NewInt(0)
-		result.RelayerAddr = relayedTx.GetRelayerAddr()
-	}
+	result.RelayerAddr, result.RelayedValue = getRelayedValues(tx)
 
 	return result
 }
@@ -2316,17 +2338,8 @@ func (sc *scProcessor) createAsyncCallBackSCRFromVMOutput(
 		OriginalSender: origScr.GetOriginalSender(),
 	}
 	setOriginalTxHash(scr, txHash, tx)
-	relayedTx, isRelayed := isRelayedSCR(tx)
-	if isRelayed {
-		scr.RelayedValue = big.NewInt(0)
-		scr.RelayerAddr = relayedTx.RelayerAddr
-	}
 
-	if common.IsValidRelayedTxV3(tx) {
-		relayedTx := tx.(data.RelayedTransactionHandler)
-		scr.RelayedValue = big.NewInt(0)
-		scr.RelayerAddr = relayedTx.GetRelayerAddr()
-	}
+	scr.RelayerAddr, scr.RelayedValue = getRelayedValues(tx)
 
 	sc.addVMOutputResultsToSCR(vmOutput, scr)
 
@@ -2591,54 +2604,7 @@ func (sc *scProcessor) createSCRForSenderAndRelayer(
 		rcvAddress = tx.GetRcvAddr()
 	}
 
-	var refundGasToRelayerSCR *smartContractResult.SmartContractResult
-	relayedSCR, isRelayed := isRelayedSCR(tx)
-	shouldRefundGasToRelayerSCR := isRelayed && callType != vmData.AsynchronousCall && gasRefund.Cmp(zero) > 0
-	if shouldRefundGasToRelayerSCR {
-		senderForRelayerRefund := tx.GetRcvAddr()
-		if !sc.isSelfShard(tx.GetRcvAddr()) {
-			senderForRelayerRefund = tx.GetSndAddr()
-		}
-
-		refundGasToRelayerSCR = &smartContractResult.SmartContractResult{
-			Nonce:          relayedSCR.Nonce + 1,
-			Value:          big.NewInt(0).Set(gasRefund),
-			RcvAddr:        relayedSCR.RelayerAddr,
-			SndAddr:        senderForRelayerRefund,
-			PrevTxHash:     txHash,
-			OriginalTxHash: relayedSCR.OriginalTxHash,
-			GasPrice:       tx.GetGasPrice(),
-			CallType:       vmData.DirectCall,
-			ReturnMessage:  []byte("gas refund for relayer"),
-			OriginalSender: relayedSCR.OriginalSender,
-		}
-		gasRemaining = 0
-	}
-
-	isRelayedV3 := common.IsValidRelayedTxV3(tx)
-	shouldRefundGasToRelayerSCR = isRelayedV3 && callType != vmData.AsynchronousCall && gasRefund.Cmp(zero) > 0
-	if shouldRefundGasToRelayerSCR {
-		senderForRelayerRefund := tx.GetRcvAddr()
-		if !sc.isSelfShard(tx.GetRcvAddr()) {
-			senderForRelayerRefund = tx.GetSndAddr()
-		}
-
-		relayedTx := tx.(data.RelayedTransactionHandler)
-
-		refundGasToRelayerSCR = &smartContractResult.SmartContractResult{
-			Nonce:          tx.GetNonce() + 1,
-			Value:          big.NewInt(0).Set(gasRefund),
-			RcvAddr:        relayedTx.GetRelayerAddr(),
-			SndAddr:        senderForRelayerRefund,
-			PrevTxHash:     txHash,
-			OriginalTxHash: txHash,
-			GasPrice:       tx.GetGasPrice(),
-			CallType:       vmData.DirectCall,
-			ReturnMessage:  []byte("gas refund for relayer"),
-			OriginalSender: tx.GetSndAddr(),
-		}
-		gasRemaining = 0
-	}
+	refundGasToRelayerSCR := sc.createRefundGasToRelayerSCRIfNeeded(tx, txHash, callType, gasRefund)
 
 	scTx := &smartContractResult.SmartContractResult{}
 	scTx.Value = big.NewInt(0).Set(storageFreeRefund)
@@ -2667,6 +2633,71 @@ func (sc *scProcessor) createSCRForSenderAndRelayer(
 
 	log.Trace("createSCRForSenderAndRelayer ", "data", string(scTx.Data), "snd", scTx.SndAddr, "rcv", scTx.RcvAddr, "gasRemaining", vmOutput.GasRemaining)
 	return scTx, refundGasToRelayerSCR
+}
+
+func (sc *scProcessor) createRefundGasToRelayerSCRIfNeeded(
+	tx data.TransactionHandler,
+	txHash []byte,
+	callType vmData.CallType,
+	gasRefund *big.Int,
+) *smartContractResult.SmartContractResult {
+	relayedSCR, isRelayed := isRelayedSCR(tx)
+	shouldRefundGasToRelayerSCR := isRelayed && callType != vmData.AsynchronousCall && gasRefund.Cmp(zero) > 0
+	if shouldRefundGasToRelayerSCR {
+		return sc.createRefundGasToRelayerSCR(
+			tx,
+			relayedSCR.Nonce+1,
+			relayedSCR.RelayerAddr,
+			relayedSCR.OriginalSender,
+			relayedSCR.OriginalTxHash,
+			txHash,
+			gasRefund)
+	}
+
+	isRelayedV3 := common.IsValidRelayedTxV3(tx)
+	shouldRefundGasToRelayerSCR = isRelayedV3 && callType != vmData.AsynchronousCall && gasRefund.Cmp(zero) > 0
+	if shouldRefundGasToRelayerSCR {
+		relayedTx := tx.(data.RelayedTransactionHandler)
+
+		return sc.createRefundGasToRelayerSCR(
+			tx,
+			tx.GetNonce()+1,
+			relayedTx.GetRelayerAddr(),
+			tx.GetSndAddr(),
+			txHash,
+			txHash,
+			gasRefund)
+	}
+
+	return nil
+}
+
+func (sc *scProcessor) createRefundGasToRelayerSCR(
+	tx data.TransactionHandler,
+	nonce uint64,
+	relayerAddr []byte,
+	originalSender []byte,
+	prevTxHash []byte,
+	originalTxHash []byte,
+	refund *big.Int,
+) *smartContractResult.SmartContractResult {
+	senderForRelayerRefund := tx.GetRcvAddr()
+	if !sc.isSelfShard(tx.GetRcvAddr()) {
+		senderForRelayerRefund = tx.GetSndAddr()
+	}
+
+	return &smartContractResult.SmartContractResult{
+		Nonce:          nonce,
+		Value:          big.NewInt(0).Set(refund),
+		RcvAddr:        relayerAddr,
+		SndAddr:        senderForRelayerRefund,
+		PrevTxHash:     prevTxHash,
+		OriginalTxHash: originalTxHash,
+		GasPrice:       tx.GetGasPrice(),
+		CallType:       vmData.DirectCall,
+		ReturnMessage:  []byte("gas refund for relayer"),
+		OriginalSender: originalSender,
+	}
 }
 
 func addReturnDataToSCR(vmOutput *vmcommon.VMOutput, scTx *smartContractResult.SmartContractResult) {
@@ -2768,7 +2799,7 @@ func (sc *scProcessor) ProcessSmartContractResult(scr *smartContractResult.Smart
 
 	gasLocked := sc.getGasLockedFromSCR(scr)
 
-	txType, _ := sc.txTypeHandler.ComputeTransactionType(scr)
+	txType, _, _ := sc.txTypeHandler.ComputeTransactionType(scr)
 	switch txType {
 	case process.MoveBalance:
 		err = sc.processSimpleSCR(scr, txHash, dstAcc)

--- a/process/smartContract/processorV2/process_test.go
+++ b/process/smartContract/processorV2/process_test.go
@@ -3129,8 +3129,8 @@ func TestScProcessor_ProcessSmartContractResultDeploySCShouldError(t *testing.T)
 	arguments.AccountsDB = accountsDB
 	arguments.ShardCoordinator = shardCoordinator
 	arguments.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.SCDeployment, process.SCDeployment
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.SCDeployment, process.SCDeployment, false
 		},
 	}
 	sc, err := NewSmartContractProcessorV2(arguments)
@@ -3190,8 +3190,8 @@ func TestScProcessor_ProcessSmartContractResultExecuteSC(t *testing.T) {
 		},
 	}
 	arguments.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.SCInvoking, process.SCInvoking
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.SCInvoking, process.SCInvoking, false
 		},
 	}
 	sc, err := NewSmartContractProcessorV2(arguments)
@@ -3253,8 +3253,8 @@ func TestScProcessor_ProcessSmartContractResultExecuteSCIfMetaAndBuiltIn(t *test
 		},
 	}
 	arguments.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.BuiltInFunctionCall, process.BuiltInFunctionCall
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.BuiltInFunctionCall, process.BuiltInFunctionCall, false
 		},
 	}
 	enableEpochsHandlerStub := enableEpochsHandlerMock.NewEnableEpochsHandlerStub()
@@ -3327,8 +3327,8 @@ func TestScProcessor_ProcessRelayedSCRValueBackToRelayer(t *testing.T) {
 		},
 	}
 	arguments.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.SCInvoking, process.SCInvoking
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.SCInvoking, process.SCInvoking, false
 		},
 	}
 	wasSaveLogsCalled := false

--- a/process/smartContract/processorV2/vmInputV2.go
+++ b/process/smartContract/processorV2/vmInputV2.go
@@ -7,6 +7,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
 	"github.com/multiversx/mx-chain-core-go/data/vm"
+	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/process"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
@@ -40,9 +41,13 @@ func (sc *scProcessor) initializeVMInputFromTx(vmInput *vmcommon.VMInput, tx dat
 	vmInput.CallValue = new(big.Int).Set(tx.GetValue())
 	vmInput.GasPrice = tx.GetGasPrice()
 
-	relayedTx, isRelayed := isRelayedTx(tx)
+	relayedTx, isRelayed := isRelayedSCR(tx)
 	if isRelayed {
 		vmInput.RelayerAddr = relayedTx.RelayerAddr
+	}
+	if common.IsValidRelayedTxV3(tx) {
+		relayedTx := tx.(data.RelayedTransactionHandler)
+		vmInput.RelayerAddr = relayedTx.GetRelayerAddr()
 	}
 
 	vmInput.GasProvided, err = sc.prepareGasProvided(tx)
@@ -68,6 +73,10 @@ func (sc *scProcessor) prepareGasProvided(tx data.TransactionHandler) (uint64, e
 	}
 
 	gasForTxData := sc.economicsFee.ComputeGasLimit(tx)
+	if common.IsValidRelayedTxV3(tx) {
+		gasForTxData -= sc.economicsFee.MinGasLimit() // this was already consumed from the relayer
+	}
+
 	if tx.GetGasLimit() < gasForTxData {
 		return 0, process.ErrNotEnoughGas
 	}

--- a/process/transaction/baseProcess.go
+++ b/process/transaction/baseProcess.go
@@ -120,7 +120,7 @@ func (txProc *baseTxProcessor) checkTxValues(
 	isUserTxOfRelayed bool,
 ) error {
 	if common.IsValidRelayedTxV3(tx) {
-		relayerAccount, _, err := txProc.getAccounts(tx.RelayerAddr, tx.RelayerAddr)
+		relayerAccount, err := txProc.getAccountFromAddress(tx.RelayerAddr)
 		if err != nil {
 			return err
 		}
@@ -244,7 +244,7 @@ func (txProc *baseTxProcessor) getFeePayer(
 		return acntSnd, false, nil
 	}
 
-	acntRelayer, _, err := txProc.getAccounts(tx.RelayerAddr, tx.RelayerAddr)
+	acntRelayer, err := txProc.getAccountFromAddress(tx.RelayerAddr)
 	if err != nil {
 		return nil, true, err
 	}
@@ -261,7 +261,7 @@ func (txProc *baseTxProcessor) computeInnerTxFee(tx *transaction.Transaction) *b
 }
 
 func (txProc *baseTxProcessor) computeInnerTxFeeAfterBaseCostFix(tx *transaction.Transaction) *big.Int {
-	_, dstShardTxType := txProc.txTypeHandler.ComputeTransactionType(tx)
+	_, dstShardTxType, _ := txProc.txTypeHandler.ComputeTransactionType(tx)
 	if dstShardTxType == process.MoveBalance {
 		return txProc.economicsFee.ComputeMoveBalanceFee(tx)
 	}

--- a/process/transaction/export_test.go
+++ b/process/transaction/export_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/state"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
@@ -100,6 +101,11 @@ func (txProc *txProcessor) ExecuteFailedRelayedTransaction(
 // CheckMaxGasPrice calls the un-exported method checkMaxGasPrice
 func (inTx *InterceptedTransaction) CheckMaxGasPrice() error {
 	return inTx.checkMaxGasPrice()
+}
+
+// SetEnableEpochsHandler sets the internal enable epochs handler
+func (inTx *InterceptedTransaction) SetEnableEpochsHandler(handler common.EnableEpochsHandler) {
+	inTx.enableEpochsHandler = handler
 }
 
 // VerifyGuardian calls the un-exported method verifyGuardian

--- a/process/transaction/interceptedTransaction.go
+++ b/process/transaction/interceptedTransaction.go
@@ -240,12 +240,16 @@ func isRelayedTx(funcName string) bool {
 }
 
 func (inTx *InterceptedTransaction) verifyIfRelayedTxV3(tx *transaction.Transaction) error {
-	if !common.IsValidRelayedTxV3(tx) {
+	if !common.IsRelayedTxV3(tx) {
 		return nil
 	}
 
 	if !inTx.enableEpochsHandler.IsFlagEnabled(common.RelayedTransactionsV3Flag) {
 		return process.ErrRelayedTxV3Disabled
+	}
+
+	if !common.IsValidRelayedTxV3(tx) {
+		return process.ErrInvalidRelayedTxV3
 	}
 
 	err := inTx.integrity(tx)

--- a/process/transaction/interceptedTransaction.go
+++ b/process/transaction/interceptedTransaction.go
@@ -43,6 +43,7 @@ type InterceptedTransaction struct {
 	sndShard               uint32
 	isForCurrentShard      bool
 	enableSignedTxWithHash bool
+	enableEpochsHandler    common.EnableEpochsHandler
 }
 
 // NewInterceptedTransaction returns a new instance of InterceptedTransaction
@@ -62,6 +63,7 @@ func NewInterceptedTransaction(
 	enableSignedTxWithHash bool,
 	txSignHasher hashing.Hasher,
 	txVersionChecker process.TxVersionCheckerHandler,
+	enableEpochsHandler common.EnableEpochsHandler,
 ) (*InterceptedTransaction, error) {
 
 	if txBuff == nil {
@@ -106,6 +108,9 @@ func NewInterceptedTransaction(
 	if check.IfNil(txVersionChecker) {
 		return nil, process.ErrNilTransactionVersionChecker
 	}
+	if check.IfNil(enableEpochsHandler) {
+		return nil, process.ErrNilEnableEpochsHandler
+	}
 
 	tx, err := createTx(protoMarshalizer, txBuff)
 	if err != nil {
@@ -128,6 +133,7 @@ func NewInterceptedTransaction(
 		enableSignedTxWithHash: enableSignedTxWithHash,
 		txVersionChecker:       txVersionChecker,
 		txSignHasher:           txSignHasher,
+		enableEpochsHandler:    enableEpochsHandler,
 	}
 
 	err = inTx.processFields(txBuff)
@@ -236,6 +242,10 @@ func isRelayedTx(funcName string) bool {
 func (inTx *InterceptedTransaction) verifyIfRelayedTxV3(tx *transaction.Transaction) error {
 	if !common.IsValidRelayedTxV3(tx) {
 		return nil
+	}
+
+	if !inTx.enableEpochsHandler.IsFlagEnabled(common.RelayedTransactionsV3Flag) {
+		return process.ErrRelayedTxV3Disabled
 	}
 
 	err := inTx.integrity(tx)

--- a/process/transaction/interceptedTransaction_test.go
+++ b/process/transaction/interceptedTransaction_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	dataTransaction "github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-crypto-go"
+	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/interceptors"
 	"github.com/multiversx/mx-chain-go/process/mock"
@@ -22,6 +23,7 @@ import (
 	"github.com/multiversx/mx-chain-go/process/transaction"
 	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/economicsmocks"
+	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
 	logger "github.com/multiversx/mx-chain-logger-go"
@@ -115,6 +117,7 @@ func createInterceptedTxWithTxFeeHandlerAndVersionChecker(tx *dataTransaction.Tr
 		false,
 		&hashingMocks.HasherMock{},
 		txVerChecker,
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 }
 
@@ -158,6 +161,7 @@ func createInterceptedTxFromPlainTx(tx *dataTransaction.Transaction, txFeeHandle
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(minTxVersion),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 }
 
@@ -206,6 +210,7 @@ func createInterceptedTxFromPlainTxWithArgParser(tx *dataTransaction.Transaction
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(tx.Version),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.RelayedTransactionsV3Flag),
 	)
 }
 
@@ -230,6 +235,7 @@ func TestNewInterceptedTransaction_NilBufferShouldErr(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(1),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
@@ -255,6 +261,7 @@ func TestNewInterceptedTransaction_NilArgsParser(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(1),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
@@ -280,6 +287,7 @@ func TestNewInterceptedTransaction_NilVersionChecker(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		nil,
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
@@ -305,6 +313,7 @@ func TestNewInterceptedTransaction_NilMarshalizerShouldErr(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(1),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
@@ -330,6 +339,7 @@ func TestNewInterceptedTransaction_NilSignMarshalizerShouldErr(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(1),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
@@ -355,6 +365,7 @@ func TestNewInterceptedTransaction_NilHasherShouldErr(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(1),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
@@ -380,6 +391,7 @@ func TestNewInterceptedTransaction_NilKeyGenShouldErr(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(1),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
@@ -405,6 +417,7 @@ func TestNewInterceptedTransaction_NilSignerShouldErr(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(1),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
@@ -430,6 +443,7 @@ func TestNewInterceptedTransaction_NilPubkeyConverterShouldErr(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(1),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
@@ -455,6 +469,7 @@ func TestNewInterceptedTransaction_NilCoordinatorShouldErr(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(1),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
@@ -480,6 +495,7 @@ func TestNewInterceptedTransaction_NilFeeHandlerShouldErr(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(1),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
@@ -505,6 +521,7 @@ func TestNewInterceptedTransaction_NilWhiteListerVerifiedTxsShouldErr(t *testing
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(1),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
@@ -530,6 +547,7 @@ func TestNewInterceptedTransaction_InvalidChainIDShouldErr(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(1),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
@@ -555,10 +573,37 @@ func TestNewInterceptedTransaction_NilTxSignHasherShouldErr(t *testing.T) {
 		false,
 		nil,
 		versioning.NewTxVersionChecker(1),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
 	assert.Equal(t, process.ErrNilHasher, err)
+}
+
+func TestNewInterceptedTransaction_NilEnableEpochsHandlerShouldErr(t *testing.T) {
+	t.Parallel()
+
+	txi, err := transaction.NewInterceptedTransaction(
+		make([]byte, 0),
+		&mock.MarshalizerMock{},
+		&mock.MarshalizerMock{},
+		&hashingMocks.HasherMock{},
+		&mock.SingleSignKeyGenMock{},
+		&mock.SignerMock{},
+		createMockPubKeyConverter(),
+		mock.NewOneShardCoordinatorMock(),
+		&economicsmocks.EconomicsHandlerStub{},
+		&testscommon.WhiteListHandlerStub{},
+		&testscommon.ArgumentParserMock{},
+		[]byte("chainID"),
+		false,
+		&hashingMocks.HasherMock{},
+		versioning.NewTxVersionChecker(1),
+		nil,
+	)
+
+	assert.Nil(t, txi)
+	assert.Equal(t, process.ErrNilEnableEpochsHandler, err)
 }
 
 func TestNewInterceptedTransaction_UnmarshalingTxFailsShouldErr(t *testing.T) {
@@ -586,6 +631,7 @@ func TestNewInterceptedTransaction_UnmarshalingTxFailsShouldErr(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(1),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, txi)
@@ -1056,6 +1102,7 @@ func TestInterceptedTransaction_CheckValiditySignedWithHashButNotEnabled(t *test
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(minTxVersion),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	err := txi.CheckValidity()
@@ -1116,6 +1163,7 @@ func TestInterceptedTransaction_CheckValiditySignedWithHashShouldWork(t *testing
 		true,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(minTxVersion),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	err := txi.CheckValidity()
@@ -1201,6 +1249,7 @@ func TestInterceptedTransaction_ScTxDeployRecvShardIdShouldBeSendersShardId(t *t
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(minTxVersion),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Nil(t, err)
@@ -1340,6 +1389,7 @@ func TestInterceptedTransaction_CheckValiditySecondTimeDoesNotVerifySig(t *testi
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(minTxVersion),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 	require.Nil(t, err)
 
@@ -1529,6 +1579,12 @@ func TestInterceptedTransaction_CheckValidityOfRelayedTxV3(t *testing.T) {
 	tx.Signature = sigOk
 	tx.RelayerSignature = sigOk
 
+	// flag not active should error
+	txi, _ = createInterceptedTxFromPlainTxWithArgParser(tx)
+	txi.SetEnableEpochsHandler(enableEpochsHandlerMock.NewEnableEpochsHandlerStub())
+	err = txi.CheckValidity()
+	assert.Equal(t, process.ErrRelayedTxV3Disabled, err)
+
 	// sender in different shard than relayer should fail
 	tx.RelayerAddr = bytes.Repeat([]byte("a"), len(relayerAddress))
 	txi, _ = createInterceptedTxFromPlainTxWithArgParser(tx)
@@ -1698,6 +1754,7 @@ func TestInterceptedTransaction_Fee(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(0),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	assert.Equal(t, big.NewInt(0), txin.Fee())
@@ -1741,6 +1798,7 @@ func TestInterceptedTransaction_String(t *testing.T) {
 		false,
 		&hashingMocks.HasherMock{},
 		versioning.NewTxVersionChecker(0),
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(),
 	)
 
 	expectedFormat := fmt.Sprintf(

--- a/process/transaction/interceptedTransaction_test.go
+++ b/process/transaction/interceptedTransaction_test.go
@@ -1585,7 +1585,14 @@ func TestInterceptedTransaction_CheckValidityOfRelayedTxV3(t *testing.T) {
 	err = txi.CheckValidity()
 	assert.Equal(t, process.ErrRelayedTxV3Disabled, err)
 
+	// invalid relayed v3 should error
+	tx.RelayerSignature = nil
+	txi, _ = createInterceptedTxFromPlainTxWithArgParser(tx)
+	err = txi.CheckValidity()
+	assert.Equal(t, process.ErrInvalidRelayedTxV3, err)
+
 	// sender in different shard than relayer should fail
+	tx.RelayerSignature = sigOk
 	tx.RelayerAddr = bytes.Repeat([]byte("a"), len(relayerAddress))
 	txi, _ = createInterceptedTxFromPlainTxWithArgParser(tx)
 	err = txi.CheckValidity()

--- a/process/transaction/metaProcess.go
+++ b/process/transaction/metaProcess.go
@@ -145,6 +145,8 @@ func (txProc *metaTxProcessor) ProcessTransaction(tx *transaction.Transaction) (
 		if txProc.enableEpochsHandler.IsFlagEnabled(common.ESDTFlag) {
 			return txProc.processSCInvoking(tx, tx.SndAddr, tx.RcvAddr)
 		}
+	case process.RelayedTxV3:
+		return vmcommon.Ok, nil // it will be processed through the scr created on source
 	}
 
 	snapshot := txProc.accounts.JournalLen()

--- a/process/transaction/metaProcess.go
+++ b/process/transaction/metaProcess.go
@@ -135,13 +135,7 @@ func (txProc *metaTxProcessor) ProcessTransaction(tx *transaction.Transaction) (
 		return 0, err
 	}
 
-	txCopy := *tx
-	txType, _ := txProc.txTypeHandler.ComputeTransactionType(tx)
-	if txType == process.RelayedTxV3 {
-		// extract the inner transaction in order to get the proper user tx type
-		txCopy.RelayerSignature = nil
-		txType, _ = txProc.txTypeHandler.ComputeTransactionType(&txCopy)
-	}
+	txType, _, _ := txProc.txTypeHandler.ComputeTransactionType(tx)
 	switch txType {
 	case process.SCDeployment:
 		return txProc.processSCDeployment(tx, tx.SndAddr)

--- a/process/transaction/metaProcess_test.go
+++ b/process/transaction/metaProcess_test.go
@@ -277,8 +277,8 @@ func TestMetaTxProcessor_ProcessTransactionScTxShouldWork(t *testing.T) {
 	args.Accounts = adb
 	args.ScProcessor = scProcessorMock
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.SCInvoking, process.SCInvoking
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.SCInvoking, process.SCInvoking, false
 		},
 	}
 	txProc, _ := txproc.NewMetaTxProcessor(args)
@@ -323,8 +323,8 @@ func TestMetaTxProcessor_ProcessTransactionScTxShouldReturnErrWhenExecutionFails
 	args.Accounts = adb
 	args.ScProcessor = scProcessorMock
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.SCInvoking, process.SCInvoking
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.SCInvoking, process.SCInvoking, false
 		},
 	}
 	txProc, _ := txproc.NewMetaTxProcessor(args)
@@ -439,8 +439,8 @@ func TestMetaTxProcessor_ProcessTransactionBuiltInCallTxShouldWork(t *testing.T)
 	args.Accounts = adb
 	args.ScProcessor = scProcessorMock
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.BuiltInFunctionCall, process.BuiltInFunctionCall
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.BuiltInFunctionCall, process.BuiltInFunctionCall, false
 		},
 	}
 	enableEpochsHandlerStub := enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.ESDTFlag)

--- a/process/transaction/shardProcess.go
+++ b/process/transaction/shardProcess.go
@@ -823,6 +823,10 @@ func (txProc *txProcessor) processRelayedTxV3(tx *transaction.Transaction) (vmco
 		return vmcommon.UserError, txProc.executingFailedTransactionRelayedV3(tx, sndAccount, relayerAccount, process.ErrGuardedRelayerNotAllowed)
 	}
 
+	if bytes.Equal(tx.RelayerAddr, tx.GuardianAddr) {
+		return vmcommon.UserError, txProc.executingFailedTransactionRelayedV3(tx, sndAccount, relayerAccount, process.ErrRelayedByGuardianNotAllowed)
+	}
+
 	userTx := *tx
 	// remove relayer signature for tx type handler
 	// hash of this user tx won't be computed/used, but the originalTxHash

--- a/process/transaction/shardProcess_test.go
+++ b/process/transaction/shardProcess_test.go
@@ -1111,8 +1111,8 @@ func TestTxProcessor_ProcessTransactionScDeployTxShouldWork(t *testing.T) {
 	args.Accounts = adb
 	args.ScProcessor = scProcessorMock
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType process.TransactionType, destinationTransactionType process.TransactionType) {
-			return process.SCDeployment, process.SCDeployment
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType process.TransactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+			return process.SCDeployment, process.SCDeployment, false
 		},
 	}
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -1159,8 +1159,8 @@ func TestTxProcessor_ProcessTransactionBuiltInFunctionCallShouldWork(t *testing.
 	args.Accounts = adb
 	args.ScProcessor = scProcessorMock
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-			return process.BuiltInFunctionCall, process.BuiltInFunctionCall
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+			return process.BuiltInFunctionCall, process.BuiltInFunctionCall, false
 		},
 	}
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -1207,8 +1207,8 @@ func TestTxProcessor_ProcessTransactionScTxShouldWork(t *testing.T) {
 	args.Accounts = adb
 	args.ScProcessor = scProcessorMock
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.SCInvoking, process.SCInvoking
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.SCInvoking, process.SCInvoking, false
 		},
 	}
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -1253,8 +1253,8 @@ func TestTxProcessor_ProcessTransactionScTxShouldReturnErrWhenExecutionFails(t *
 	args.Accounts = adb
 	args.ScProcessor = scProcessorMock
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.SCInvoking, process.SCInvoking
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.SCInvoking, process.SCInvoking, false
 		},
 	}
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -1573,8 +1573,8 @@ func TestTxProcessor_ProcessTransactionShouldReturnErrForInvalidMetaTx(t *testin
 		},
 	}
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.MoveBalance, process.MoveBalance
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.MoveBalance, process.MoveBalance, false
 		},
 	}
 	args.EnableEpochsHandler = enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.MetaProtectionFlag)
@@ -1621,8 +1621,8 @@ func TestTxProcessor_ProcessTransactionShouldTreatAsInvalidTxIfTxTypeIsWrong(t *
 		},
 	}
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.InvalidTransaction, process.InvalidTransaction
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.InvalidTransaction, process.InvalidTransaction, false
 		},
 	}
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -2181,8 +2181,8 @@ func TestTxProcessor_ProcessRelayedTransactionArgsParserErrorShouldError(t *test
 		return nil, errors.New("failure")
 	}
 	args.Accounts = adb
-	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-		return process.RelayedTx, process.RelayedTx
+	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+		return process.RelayedTx, process.RelayedTx, false
 	}}
 
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -2244,8 +2244,8 @@ func TestTxProcessor_ProcessRelayedTransactionMultipleArgumentsShouldError(t *te
 		return nil, errors.New("failure")
 	}
 	args.Accounts = adb
-	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-		return process.RelayedTx, process.RelayedTx
+	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+		return process.RelayedTx, process.RelayedTx, false
 	}}
 
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -2307,8 +2307,8 @@ func TestTxProcessor_ProcessRelayedTransactionFailUnMarshalInnerShouldError(t *t
 		return nil, errors.New("failure")
 	}
 	args.Accounts = adb
-	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-		return process.RelayedTx, process.RelayedTx
+	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+		return process.RelayedTx, process.RelayedTx, false
 	}}
 
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -2370,8 +2370,8 @@ func TestTxProcessor_ProcessRelayedTransactionDifferentSenderInInnerTxThanReceiv
 		return nil, errors.New("failure")
 	}
 	args.Accounts = adb
-	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-		return process.RelayedTx, process.RelayedTx
+	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+		return process.RelayedTx, process.RelayedTx, false
 	}}
 
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -2433,8 +2433,8 @@ func TestTxProcessor_ProcessRelayedTransactionSmallerValueInnerTxShouldError(t *
 		return nil, errors.New("failure")
 	}
 	args.Accounts = adb
-	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-		return process.RelayedTx, process.RelayedTx
+	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+		return process.RelayedTx, process.RelayedTx, false
 	}}
 
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -2496,8 +2496,8 @@ func TestTxProcessor_ProcessRelayedTransactionGasPriceMismatchShouldError(t *tes
 		return nil, errors.New("failure")
 	}
 	args.Accounts = adb
-	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-		return process.RelayedTx, process.RelayedTx
+	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+		return process.RelayedTx, process.RelayedTx, false
 	}}
 
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -2559,8 +2559,8 @@ func TestTxProcessor_ProcessRelayedTransactionGasLimitMismatchShouldError(t *tes
 		return nil, errors.New("failure")
 	}
 	args.Accounts = adb
-	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-		return process.RelayedTx, process.RelayedTx
+	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+		return process.RelayedTx, process.RelayedTx, false
 	}}
 
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -2912,8 +2912,8 @@ func TestTxProcessor_ProcessUserTxOfTypeRelayedShouldError(t *testing.T) {
 		return nil, errors.New("failure")
 	}
 	args.Accounts = adb
-	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-		return process.RelayedTx, process.RelayedTx
+	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+		return process.RelayedTx, process.RelayedTx, false
 	}}
 
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -2975,8 +2975,8 @@ func TestTxProcessor_ProcessUserTxOfTypeMoveBalanceShouldWork(t *testing.T) {
 		return nil, errors.New("failure")
 	}
 	args.Accounts = adb
-	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-		return process.MoveBalance, process.MoveBalance
+	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+		return process.MoveBalance, process.MoveBalance, false
 	}}
 
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -3038,8 +3038,8 @@ func TestTxProcessor_ProcessUserTxOfTypeSCDeploymentShouldWork(t *testing.T) {
 		return nil, errors.New("failure")
 	}
 	args.Accounts = adb
-	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-		return process.SCDeployment, process.SCDeployment
+	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+		return process.SCDeployment, process.SCDeployment, false
 	}}
 
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -3101,8 +3101,8 @@ func TestTxProcessor_ProcessUserTxOfTypeSCInvokingShouldWork(t *testing.T) {
 		return nil, errors.New("failure")
 	}
 	args.Accounts = adb
-	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-		return process.SCInvoking, process.SCInvoking
+	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+		return process.SCInvoking, process.SCInvoking, false
 	}}
 
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -3164,8 +3164,8 @@ func TestTxProcessor_ProcessUserTxOfTypeBuiltInFunctionCallShouldWork(t *testing
 		return nil, errors.New("failure")
 	}
 	args.Accounts = adb
-	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-		return process.BuiltInFunctionCall, process.BuiltInFunctionCall
+	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+		return process.BuiltInFunctionCall, process.BuiltInFunctionCall, false
 	}}
 
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -3231,8 +3231,8 @@ func TestTxProcessor_ProcessUserTxErrNotPayableShouldFailRelayTx(t *testing.T) {
 		return nil, errors.New("failure")
 	}
 	args.Accounts = adb
-	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-		return process.MoveBalance, process.MoveBalance
+	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+		return process.MoveBalance, process.MoveBalance, false
 	}}
 
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -3300,8 +3300,8 @@ func TestTxProcessor_ProcessUserTxFailedBuiltInFunctionCall(t *testing.T) {
 		return nil, errors.New("failure")
 	}
 	args.Accounts = adb
-	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType) {
-		return process.BuiltInFunctionCall, process.BuiltInFunctionCall
+	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (transactionType, destinationTransactionType process.TransactionType, isRelayedV3 bool) {
+		return process.BuiltInFunctionCall, process.BuiltInFunctionCall, false
 	}}
 
 	execTx, _ := txproc.NewTxProcessor(args)
@@ -3522,13 +3522,13 @@ func TestTxProcessor_ProcessMoveBalanceToNonPayableContract(t *testing.T) {
 	args.SignMarshalizer = &marshaller
 	cnt := 0
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
 			cnt++
 			if cnt == 1 {
-				return process.RelayedTx, process.RelayedTx
+				return process.RelayedTx, process.RelayedTx, false
 			}
 
-			return process.MoveBalance, process.MoveBalance
+			return process.MoveBalance, process.MoveBalance, false
 		},
 	}
 	args.EnableEpochsHandler = enableEpochsHandlerMock.NewEnableEpochsHandlerStub(

--- a/process/transaction/shardProcess_test.go
+++ b/process/transaction/shardProcess_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core"
@@ -2732,7 +2733,8 @@ func TestTxProcessor_ProcessRelayedTransactionV3(t *testing.T) {
 		txCopy := *tx
 		txCopy.Nonce = acntSrc.GetNonce()
 		returnCode, err := txProcLocal.ProcessTransaction(&txCopy)
-		assert.Equal(t, process.ErrFailedTransaction, err)
+		assert.True(t, errors.Is(err, process.ErrTransactionNotExecutable))
+		assert.True(t, strings.Contains(err.Error(), process.ErrRelayedTxV3Disabled.Error()))
 		assert.Equal(t, vmcommon.UserError, returnCode)
 	})
 	t.Run("relayer not in the same shard with the sender should error", func(t *testing.T) {
@@ -2748,7 +2750,8 @@ func TestTxProcessor_ProcessRelayedTransactionV3(t *testing.T) {
 		txCopy := *tx
 		txCopy.Nonce = acntSrc.GetNonce()
 		returnCode, err := txProcLocal.ProcessTransaction(&txCopy)
-		assert.Equal(t, process.ErrFailedTransaction, err)
+		assert.True(t, errors.Is(err, process.ErrTransactionNotExecutable))
+		assert.True(t, strings.Contains(err.Error(), process.ErrShardIdMissmatch.Error()))
 		assert.Equal(t, vmcommon.UserError, returnCode)
 	})
 	t.Run("guarded relayer account should error", func(t *testing.T) {
@@ -2781,7 +2784,8 @@ func TestTxProcessor_ProcessRelayedTransactionV3(t *testing.T) {
 		txCopy := *tx
 		txCopy.Nonce = acntSrc.GetNonce()
 		returnCode, err := txProcLocal.ProcessTransaction(&txCopy)
-		assert.Equal(t, process.ErrFailedTransaction, err)
+		assert.True(t, errors.Is(err, process.ErrTransactionNotExecutable))
+		assert.True(t, strings.Contains(err.Error(), process.ErrGuardedRelayerNotAllowed.Error()))
 		assert.Equal(t, vmcommon.UserError, returnCode)
 	})
 	t.Run("same guardian and relayer should error", func(t *testing.T) {
@@ -2789,7 +2793,8 @@ func TestTxProcessor_ProcessRelayedTransactionV3(t *testing.T) {
 		txCopy.Nonce = acntSrc.GetNonce()
 		txCopy.GuardianAddr = txCopy.RelayerAddr
 		returnCode, err := txProc.ProcessTransaction(&txCopy)
-		assert.Equal(t, process.ErrFailedTransaction, err)
+		assert.True(t, errors.Is(err, process.ErrTransactionNotExecutable))
+		assert.True(t, strings.Contains(err.Error(), process.ErrRelayedByGuardianNotAllowed.Error()))
 		assert.Equal(t, vmcommon.UserError, returnCode)
 	})
 	t.Run("insufficient gas limit should error", func(t *testing.T) {

--- a/process/transaction/shardProcess_test.go
+++ b/process/transaction/shardProcess_test.go
@@ -2784,6 +2784,14 @@ func TestTxProcessor_ProcessRelayedTransactionV3(t *testing.T) {
 		assert.Equal(t, process.ErrFailedTransaction, err)
 		assert.Equal(t, vmcommon.UserError, returnCode)
 	})
+	t.Run("same guardian and relayer should error", func(t *testing.T) {
+		txCopy := *tx
+		txCopy.Nonce = acntSrc.GetNonce()
+		txCopy.GuardianAddr = txCopy.RelayerAddr
+		returnCode, err := txProc.ProcessTransaction(&txCopy)
+		assert.Equal(t, process.ErrFailedTransaction, err)
+		assert.Equal(t, vmcommon.UserError, returnCode)
+	})
 	t.Run("insufficient gas limit should error", func(t *testing.T) {
 		txCopy := *tx
 		txCopy.Nonce = acntSrc.GetNonce()

--- a/process/transaction/shardProcess_test.go
+++ b/process/transaction/shardProcess_test.go
@@ -923,7 +923,7 @@ func TestTxProcessor_ProcessMoveBalanceToSmartPayableContract(t *testing.T) {
 
 	_, err := execTx.ProcessTransaction(&tx)
 	assert.Nil(t, err)
-	assert.Equal(t, 2, saveAccountCalled)
+	assert.Equal(t, 3, saveAccountCalled)
 }
 
 func testProcessCheck(t *testing.T, nonce uint64, value *big.Int) {
@@ -989,7 +989,7 @@ func TestTxProcessor_ProcessMoveBalancesShouldWork(t *testing.T) {
 
 	_, err := execTx.ProcessTransaction(&tx)
 	assert.Nil(t, err)
-	assert.Equal(t, 2, saveAccountCalled)
+	assert.Equal(t, 3, saveAccountCalled)
 }
 
 func TestTxProcessor_ProcessOkValsShouldWork(t *testing.T) {
@@ -1025,7 +1025,7 @@ func TestTxProcessor_ProcessOkValsShouldWork(t *testing.T) {
 	assert.Equal(t, uint64(5), acntSrc.GetNonce())
 	assert.Equal(t, big.NewInt(29), acntSrc.GetBalance())
 	assert.Equal(t, big.NewInt(71), acntDst.GetBalance())
-	assert.Equal(t, 2, saveAccountCalled)
+	assert.Equal(t, 3, saveAccountCalled)
 }
 
 func TestTxProcessor_MoveBalanceWithFeesShouldWork(t *testing.T) {
@@ -1072,7 +1072,7 @@ func TestTxProcessor_MoveBalanceWithFeesShouldWork(t *testing.T) {
 	assert.Equal(t, uint64(5), acntSrc.GetNonce())
 	assert.Equal(t, big.NewInt(13), acntSrc.GetBalance())
 	assert.Equal(t, big.NewInt(71), acntDst.GetBalance())
-	assert.Equal(t, 2, saveAccountCalled)
+	assert.Equal(t, 3, saveAccountCalled)
 }
 
 func TestTxProcessor_ProcessTransactionScDeployTxShouldWork(t *testing.T) {
@@ -1324,7 +1324,7 @@ func TestTxProcessor_ProcessTransactionScTxShouldNotBeCalledWhenAdrDstIsNotInNod
 	_, err := execTx.ProcessTransaction(&tx)
 	assert.Nil(t, err)
 	assert.False(t, wasCalled)
-	assert.Equal(t, 1, saveAccountCalled)
+	assert.Equal(t, 2, saveAccountCalled)
 }
 
 func TestTxProcessor_ProcessTxFeeIntraShard(t *testing.T) {
@@ -2805,7 +2805,7 @@ func TestTxProcessor_ProcessRelayedTransactionV3(t *testing.T) {
 		require.NotNil(t, txProcLocal)
 
 		returnCode, err := txProcLocal.ProcessTransaction(&txCopy)
-		assert.Equal(t, process.ErrFailedTransaction, err)
+		assert.Equal(t, process.ErrNotEnoughGas, err)
 		assert.Equal(t, vmcommon.UserError, returnCode)
 	})
 }

--- a/process/transactionEvaluator/transactionEvaluator.go
+++ b/process/transactionEvaluator/transactionEvaluator.go
@@ -111,7 +111,7 @@ func (ate *apiTransactionEvaluator) ComputeTransactionGasLimit(tx *transaction.T
 		ate.mutExecution.Unlock()
 	}()
 
-	txTypeOnSender, txTypeOnDestination := ate.txTypeHandler.ComputeTransactionType(tx)
+	txTypeOnSender, txTypeOnDestination, _ := ate.txTypeHandler.ComputeTransactionType(tx)
 	if txTypeOnSender == process.MoveBalance && txTypeOnDestination == process.MoveBalance {
 		return ate.computeMoveBalanceCost(tx), nil
 	}

--- a/process/transactionEvaluator/transactionEvaluator_test.go
+++ b/process/transactionEvaluator/transactionEvaluator_test.go
@@ -114,8 +114,8 @@ func TestComputeTransactionGasLimit_MoveBalance(t *testing.T) {
 
 	args := createArgs()
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.MoveBalance, process.MoveBalance
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.MoveBalance, process.MoveBalance, false
 		},
 	}
 	args.FeeHandler = &economicsmocks.EconomicsHandlerStub{
@@ -153,8 +153,8 @@ func TestComputeTransactionGasLimit_MoveBalanceInvalidNonceShouldStillComputeCos
 
 	args := createArgs()
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.MoveBalance, process.MoveBalance
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.MoveBalance, process.MoveBalance, false
 		},
 	}
 	args.FeeHandler = &economicsmocks.EconomicsHandlerStub{
@@ -187,8 +187,8 @@ func TestComputeTransactionGasLimit_BuiltInFunction(t *testing.T) {
 	consumedGasUnits := uint64(4000)
 	args := createArgs()
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.BuiltInFunctionCall, process.BuiltInFunctionCall
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.BuiltInFunctionCall, process.BuiltInFunctionCall, false
 		},
 	}
 	args.FeeHandler = &economicsmocks.EconomicsHandlerStub{
@@ -223,8 +223,8 @@ func TestComputeTransactionGasLimit_BuiltInFunctionShouldErr(t *testing.T) {
 	localErr := errors.New("local err")
 	args := createArgs()
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.BuiltInFunctionCall, process.BuiltInFunctionCall
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.BuiltInFunctionCall, process.BuiltInFunctionCall, false
 		},
 	}
 	args.FeeHandler = &economicsmocks.EconomicsHandlerStub{
@@ -253,8 +253,8 @@ func TestComputeTransactionGasLimit_BuiltInFunctionShouldErr(t *testing.T) {
 func TestComputeTransactionGasLimit_NilVMOutput(t *testing.T) {
 	args := createArgs()
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.BuiltInFunctionCall, process.BuiltInFunctionCall
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.BuiltInFunctionCall, process.BuiltInFunctionCall, false
 		},
 	}
 	args.FeeHandler = &economicsmocks.EconomicsHandlerStub{
@@ -284,8 +284,8 @@ func TestComputeTransactionGasLimit_NilVMOutput(t *testing.T) {
 func TestComputeTransactionGasLimit_RetCodeNotOk(t *testing.T) {
 	args := createArgs()
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.BuiltInFunctionCall, process.BuiltInFunctionCall
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.BuiltInFunctionCall, process.BuiltInFunctionCall, false
 		},
 	}
 	args.FeeHandler = &economicsmocks.EconomicsHandlerStub{
@@ -321,8 +321,8 @@ func TestTransactionEvaluator_RelayedTxShouldErr(t *testing.T) {
 
 	args := createArgs()
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.RelayedTx, process.RelayedTx
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.RelayedTx, process.RelayedTx, false
 		},
 	}
 	tce, _ := NewAPITransactionEvaluator(args)
@@ -386,8 +386,8 @@ func TestApiTransactionEvaluator_ComputeTransactionGasLimit(t *testing.T) {
 	_ = args.BlockChain.SetCurrentBlockHeaderAndRootHash(&block.Header{Nonce: expectedNonce}, []byte("test"))
 
 	args.TxTypeHandler = &testscommon.TxTypeHandlerMock{
-		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
-			return process.SCInvoking, process.SCInvoking
+		ComputeTransactionTypeCalled: func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.SCInvoking, process.SCInvoking, false
 		},
 	}
 	args.TxSimulator = &mock.TransactionSimulatorStub{

--- a/testscommon/scProcessorMock.go
+++ b/testscommon/scProcessorMock.go
@@ -10,7 +10,7 @@ import (
 
 // SCProcessorMock -
 type SCProcessorMock struct {
-	ComputeTransactionTypeCalled           func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType)
+	ComputeTransactionTypeCalled           func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool)
 	ExecuteSmartContractTransactionCalled  func(tx data.TransactionHandler, acntSrc, acntDst state.UserAccountHandler) (vmcommon.ReturnCode, error)
 	ExecuteBuiltInFunctionCalled           func(tx data.TransactionHandler, acntSrc, acntDst state.UserAccountHandler) (vmcommon.ReturnCode, error)
 	DeploySmartContractCalled              func(tx data.TransactionHandler, acntSrc state.UserAccountHandler) (vmcommon.ReturnCode, error)
@@ -45,9 +45,9 @@ func (sc *SCProcessorMock) ProcessIfError(
 }
 
 // ComputeTransactionType -
-func (sc *SCProcessorMock) ComputeTransactionType(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
+func (sc *SCProcessorMock) ComputeTransactionType(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
 	if sc.ComputeTransactionTypeCalled == nil {
-		return process.MoveBalance, process.MoveBalance
+		return process.MoveBalance, process.MoveBalance, false
 	}
 
 	return sc.ComputeTransactionTypeCalled(tx)

--- a/testscommon/transactionCoordinatorMock.go
+++ b/testscommon/transactionCoordinatorMock.go
@@ -12,7 +12,7 @@ import (
 
 // TransactionCoordinatorMock -
 type TransactionCoordinatorMock struct {
-	ComputeTransactionTypeCalled                         func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType)
+	ComputeTransactionTypeCalled                         func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool)
 	RequestMiniBlocksAndTransactionsCalled               func(header data.HeaderHandler)
 	RequestBlockTransactionsCalled                       func(body *block.Body)
 	IsDataPreparedForProcessingCalled                    func(haveTime func() time.Duration) error
@@ -57,9 +57,9 @@ func (tcm *TransactionCoordinatorMock) CreateReceiptsHash() ([]byte, error) {
 }
 
 // ComputeTransactionType -
-func (tcm *TransactionCoordinatorMock) ComputeTransactionType(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
+func (tcm *TransactionCoordinatorMock) ComputeTransactionType(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
 	if tcm.ComputeTransactionTypeCalled == nil {
-		return 0, 0
+		return 0, 0, false
 	}
 
 	return tcm.ComputeTransactionTypeCalled(tx)

--- a/testscommon/txTypeHandlerMock.go
+++ b/testscommon/txTypeHandlerMock.go
@@ -7,13 +7,13 @@ import (
 
 // TxTypeHandlerMock -
 type TxTypeHandlerMock struct {
-	ComputeTransactionTypeCalled func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType)
+	ComputeTransactionTypeCalled func(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool)
 }
 
 // ComputeTransactionType -
-func (th *TxTypeHandlerMock) ComputeTransactionType(tx data.TransactionHandler) (process.TransactionType, process.TransactionType) {
+func (th *TxTypeHandlerMock) ComputeTransactionType(tx data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
 	if th.ComputeTransactionTypeCalled == nil {
-		return process.MoveBalance, process.MoveBalance
+		return process.MoveBalance, process.MoveBalance, false
 	}
 
 	return th.ComputeTransactionTypeCalled(tx)


### PR DESCRIPTION
## Reasoning behind the pull request
- the tx validity checks are always returning insufficient funds for sender, even when there are no funds at relayer 
- relayed v3 calls to meta sc are also processed as a transaction on metachain, resulting in duplicated processing on meta: 1 as a regular transaction to meta, 2 from the scr generated from the original relayed tx
- a check for guardian != relayer should be added in order to avoid same signature
  
## Proposed changes
- fix tx validity wrapped error
- avoid processing of relayed tx v3 on meta as regular tx, but only as scr
- added check on for guardian != relayer

## Testing procedure
- will be tested with feat branch and scenarios

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
