### PR TITLE
Mempool: lower "maxNum" when selecting transactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/multiversx/mx-chain-es-indexer-go v1.7.10
 	github.com/multiversx/mx-chain-logger-go v1.0.15
 	github.com/multiversx/mx-chain-scenario-go v1.4.4
-	github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241202081201-f9a268fc6918
+	github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241202095036-f8323f446689
 	github.com/multiversx/mx-chain-vm-common-go v1.5.16
 	github.com/multiversx/mx-chain-vm-go v1.5.37
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.68

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/multiversx/mx-chain-logger-go v1.0.15 h1:HlNdK8etyJyL9NQ+6mIXyKPEBo+w
 github.com/multiversx/mx-chain-logger-go v1.0.15/go.mod h1:t3PRKaWB1M+i6gUfD27KXgzLJJC+mAQiN+FLlL1yoGQ=
 github.com/multiversx/mx-chain-scenario-go v1.4.4 h1:DVE2V+FPeyD/yWoC+KEfPK3jsFzHeruelESfpTlf460=
 github.com/multiversx/mx-chain-scenario-go v1.4.4/go.mod h1:kI+TWR3oIEgUkbwkHCPo2CQ3VjIge+ezGTibiSGwMxo=
-github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241202081201-f9a268fc6918 h1:7gbYT9Q7Fww60wUer/tD1h4I+C5WGYUDJDLYnw0hGPg=
-github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241202081201-f9a268fc6918/go.mod h1:eFDEOrG7Wiyk5I/ObpwcN2eoBlOnnfeEMTvTer1cymk=
+github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241202095036-f8323f446689 h1:qijedQ0WVc3ydsfNtMXbOiLgBc9Mw7iGzbhhrZVBY+0=
+github.com/multiversx/mx-chain-storage-go v1.0.18-0.20241202095036-f8323f446689/go.mod h1:eFDEOrG7Wiyk5I/ObpwcN2eoBlOnnfeEMTvTer1cymk=
 github.com/multiversx/mx-chain-vm-common-go v1.5.16 h1:g1SqYjxl7K66Y1O/q6tvDJ37fzpzlxCSfRzSm/woQQY=
 github.com/multiversx/mx-chain-vm-common-go v1.5.16/go.mod h1:1rSkXreUZNXyPTTdhj47M+Fy62yjxbu3aAsXEtKN3UY=
 github.com/multiversx/mx-chain-vm-go v1.5.37 h1:Iy3KCvM+DOq1f9UPA7uYK/rI3ZbBOXc2CVNO2/vm5zw=

--- a/process/constants.go
+++ b/process/constants.go
@@ -143,7 +143,7 @@ const MaxGasFeeHigherFactorAccepted = 10
 const TxCacheSelectionGasRequested = 10_000_000_000
 
 // TxCacheSelectionMaxNumTxs defines the maximum number of transactions that should be selected from the cache.
-const TxCacheSelectionMaxNumTxs = 50000
+const TxCacheSelectionMaxNumTxs = 30_000
 
 // TxCacheSelectionLoopMaximumDuration defines the maximum duration for the loop that selects transactions from the cache.
 const TxCacheSelectionLoopMaximumDuration = 250 * time.Millisecond


### PR DESCRIPTION
## Reasoning behind the pull request
- Since the selection flow does not include not-executable transactions anymore, we can use a lower `maxNum` when selecting transactions (optimization).
  
## Proposed changes
- Adjust constant `TxCacheSelectionMaxNumTxs` from 50k to 30k.
- https://github.com/multiversx/mx-chain-storage-go/pull/65

## Testing procedure
- Standard & heavy testing. 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
