### PR TITLE
Fix receipts hash mismatch

### DIFF
--- a/integrationTests/chainSimulator/relayedTx/relayedTx_test.go
+++ b/integrationTests/chainSimulator/relayedTx/relayedTx_test.go
@@ -151,7 +151,8 @@ func testRelayedV3MoveBalance(
 		result, err := cs.SendTxAndGenerateBlockTilTxIsExecuted(relayedTx, maxNumOfBlocksToGenerateWhenExecutingTx)
 		require.NoError(t, err)
 
-		if relayerShard == destinationShard {
+		isIntraShard := relayerShard == destinationShard
+		if isIntraShard {
 			require.NoError(t, cs.GenerateBlocks(maxNumOfBlocksToGenerateWhenExecutingTx))
 		}
 
@@ -181,7 +182,7 @@ func testRelayedV3MoveBalance(
 		// check intra shard logs, should be none
 		require.Nil(t, result.Logs)
 
-		if extraGas {
+		if extraGas && isIntraShard {
 			require.NotNil(t, result.Receipt)
 		}
 	}

--- a/integrationTests/chainSimulator/relayedTx/relayedTx_test.go
+++ b/integrationTests/chainSimulator/relayedTx/relayedTx_test.go
@@ -180,6 +180,10 @@ func testRelayedV3MoveBalance(
 
 		// check intra shard logs, should be none
 		require.Nil(t, result.Logs)
+
+		if extraGas {
+			require.NotNil(t, result.Receipt)
+		}
 	}
 }
 
@@ -822,6 +826,37 @@ func TestRelayedTransactionFeeField(t *testing.T) {
 		require.Equal(t, expectedFee.String(), result.InitiallyPaidFee)
 		require.Equal(t, uint64(gasLimit), result.GasUsed)
 	})
+}
+
+func TestRegularMoveBalanceWithRefundReceipt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	cs := startChainSimulator(t, func(cfg *config.Configs) {})
+	defer cs.Close()
+
+	initialBalance := big.NewInt(0).Mul(oneEGLD, big.NewInt(10))
+
+	sender, err := cs.GenerateAndMintWalletAddress(0, initialBalance)
+	require.NoError(t, err)
+
+	// generate one block so the minting has effect
+	err = cs.GenerateBlocks(1)
+	require.NoError(t, err)
+
+	senderNonce := uint64(0)
+
+	extraGas := uint64(minGasLimit)
+	gasLimit := minGasLimit + extraGas
+	tx := generateTransaction(sender.Bytes, senderNonce, sender.Bytes, oneEGLD, "", gasLimit)
+
+	result, err := cs.SendTxAndGenerateBlockTilTxIsExecuted(tx, maxNumOfBlocksToGenerateWhenExecutingTx)
+	require.NoError(t, err)
+
+	require.NotNil(t, result.Receipt)
+	expectedGasRefunded := core.SafeMul(extraGas, minGasPrice/deductionFactor)
+	require.Equal(t, expectedGasRefunded.String(), result.Receipt.Value.String())
 }
 
 func startChainSimulator(

--- a/process/transaction/shardProcess.go
+++ b/process/transaction/shardProcess.go
@@ -549,7 +549,11 @@ func (txProc *txProcessor) processMoveBalance(
 		}
 	}
 
-	txHash := originalTxHash
+	txHash, err := core.CalculateHash(txProc.marshalizer, txProc.hasher, tx)
+	if err != nil {
+		return err
+	}
+
 	err = txProc.createReceiptWithReturnedGas(txHash, tx, feePayer, moveBalanceCost, totalCost, destShardTxType, isUserTxOfRelayed)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Reasoning behind the pull request
- missing receipt for move balance intra shard in case of refund
  
## Proposed changes
- compute the txHash as before

## Testing procedure
- with feat branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
