### PR TITLE
Fix transaction/pool endpoint issues

### DIFF
--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -394,8 +394,8 @@ func (atp *apiTransactionProcessor) getFieldGettersForTx(wrappedTx *txcache.Wrap
 		rcvUsernameField: wrappedTx.Tx.GetRcvUserName(),
 		dataField:        wrappedTx.Tx.GetData(),
 		valueField:       getTxValue(wrappedTx),
-		senderShardID:    wrappedTx.SenderShardID,
-		receiverShardID:  wrappedTx.ReceiverShardID,
+		senderShardID:    atp.shardCoordinator.ComputeId(wrappedTx.Tx.GetSndAddr()),
+		receiverShardID:  atp.shardCoordinator.ComputeId(wrappedTx.Tx.GetRcvAddr()),
 	}
 
 	guardedTx, isGuardedTx := wrappedTx.Tx.(data.GuardedTransactionHandler)

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -933,6 +933,9 @@ func TestApiTransactionProcessor_GetTransactionsPoolForSender(t *testing.T) {
 		NumberOfShardsCalled: func() uint32 {
 			return 1
 		},
+		ComputeIdCalled: func(address []byte) uint32 {
+			return 1 // force to return different from 0
+		},
 	}
 	atp, err := NewAPITransactionProcessor(args)
 	require.NoError(t, err)
@@ -945,7 +948,17 @@ func TestApiTransactionProcessor_GetTransactionsPoolForSender(t *testing.T) {
 	for i, tx := range res.Transactions {
 		require.Equal(t, expectedHashes[i], tx.TxFields[hashField])
 		require.Equal(t, expectedValues[i], tx.TxFields[valueField])
-		require.Equal(t, sender, tx.TxFields["sender"])
+		require.Equal(t, sender, tx.TxFields[senderField])
+		require.Equal(t, uint32(1), tx.TxFields[senderShardID])
+		require.Equal(t, uint32(1), tx.TxFields[senderShardID])
+	}
+
+	res, err = atp.GetTransactionsPoolForSender(sender, "sender,value") // no hash, should be by default
+	require.NoError(t, err)
+	for i, tx := range res.Transactions {
+		require.Equal(t, expectedHashes[i], tx.TxFields[hashField])
+		require.Equal(t, expectedValues[i], tx.TxFields[valueField])
+		require.Equal(t, sender, tx.TxFields[senderField])
 	}
 
 	// if no tx is found in pool for a sender, it isn't an error, but return empty slice

--- a/node/external/transactionAPI/fieldsHandler.go
+++ b/node/external/transactionAPI/fieldsHandler.go
@@ -38,8 +38,11 @@ func newFieldsHandler(parameters string) fieldsHandler {
 	}
 
 	parameters = strings.ToLower(parameters)
+	fieldsMap := sliceToMap(strings.Split(parameters, separator))
+	fieldsMap[hashField] = struct{}{} // hashField should always be returned
+
 	return fieldsHandler{
-		fieldsMap: sliceToMap(strings.Split(parameters, separator)),
+		fieldsMap: fieldsMap,
 	}
 }
 

--- a/node/external/transactionAPI/fieldsHandler_test.go
+++ b/node/external/transactionAPI/fieldsHandler_test.go
@@ -20,9 +20,11 @@ func Test_newFieldsHandler(t *testing.T) {
 	for _, field := range splitFields {
 		require.True(t, fh.IsFieldSet(field), fmt.Sprintf("field %s is not set", field))
 	}
+	require.True(t, fh.IsFieldSet(hashField), fmt.Sprintf("hashField should have been returned by default"))
 
 	fh = newFieldsHandler("*")
 	for _, field := range splitFields {
 		require.True(t, fh.IsFieldSet(field))
 	}
+	require.True(t, fh.IsFieldSet(hashField), fmt.Sprintf("hashField should have been returned by default"))
 }

--- a/node/external/transactionAPI/fieldsHandler_test.go
+++ b/node/external/transactionAPI/fieldsHandler_test.go
@@ -20,11 +20,11 @@ func Test_newFieldsHandler(t *testing.T) {
 	for _, field := range splitFields {
 		require.True(t, fh.IsFieldSet(field), fmt.Sprintf("field %s is not set", field))
 	}
-	require.True(t, fh.IsFieldSet(hashField), fmt.Sprintf("hashField should have been returned by default"))
+	require.True(t, fh.IsFieldSet(hashField), "hashField should have been returned by default")
 
 	fh = newFieldsHandler("*")
 	for _, field := range splitFields {
 		require.True(t, fh.IsFieldSet(field))
 	}
-	require.True(t, fh.IsFieldSet(hashField), fmt.Sprintf("hashField should have been returned by default"))
+	require.True(t, fh.IsFieldSet(hashField), "hashField should have been returned by default")
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- if hash is not explicitly provided, it is not returned in response
- when requesting with fields=*, senderShard and receiverShard are always 0
  
## Proposed changes
- fix the fields

## Testing procedure
- standard system test + add some cross shard txs in the pool. Check:
   - /transaction/pool?fields=* returns proper shards for sender and receiver. 
   - /transaction/pool?by-sender="sender"&fields="*" returns proper shards
   - /transaction/pool?by-sender="sender"&fields=sender returns txHash as well(same for all combinations of fields)

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
