### PR TITLE
Accept relayed tx v3 with sender account non-existent

### DIFF
--- a/process/dataValidators/txValidator.go
+++ b/process/dataValidators/txValidator.go
@@ -2,7 +2,6 @@ package dataValidators
 
 import (
 	"fmt"
-	"math/big"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
@@ -95,7 +94,7 @@ func hasTxValue(interceptedTx process.InterceptedTransactionHandler) bool {
 		return false
 	}
 
-	return big.NewInt(0).Cmp(txValue) < 0
+	return txValue.Sign() > 0
 }
 
 func (txv *txValidator) checkAccount(

--- a/process/dataValidators/txValidator_test.go
+++ b/process/dataValidators/txValidator_test.go
@@ -324,10 +324,10 @@ func TestTxValidator_CheckTxValidityAccountBalanceIsLessThanTxTotalValueShouldRe
 		adb.GetExistingAccountCalled = func(address []byte) (handler vmcommon.AccountHandler, e error) {
 			cnt++
 			if cnt == 1 {
-				require.True(t, bytes.Equal(providedSenderAddress, address))
-			} else {
-				require.True(t, bytes.Equal(providedRelayerAddress, address))
+				return nil, errors.New("sender not found")
 			}
+
+			require.True(t, bytes.Equal(providedRelayerAddress, address))
 
 			acc, _ := accounts.NewUserAccount(address, &trie.DataTrieTrackerStub{}, &trie.TrieLeafParserStub{})
 			acc.Nonce = accountNonce
@@ -358,6 +358,7 @@ func TestTxValidator_CheckTxValidityAccountBalanceIsLessThanTxTotalValueShouldRe
 				Signature:        []byte("address sig"),
 				RelayerAddr:      providedRelayerAddress,
 				RelayerSignature: []byte("relayer sig"),
+				Value:            big.NewInt(0),
 			}
 		}
 		result := txValidator.CheckTxValidity(txValidatorHandler)


### PR DESCRIPTION
## Reasoning behind the pull request
- relayed txs v3 with sender account not-existent are rejected by interceptors, despite the zero value of transaction
  
## Proposed changes
- allow relayed txs v3 with new senders, in case of zero value transactions

## Testing procedure
- with feat branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
