### PR TITLE
Mempool: adjust sender constraints

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -386,9 +386,9 @@
 [TxDataPool]
     Name = "TxDataPool"
     Capacity = 600000
-    SizePerSender = 20000
+    SizePerSender = 5001
     SizeInBytes = 419430400 #400MB
-    SizeInBytesPerSender = 12288000
+    SizeInBytesPerSender = 12288000 #12MB
     Type = "TxCache"
     Shards = 16
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/multiversx/mx-chain-es-indexer-go v1.7.10
 	github.com/multiversx/mx-chain-logger-go v1.0.15
 	github.com/multiversx/mx-chain-scenario-go v1.4.4
-	github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241129143541-8c5c73c5cbfd
+	github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241202081201-f9a268fc6918
 	github.com/multiversx/mx-chain-vm-common-go v1.5.16
 	github.com/multiversx/mx-chain-vm-go v1.5.37
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.68

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/multiversx/mx-chain-logger-go v1.0.15 h1:HlNdK8etyJyL9NQ+6mIXyKPEBo+w
 github.com/multiversx/mx-chain-logger-go v1.0.15/go.mod h1:t3PRKaWB1M+i6gUfD27KXgzLJJC+mAQiN+FLlL1yoGQ=
 github.com/multiversx/mx-chain-scenario-go v1.4.4 h1:DVE2V+FPeyD/yWoC+KEfPK3jsFzHeruelESfpTlf460=
 github.com/multiversx/mx-chain-scenario-go v1.4.4/go.mod h1:kI+TWR3oIEgUkbwkHCPo2CQ3VjIge+ezGTibiSGwMxo=
-github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241129143541-8c5c73c5cbfd h1:0yZsj/QI/x/bENE0gEb1d742df+elNTbhr8ujhYh9SU=
-github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241129143541-8c5c73c5cbfd/go.mod h1:eFDEOrG7Wiyk5I/ObpwcN2eoBlOnnfeEMTvTer1cymk=
+github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241202081201-f9a268fc6918 h1:7gbYT9Q7Fww60wUer/tD1h4I+C5WGYUDJDLYnw0hGPg=
+github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241202081201-f9a268fc6918/go.mod h1:eFDEOrG7Wiyk5I/ObpwcN2eoBlOnnfeEMTvTer1cymk=
 github.com/multiversx/mx-chain-vm-common-go v1.5.16 h1:g1SqYjxl7K66Y1O/q6tvDJ37fzpzlxCSfRzSm/woQQY=
 github.com/multiversx/mx-chain-vm-common-go v1.5.16/go.mod h1:1rSkXreUZNXyPTTdhj47M+Fy62yjxbu3aAsXEtKN3UY=
 github.com/multiversx/mx-chain-vm-go v1.5.37 h1:Iy3KCvM+DOq1f9UPA7uYK/rI3ZbBOXc2CVNO2/vm5zw=


### PR DESCRIPTION
## Reasoning behind the pull request
- When adding transactions in the mempool, the addition is subject to the so-called "sender constraints". Historically, the parameters that guide the constraints were [these](https://github.com/multiversx/mx-chain-mainnet-config/blob/v1.8.4.0/config.toml#L389).
- However, since, for some time, the interceptors apply [this constraint](https://docs.multiversx.com/integrators/creating-transactions/#issue-too-many-transactions-from-the-same-account), it's reasonable to adjust the "sender constraints", as well.
- https://github.com/multiversx/mx-chain-storage-go/pull/64
  
## Proposed changes
- `Adjust TxDataPool.SizePerSender` to a lower value.

## Testing procedure
- Standard testing.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
