### PR TITLE
Enable (newline-delimited) JSON logging

### DIFF
--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -246,6 +246,11 @@ var (
 		Name:  "log-save",
 		Usage: "Boolean option for enabling log saving. If set, it will automatically save all the logs into a file.",
 	}
+	// logSaveFileJson is used to enable log saving as newline-delimited JSON
+	logSaveFileJson = cli.BoolFlag{
+		Name:  "log-save-json",
+		Usage: "Boolean option for enabling log saving as newline-delimited JSON.",
+	}
 	// logWithCorrelation is used to enable log correlation elements
 	logWithCorrelation = cli.BoolFlag{
 		Name:  "log-correlation",
@@ -443,6 +448,7 @@ func getFlags() []cli.Flag {
 		disableAnsiColor,
 		logLevel,
 		logSaveFile,
+		logSaveFileJson,
 		logWithCorrelation,
 		logWithLoggerName,
 		useLogView,
@@ -481,6 +487,7 @@ func getFlagsConfig(ctx *cli.Context, log logger.Logger) *config.ContextFlagsCon
 	flagsConfig.LogsDir = getCustomDirIfSet(ctx, logsDirectory, log)
 	flagsConfig.EnableGops = ctx.GlobalBool(gopsEn.Name)
 	flagsConfig.SaveLogFile = ctx.GlobalBool(logSaveFile.Name)
+	flagsConfig.SaveLogFileJson = ctx.GlobalBool(logSaveFile.Name)
 	flagsConfig.EnableLogCorrelation = ctx.GlobalBool(logWithCorrelation.Name)
 	flagsConfig.EnableLogName = ctx.GlobalBool(logWithLoggerName.Name)
 	flagsConfig.LogLevel = ctx.GlobalString(logLevel.Name)

--- a/cmd/node/logging.go
+++ b/cmd/node/logging.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-go/cmd/node/factory"
+	"github.com/multiversx/mx-chain-go/config"
+	logger "github.com/multiversx/mx-chain-logger-go"
+	"github.com/multiversx/mx-chain-logger-go/file"
+)
+
+type nodeLogging struct {
+	fileLogging     factory.FileLoggingHandler
+	fileLoggingJson factory.FileLoggingHandler
+}
+
+func (logging *nodeLogging) setup(log logger.Logger, flagsConfig *config.ContextFlagsConfig) error {
+	err := logging.handleSaveLogFile(flagsConfig)
+	if err != nil {
+		return err
+	}
+
+	err = logging.handleSaveLogFileJson(flagsConfig)
+	if err != nil {
+		return err
+	}
+
+	err = logger.SetDisplayByteSlice(logger.ToHex)
+	if err != nil {
+		return err
+	}
+
+	err = logger.SetLogLevel(flagsConfig.LogLevel)
+	if err != nil {
+		return err
+	}
+
+	err = logging.handleDisableAnsiColor(flagsConfig)
+	if err != nil {
+		return err
+	}
+
+	logger.ToggleCorrelation(flagsConfig.EnableLogCorrelation)
+	logger.ToggleLoggerName(flagsConfig.EnableLogName)
+
+	log.Debug("logging set up",
+		"level", flagsConfig.LogLevel,
+		"save log file", flagsConfig.SaveLogFile,
+		"save log file (JSON)", flagsConfig.SaveLogFileJson,
+		"disable ANSI color", flagsConfig.DisableAnsiColor,
+	)
+
+	return nil
+}
+
+func (logging *nodeLogging) handleSaveLogFile(flagsConfig *config.ContextFlagsConfig) error {
+	if !flagsConfig.SaveLogFile {
+		return nil
+	}
+
+	args := file.ArgsFileLogging{
+		WorkingDir:      flagsConfig.LogsDir,
+		DefaultLogsPath: defaultLogsPath,
+		LogFilePrefix:   logFilePrefix,
+	}
+
+	fileLogging, err := file.NewFileLogging(args)
+	if err != nil {
+		return fmt.Errorf("%w creating log file", err)
+	}
+
+	logging.fileLogging = fileLogging
+	return nil
+}
+
+func (logging *nodeLogging) handleSaveLogFileJson(flagsConfig *config.ContextFlagsConfig) error {
+	if !flagsConfig.SaveLogFileJson {
+		return nil
+	}
+
+	args := file.ArgsFileLogging{
+		WorkingDir:      flagsConfig.LogsDir,
+		DefaultLogsPath: defaultLogsPath,
+		LogFilePrefix:   logFilePrefix,
+		LogAsJson:       true,
+	}
+
+	fileLoggingJson, err := file.NewFileLogging(args)
+	if err != nil {
+		return fmt.Errorf("%w creating log file (JSON)", err)
+	}
+
+	logging.fileLoggingJson = fileLoggingJson
+	return nil
+}
+
+func (logging *nodeLogging) handleDisableAnsiColor(flagsConfig *config.ContextFlagsConfig) error {
+	if !flagsConfig.DisableAnsiColor {
+		return nil
+	}
+
+	err := logger.RemoveLogObserver(os.Stdout)
+	if err != nil {
+		return err
+	}
+
+	err = logger.AddLogObserver(os.Stdout, &logger.PlainFormatter{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (logging *nodeLogging) applyFileLifeSpan(log logger.Logger, config *config.Config) error {
+	durationLogLifeSpan := time.Second * time.Duration(config.Logs.LogFileLifeSpanInSec)
+	sizeLogLifeSpanInMB := uint64(config.Logs.LogFileLifeSpanInMB)
+
+	if !check.IfNil(logging.fileLogging) {
+		err := logging.fileLogging.ChangeFileLifeSpan(durationLogLifeSpan, sizeLogLifeSpanInMB)
+		if err != nil {
+			return err
+		}
+
+		log.Debug("log file life span changed", "duration", durationLogLifeSpan, "size", sizeLogLifeSpanInMB)
+	}
+
+	if !check.IfNil(logging.fileLoggingJson) {
+		err := logging.fileLoggingJson.ChangeFileLifeSpan(durationLogLifeSpan, sizeLogLifeSpanInMB)
+		if err != nil {
+			return err
+		}
+
+		log.Debug("log file life span changed (JSON)", "duration", durationLogLifeSpan, "size", sizeLogLifeSpanInMB)
+	}
+
+	return nil
+}
+
+func (logging *nodeLogging) closeFiles(log logger.Logger) {
+	if !check.IfNil(logging.fileLogging) {
+		err := logging.fileLogging.Close()
+		log.LogIfError(err)
+	}
+
+	if !check.IfNil(logging.fileLoggingJson) {
+		err := logging.fileLoggingJson.Close()
+		log.LogIfError(err)
+	}
+}

--- a/config/contextFlagsConfig.go
+++ b/config/contextFlagsConfig.go
@@ -7,6 +7,7 @@ type ContextFlagsConfig struct {
 	LogsDir                      string
 	EnableGops                   bool
 	SaveLogFile                  bool
+	SaveLogFileJson              bool
 	EnableLogCorrelation         bool
 	EnableLogName                bool
 	LogLevel                     string

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/multiversx/mx-chain-core-go v1.2.23
 	github.com/multiversx/mx-chain-crypto-go v1.2.12
 	github.com/multiversx/mx-chain-es-indexer-go v1.7.10
-	github.com/multiversx/mx-chain-logger-go v1.0.15
+	github.com/multiversx/mx-chain-logger-go v1.0.16-0.20241206203529-1069e4b181f1
 	github.com/multiversx/mx-chain-scenario-go v1.4.4
 	github.com/multiversx/mx-chain-storage-go v1.0.18
 	github.com/multiversx/mx-chain-vm-common-go v1.5.16

--- a/go.sum
+++ b/go.sum
@@ -393,8 +393,8 @@ github.com/multiversx/mx-chain-crypto-go v1.2.12 h1:zWip7rpUS4CGthJxfKn5MZfMfYPj
 github.com/multiversx/mx-chain-crypto-go v1.2.12/go.mod h1:HzcPpCm1zanNct/6h2rIh+MFrlXbjA5C8+uMyXj3LI4=
 github.com/multiversx/mx-chain-es-indexer-go v1.7.10 h1:Umi7WN8h4BOXLw7CM3VgvaWkLGef7nXtaPIGbjBCT3U=
 github.com/multiversx/mx-chain-es-indexer-go v1.7.10/go.mod h1:oGcRK2E3Syv6vRTszWrrb/TqD8akq0yeoMr1wPPiTO4=
-github.com/multiversx/mx-chain-logger-go v1.0.15 h1:HlNdK8etyJyL9NQ+6mIXyKPEBo+wRqOwi3n+m2QIHXc=
-github.com/multiversx/mx-chain-logger-go v1.0.15/go.mod h1:t3PRKaWB1M+i6gUfD27KXgzLJJC+mAQiN+FLlL1yoGQ=
+github.com/multiversx/mx-chain-logger-go v1.0.16-0.20241206203529-1069e4b181f1 h1:iufFZRFWofTZtJV/3e5ktpUehElDd+VOyDzhJB6J3qY=
+github.com/multiversx/mx-chain-logger-go v1.0.16-0.20241206203529-1069e4b181f1/go.mod h1:t3PRKaWB1M+i6gUfD27KXgzLJJC+mAQiN+FLlL1yoGQ=
 github.com/multiversx/mx-chain-scenario-go v1.4.4 h1:DVE2V+FPeyD/yWoC+KEfPK3jsFzHeruelESfpTlf460=
 github.com/multiversx/mx-chain-scenario-go v1.4.4/go.mod h1:kI+TWR3oIEgUkbwkHCPo2CQ3VjIge+ezGTibiSGwMxo=
 github.com/multiversx/mx-chain-storage-go v1.0.18 h1:DA33o5COEjnCKclCeCvzXXI0zIgFp2QqZK32UTVvDes=

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -652,6 +652,8 @@ func (boot *baseBootstrap) syncBlock() error {
 	err = boot.blockProcessor.ProcessBlock(header, body, haveTime)
 	elapsedTime := time.Since(startProcessBlockTime)
 	log.Debug("elapsed time to process block",
+		"round", header.GetRound(),
+		"nonce", header.GetNonce(),
 		"time [s]", elapsedTime,
 	)
 	if err != nil {
@@ -662,6 +664,8 @@ func (boot *baseBootstrap) syncBlock() error {
 	err = boot.blockProcessor.ProcessScheduledBlock(header, body, haveTime)
 	elapsedTime = time.Since(startProcessScheduledBlockTime)
 	log.Debug("elapsed time to process scheduled block",
+		"round", header.GetRound(),
+		"nonce", header.GetNonce(),
 		"time [s]", elapsedTime,
 	)
 	if err != nil {
@@ -675,6 +679,8 @@ func (boot *baseBootstrap) syncBlock() error {
 		log.Warn("syncBlock.CommitBlock", "elapsed time", elapsedTime)
 	} else {
 		log.Debug("elapsed time to commit block",
+			"round", header.GetRound(),
+			"nonce", header.GetNonce(),
 			"time [s]", elapsedTime,
 		)
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- Often, it's useful to have a more structure representation of the Node's logs.
  
## Proposed changes
- https://github.com/multiversx/mx-chain-logger-go/pull/33
- Add a new CLI flag: `--log-save-json`. Logs will be written to a `*.jsonl` file (new-line delimited JSON).
- Can be used on its own, or together with `--log-save` (log files will be paired).

## Testing procedure
- Standard testing
- Enable only standard file logging, without JSON logging
- Enable only JSON file logging, without standard file logging
- Enable both standard file logging and JSON logging

Example of a log line (excerpt from a `.jsonl` log file):

```
{"Message":"highest final shard block","LogLevel":1,"Args":["shard","1","nonce","821198"],"Timestamp":1733518032262273416,"LoggerName":"process/block","Correlation":{"Shard":"1","Epoch":685,"Round":822772,"SubRound":"(END_ROUND)"}}
```

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
