### PR TITLE
encoded tx hash to hex format due to serializing issues in proto.

### DIFF
--- a/state/stateChanges/collector.go
+++ b/state/stateChanges/collector.go
@@ -2,6 +2,7 @@ package stateChanges
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -100,7 +101,7 @@ func (c *collector) Publish() (map[string]*data.StateChanges, error) {
 
 	stateChangesForTxs := make(map[string]*data.StateChanges)
 	for _, stateChange := range c.stateChanges {
-		txHash := string(stateChange.GetTxHash())
+		txHash := hex.EncodeToString(stateChange.GetTxHash())
 
 		st, ok := stateChange.(*data.StateChange)
 		if !ok {

--- a/state/stateChanges/collector_test.go
+++ b/state/stateChanges/collector_test.go
@@ -1,6 +1,7 @@
 package stateChanges
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -344,10 +345,10 @@ func TestStateChangesCollector_Publish(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, stateChangesForTx, 1)
-		require.Len(t, stateChangesForTx["hash0"].StateChanges, 10)
+		require.Len(t, stateChangesForTx[hex.EncodeToString([]byte("hash0"))].StateChanges, 10)
 
 		require.Equal(t, stateChangesForTx, map[string]*data.StateChanges{
-			"hash0": {
+			hex.EncodeToString([]byte("hash0")): {
 				StateChanges: []*data.StateChange{
 					{Type: data.Write, TxHash: []byte("hash0")},
 					{Type: data.Write, TxHash: []byte("hash0")},
@@ -391,10 +392,10 @@ func TestStateChangesCollector_Publish(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, stateChangesForTx, 1)
-		require.Len(t, stateChangesForTx["hash1"].StateChanges, 10)
+		require.Len(t, stateChangesForTx[hex.EncodeToString([]byte("hash1"))].StateChanges, 10)
 
 		require.Equal(t, stateChangesForTx, map[string]*data.StateChanges{
-			"hash1": {
+			hex.EncodeToString([]byte("hash1")): {
 				StateChanges: []*data.StateChange{
 					{Type: data.Read, TxHash: []byte("hash1")},
 					{Type: data.Read, TxHash: []byte("hash1")},
@@ -438,11 +439,11 @@ func TestStateChangesCollector_Publish(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, stateChangesForTx, 2)
-		require.Len(t, stateChangesForTx["hash0"].StateChanges, 10)
-		require.Len(t, stateChangesForTx["hash1"].StateChanges, 10)
+		require.Len(t, stateChangesForTx[hex.EncodeToString([]byte("hash0"))].StateChanges, 10)
+		require.Len(t, stateChangesForTx[hex.EncodeToString([]byte("hash1"))].StateChanges, 10)
 
 		require.Equal(t, stateChangesForTx, map[string]*data.StateChanges{
-			"hash0": {
+			hex.EncodeToString([]byte("hash0")): {
 				StateChanges: []*data.StateChange{
 					{Type: data.Write, TxHash: []byte("hash0")},
 					{Type: data.Write, TxHash: []byte("hash0")},
@@ -456,7 +457,7 @@ func TestStateChangesCollector_Publish(t *testing.T) {
 					{Type: data.Write, TxHash: []byte("hash0")},
 				},
 			},
-			"hash1": {
+			hex.EncodeToString([]byte("hash1")): {
 				StateChanges: []*data.StateChange{
 					{Type: data.Read, TxHash: []byte("hash1")},
 					{Type: data.Read, TxHash: []byte("hash1")},


### PR DESCRIPTION
## Reasoning behind the pull request
- Issue with serializing of unencoded hashes in proto on the connector side.
  
## Proposed changes
- Encode the hash of the transaction when storing the state changes.

## Testing procedure
- Local testnet with state changes collector enabled and outport driver.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
