### PR TITLE
Bug-fix /transaction/:txHash endpoint 

### DIFF
--- a/dblookupext/historyRepository_test.go
+++ b/dblookupext/historyRepository_test.go
@@ -2,13 +2,13 @@ package dblookupext
 
 import (
 	"errors"
-	"github.com/multiversx/mx-chain-core-go/marshal"
 	"sync"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common/mock"
 	"github.com/multiversx/mx-chain-go/dblookupext/esdtSupply"
 	epochStartMocks "github.com/multiversx/mx-chain-go/epochStart/mock"

--- a/dblookupext/miniblockMetadata.pb.go
+++ b/dblookupext/miniblockMetadata.pb.go
@@ -28,19 +28,20 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // MiniblockMetadata is used to store information about a history transaction
 type MiniblockMetadata struct {
-	SourceShardID                     uint32 `protobuf:"varint,1,opt,name=SourceShardID,proto3" json:"SourceShardID,omitempty"`
-	DestinationShardID                uint32 `protobuf:"varint,2,opt,name=DestinationShardID,proto3" json:"DestinationShardID,omitempty"`
-	Round                             uint64 `protobuf:"varint,3,opt,name=Round,proto3" json:"Round,omitempty"`
-	HeaderNonce                       uint64 `protobuf:"varint,4,opt,name=HeaderNonce,proto3" json:"HeaderNonce,omitempty"`
-	HeaderHash                        []byte `protobuf:"bytes,5,opt,name=HeaderHash,proto3" json:"HeaderHash,omitempty"`
-	MiniblockHash                     []byte `protobuf:"bytes,6,opt,name=MiniblockHash,proto3" json:"MiniblockHash,omitempty"`
-	DeprecatedStatus                  []byte `protobuf:"bytes,7,opt,name=DeprecatedStatus,proto3" json:"DeprecatedStatus,omitempty"` // Deprecated: Do not use.
-	Epoch                             uint32 `protobuf:"varint,8,opt,name=Epoch,proto3" json:"Epoch,omitempty"`
-	NotarizedAtSourceInMetaNonce      uint64 `protobuf:"varint,9,opt,name=NotarizedAtSourceInMetaNonce,proto3" json:"NotarizedAtSourceInMetaNonce,omitempty"`
-	NotarizedAtDestinationInMetaNonce uint64 `protobuf:"varint,10,opt,name=NotarizedAtDestinationInMetaNonce,proto3" json:"NotarizedAtDestinationInMetaNonce,omitempty"`
-	NotarizedAtSourceInMetaHash       []byte `protobuf:"bytes,11,opt,name=NotarizedAtSourceInMetaHash,proto3" json:"NotarizedAtSourceInMetaHash,omitempty"`
-	NotarizedAtDestinationInMetaHash  []byte `protobuf:"bytes,12,opt,name=NotarizedAtDestinationInMetaHash,proto3" json:"NotarizedAtDestinationInMetaHash,omitempty"`
-	Type                              int32  `protobuf:"varint,13,opt,name=Type,proto3" json:"Type,omitempty"`
+	SourceShardID                     uint32                  `protobuf:"varint,1,opt,name=SourceShardID,proto3" json:"SourceShardID,omitempty"`
+	DestinationShardID                uint32                  `protobuf:"varint,2,opt,name=DestinationShardID,proto3" json:"DestinationShardID,omitempty"`
+	Round                             uint64                  `protobuf:"varint,3,opt,name=Round,proto3" json:"Round,omitempty"`
+	HeaderNonce                       uint64                  `protobuf:"varint,4,opt,name=HeaderNonce,proto3" json:"HeaderNonce,omitempty"`
+	HeaderHash                        []byte                  `protobuf:"bytes,5,opt,name=HeaderHash,proto3" json:"HeaderHash,omitempty"`
+	MiniblockHash                     []byte                  `protobuf:"bytes,6,opt,name=MiniblockHash,proto3" json:"MiniblockHash,omitempty"`
+	DeprecatedStatus                  []byte                  `protobuf:"bytes,7,opt,name=DeprecatedStatus,proto3" json:"DeprecatedStatus,omitempty"` // Deprecated: Do not use.
+	Epoch                             uint32                  `protobuf:"varint,8,opt,name=Epoch,proto3" json:"Epoch,omitempty"`
+	NotarizedAtSourceInMetaNonce      uint64                  `protobuf:"varint,9,opt,name=NotarizedAtSourceInMetaNonce,proto3" json:"NotarizedAtSourceInMetaNonce,omitempty"`
+	NotarizedAtDestinationInMetaNonce uint64                  `protobuf:"varint,10,opt,name=NotarizedAtDestinationInMetaNonce,proto3" json:"NotarizedAtDestinationInMetaNonce,omitempty"`
+	NotarizedAtSourceInMetaHash       []byte                  `protobuf:"bytes,11,opt,name=NotarizedAtSourceInMetaHash,proto3" json:"NotarizedAtSourceInMetaHash,omitempty"`
+	NotarizedAtDestinationInMetaHash  []byte                  `protobuf:"bytes,12,opt,name=NotarizedAtDestinationInMetaHash,proto3" json:"NotarizedAtDestinationInMetaHash,omitempty"`
+	Type                              int32                   `protobuf:"varint,13,opt,name=Type,proto3" json:"Type,omitempty"`
+	PartialExecutionInfo              []*PartialExecutionInfo `protobuf:"bytes,14,rep,name=PartialExecutionInfo,proto3" json:"PartialExecutionInfo,omitempty"`
 }
 
 func (m *MiniblockMetadata) Reset()      { *m = MiniblockMetadata{} }
@@ -163,40 +164,109 @@ func (m *MiniblockMetadata) GetType() int32 {
 	return 0
 }
 
+func (m *MiniblockMetadata) GetPartialExecutionInfo() []*PartialExecutionInfo {
+	if m != nil {
+		return m.PartialExecutionInfo
+	}
+	return nil
+}
+
+// PartialExecutionInfo is used to store information about partial executed miniblock
+type PartialExecutionInfo struct {
+	NotarizedAtDestinationMetaNonce  uint64 `protobuf:"varint,1,opt,name=NotarizedAtDestinationMetaNonce,proto3" json:"NotarizedAtDestinationMetaNonce,omitempty"`
+	NotarizedAtDestinationInMetaHash []byte `protobuf:"bytes,2,opt,name=NotarizedAtDestinationInMetaHash,proto3" json:"NotarizedAtDestinationInMetaHash,omitempty"`
+	LastProcessedTxIndex             int32  `protobuf:"varint,3,opt,name=LastProcessedTxIndex,proto3" json:"LastProcessedTxIndex,omitempty"`
+}
+
+func (m *PartialExecutionInfo) Reset()      { *m = PartialExecutionInfo{} }
+func (*PartialExecutionInfo) ProtoMessage() {}
+func (*PartialExecutionInfo) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cd82f29831cbb1fe, []int{1}
+}
+func (m *PartialExecutionInfo) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *PartialExecutionInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	b = b[:cap(b)]
+	n, err := m.MarshalToSizedBuffer(b)
+	if err != nil {
+		return nil, err
+	}
+	return b[:n], nil
+}
+func (m *PartialExecutionInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PartialExecutionInfo.Merge(m, src)
+}
+func (m *PartialExecutionInfo) XXX_Size() int {
+	return m.Size()
+}
+func (m *PartialExecutionInfo) XXX_DiscardUnknown() {
+	xxx_messageInfo_PartialExecutionInfo.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_PartialExecutionInfo proto.InternalMessageInfo
+
+func (m *PartialExecutionInfo) GetNotarizedAtDestinationMetaNonce() uint64 {
+	if m != nil {
+		return m.NotarizedAtDestinationMetaNonce
+	}
+	return 0
+}
+
+func (m *PartialExecutionInfo) GetNotarizedAtDestinationInMetaHash() []byte {
+	if m != nil {
+		return m.NotarizedAtDestinationInMetaHash
+	}
+	return nil
+}
+
+func (m *PartialExecutionInfo) GetLastProcessedTxIndex() int32 {
+	if m != nil {
+		return m.LastProcessedTxIndex
+	}
+	return 0
+}
+
 func init() {
 	proto.RegisterType((*MiniblockMetadata)(nil), "proto.MiniblockMetadata")
+	proto.RegisterType((*PartialExecutionInfo)(nil), "proto.PartialExecutionInfo")
 }
 
 func init() { proto.RegisterFile("miniblockMetadata.proto", fileDescriptor_cd82f29831cbb1fe) }
 
 var fileDescriptor_cd82f29831cbb1fe = []byte{
-	// 406 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x92, 0x4f, 0x6e, 0xda, 0x40,
-	0x18, 0xc5, 0x3d, 0xd4, 0xa6, 0xed, 0x00, 0x52, 0x3b, 0xaa, 0xd4, 0x51, 0x5b, 0x8d, 0xdc, 0xaa,
-	0x0b, 0x6f, 0x6a, 0x16, 0xbd, 0x40, 0x8b, 0x40, 0x82, 0xaa, 0xb0, 0x30, 0x5d, 0x75, 0x37, 0xb6,
-	0x27, 0xd8, 0x02, 0x3c, 0x96, 0x19, 0x4b, 0x49, 0x56, 0x39, 0x42, 0x8e, 0x91, 0xa3, 0x64, 0xc9,
-	0x92, 0x65, 0x3c, 0x6c, 0xb2, 0xe4, 0x08, 0x91, 0x3f, 0x2b, 0x91, 0xc9, 0x1f, 0x58, 0x31, 0xef,
-	0x7d, 0x3f, 0xde, 0x7c, 0xf3, 0x64, 0xfc, 0x71, 0x19, 0x27, 0xb1, 0xbf, 0x90, 0xc1, 0x7c, 0x2c,
-	0x14, 0x0f, 0xb9, 0xe2, 0x6e, 0x9a, 0x49, 0x25, 0x89, 0x05, 0x3f, 0x9f, 0x7e, 0xcc, 0x62, 0x15,
-	0xe5, 0xbe, 0x1b, 0xc8, 0x65, 0x77, 0x26, 0x67, 0xb2, 0x0b, 0xb6, 0x9f, 0x9f, 0x80, 0x02, 0x01,
-	0xa7, 0xea, 0x5f, 0xdf, 0x0a, 0x13, 0xbf, 0x1f, 0x3f, 0x4e, 0x24, 0xdf, 0x71, 0x67, 0x2a, 0xf3,
-	0x2c, 0x10, 0xd3, 0x88, 0x67, 0xe1, 0xa8, 0x4f, 0x91, 0x8d, 0x9c, 0x8e, 0xb7, 0x6f, 0x12, 0x17,
-	0x93, 0xbe, 0x58, 0xa9, 0x38, 0xe1, 0x2a, 0x96, 0xc9, 0x3d, 0xda, 0x00, 0xf4, 0x99, 0x09, 0xf9,
-	0x80, 0x2d, 0x4f, 0xe6, 0x49, 0x48, 0x5f, 0xd9, 0xc8, 0x31, 0xbd, 0x4a, 0x10, 0x1b, 0xb7, 0x86,
-	0x82, 0x87, 0x22, 0x9b, 0xc8, 0x24, 0x10, 0xd4, 0x84, 0x59, 0xdd, 0x22, 0x0c, 0xe3, 0x4a, 0x0e,
-	0xf9, 0x2a, 0xa2, 0x96, 0x8d, 0x9c, 0xb6, 0x57, 0x73, 0xca, 0x6d, 0x1f, 0x9e, 0x00, 0x48, 0x13,
-	0x90, 0x7d, 0x93, 0xb8, 0xf8, 0x5d, 0x5f, 0xa4, 0x99, 0x08, 0xb8, 0x12, 0xe1, 0x54, 0x71, 0x95,
-	0xaf, 0xe8, 0xeb, 0x12, 0xec, 0x35, 0x28, 0xf2, 0x9e, 0xcc, 0xca, 0x6d, 0x07, 0xa9, 0x0c, 0x22,
-	0xfa, 0x06, 0x1e, 0x54, 0x09, 0xd2, 0xc3, 0x5f, 0x26, 0x52, 0xf1, 0x2c, 0x3e, 0x17, 0xe1, 0x6f,
-	0x55, 0xf5, 0x31, 0x4a, 0xca, 0xe2, 0xaa, 0xf5, 0xdf, 0xc2, 0xfa, 0x07, 0x19, 0xf2, 0x17, 0x7f,
-	0xad, 0xcd, 0x6b, 0x45, 0xd5, 0x83, 0x30, 0x04, 0x1d, 0x07, 0xc9, 0x2f, 0xfc, 0xf9, 0x85, 0xdb,
-	0xa0, 0x8b, 0x16, 0x74, 0x71, 0x08, 0x21, 0x7f, 0xb0, 0x7d, 0xe8, 0x1a, 0x88, 0x69, 0x43, 0xcc,
-	0x51, 0x8e, 0x10, 0x6c, 0xfe, 0x3b, 0x4b, 0x05, 0xed, 0xd8, 0xc8, 0xb1, 0x3c, 0x38, 0xf7, 0x06,
-	0xeb, 0x82, 0x19, 0x9b, 0x82, 0x19, 0xbb, 0x82, 0xa1, 0x0b, 0xcd, 0xd0, 0x95, 0x66, 0xe8, 0x5a,
-	0x33, 0xb4, 0xd6, 0x0c, 0x6d, 0x34, 0x43, 0x37, 0x9a, 0xa1, 0x5b, 0xcd, 0x8c, 0x9d, 0x66, 0xe8,
-	0x72, 0xcb, 0x8c, 0xf5, 0x96, 0x19, 0x9b, 0x2d, 0x33, 0xfe, 0xb7, 0x42, 0x7f, 0x21, 0xe5, 0x3c,
-	0x4f, 0xc5, 0xa9, 0xf2, 0x9b, 0xf0, 0xc5, 0xfe, 0xbc, 0x0b, 0x00, 0x00, 0xff, 0xff, 0x36, 0xbd,
-	0xc5, 0xb9, 0x02, 0x03, 0x00, 0x00,
+	// 487 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0xc1, 0x6e, 0xd3, 0x40,
+	0x10, 0x86, 0xbd, 0x69, 0x5c, 0x60, 0xd2, 0x20, 0x58, 0x45, 0x62, 0x45, 0xd1, 0x62, 0x2a, 0x0e,
+	0xbe, 0xe0, 0x4a, 0xe5, 0x05, 0x20, 0x4a, 0xa4, 0x04, 0xb5, 0xa5, 0x72, 0x7a, 0xe2, 0xb6, 0xf6,
+	0x6e, 0x13, 0xab, 0xa9, 0xd7, 0xb2, 0xd7, 0x52, 0xe0, 0xc4, 0x23, 0xf0, 0x18, 0x9c, 0x79, 0x0a,
+	0x8e, 0x39, 0xe6, 0xd8, 0x38, 0x17, 0x8e, 0x7d, 0x04, 0x94, 0xb1, 0x00, 0x17, 0x4c, 0xd2, 0x53,
+	0x76, 0x66, 0xbe, 0xf9, 0xf7, 0xdf, 0x5f, 0x31, 0x3c, 0xb9, 0x8a, 0xe2, 0x28, 0x98, 0xea, 0xf0,
+	0xf2, 0x44, 0x19, 0x21, 0x85, 0x11, 0x5e, 0x92, 0x6a, 0xa3, 0xa9, 0x8d, 0x3f, 0x4f, 0x5f, 0x8d,
+	0x23, 0x33, 0xc9, 0x03, 0x2f, 0xd4, 0x57, 0x87, 0x63, 0x3d, 0xd6, 0x87, 0xd8, 0x0e, 0xf2, 0x0b,
+	0xac, 0xb0, 0xc0, 0x53, 0xb9, 0x75, 0xf0, 0xcd, 0x86, 0xc7, 0x27, 0x7f, 0x2b, 0xd2, 0x97, 0xd0,
+	0x1e, 0xe9, 0x3c, 0x0d, 0xd5, 0x68, 0x22, 0x52, 0x39, 0xec, 0x31, 0xe2, 0x10, 0xb7, 0xed, 0xdf,
+	0x6e, 0x52, 0x0f, 0x68, 0x4f, 0x65, 0x26, 0x8a, 0x85, 0x89, 0x74, 0xfc, 0x0b, 0x6d, 0x20, 0x5a,
+	0x33, 0xa1, 0x1d, 0xb0, 0x7d, 0x9d, 0xc7, 0x92, 0xed, 0x38, 0xc4, 0x6d, 0xfa, 0x65, 0x41, 0x1d,
+	0x68, 0x0d, 0x94, 0x90, 0x2a, 0x3d, 0xd5, 0x71, 0xa8, 0x58, 0x13, 0x67, 0xd5, 0x16, 0xe5, 0x00,
+	0x65, 0x39, 0x10, 0xd9, 0x84, 0xd9, 0x0e, 0x71, 0xf7, 0xfc, 0x4a, 0x67, 0xed, 0xf6, 0xf7, 0x13,
+	0x10, 0xd9, 0x45, 0xe4, 0x76, 0x93, 0x7a, 0xf0, 0xa8, 0xa7, 0x92, 0x54, 0x85, 0xc2, 0x28, 0x39,
+	0x32, 0xc2, 0xe4, 0x19, 0xbb, 0xb7, 0x06, 0xbb, 0x0d, 0x46, 0xfc, 0x7f, 0x66, 0x6b, 0xb7, 0xfd,
+	0x44, 0x87, 0x13, 0x76, 0x1f, 0x1f, 0x54, 0x16, 0xb4, 0x0b, 0xcf, 0x4e, 0xb5, 0x11, 0x69, 0xf4,
+	0x49, 0xc9, 0xb7, 0xa6, 0xcc, 0x63, 0x18, 0xaf, 0x83, 0x2b, 0xed, 0x3f, 0x40, 0xfb, 0x1b, 0x19,
+	0x7a, 0x0c, 0x2f, 0x2a, 0xf3, 0x4a, 0x50, 0x55, 0x21, 0x40, 0xa1, 0xed, 0x20, 0x7d, 0x03, 0xfb,
+	0xff, 0xb9, 0x0d, 0xb3, 0x68, 0x61, 0x16, 0x9b, 0x10, 0xfa, 0x0e, 0x9c, 0x4d, 0xd7, 0xa0, 0xcc,
+	0x1e, 0xca, 0x6c, 0xe5, 0x28, 0x85, 0xe6, 0xf9, 0xc7, 0x44, 0xb1, 0xb6, 0x43, 0x5c, 0xdb, 0xc7,
+	0x33, 0x7d, 0x0f, 0x9d, 0x33, 0x91, 0x9a, 0x48, 0x4c, 0xfb, 0x33, 0x15, 0xe6, 0xe5, 0xc6, 0x85,
+	0x66, 0x0f, 0x9d, 0x1d, 0xb7, 0x75, 0xb4, 0x5f, 0xfe, 0x13, 0xbd, 0x3a, 0xc4, 0xaf, 0x5d, 0x3c,
+	0xb8, 0x26, 0xf5, 0x8a, 0x74, 0x00, 0xcf, 0xeb, 0x1d, 0xfe, 0xc9, 0x95, 0x60, 0xae, 0xdb, 0xb0,
+	0x3b, 0x65, 0xd2, 0xb8, 0x63, 0x26, 0x47, 0xd0, 0x39, 0x16, 0x99, 0x39, 0x4b, 0x75, 0xa8, 0xb2,
+	0x4c, 0xc9, 0xf3, 0xd9, 0x30, 0x96, 0x6a, 0x86, 0x9f, 0x81, 0xed, 0xd7, 0xce, 0xba, 0xfd, 0xf9,
+	0x92, 0x5b, 0x8b, 0x25, 0xb7, 0x6e, 0x96, 0x9c, 0x7c, 0x2e, 0x38, 0xf9, 0x5a, 0x70, 0xf2, 0xbd,
+	0xe0, 0x64, 0x5e, 0x70, 0xb2, 0x28, 0x38, 0xb9, 0x2e, 0x38, 0xf9, 0x51, 0x70, 0xeb, 0xa6, 0xe0,
+	0xe4, 0xcb, 0x8a, 0x5b, 0xf3, 0x15, 0xb7, 0x16, 0x2b, 0x6e, 0x7d, 0x68, 0xc9, 0x60, 0xaa, 0xf5,
+	0x65, 0x9e, 0xa8, 0x99, 0x09, 0x76, 0x31, 0xdb, 0xd7, 0x3f, 0x03, 0x00, 0x00, 0xff, 0xff, 0x97,
+	0xca, 0x1a, 0xf0, 0x36, 0x04, 0x00, 0x00,
 }
 
 func (this *MiniblockMetadata) Equal(that interface{}) bool {
@@ -257,13 +327,51 @@ func (this *MiniblockMetadata) Equal(that interface{}) bool {
 	if this.Type != that1.Type {
 		return false
 	}
+	if len(this.PartialExecutionInfo) != len(that1.PartialExecutionInfo) {
+		return false
+	}
+	for i := range this.PartialExecutionInfo {
+		if !this.PartialExecutionInfo[i].Equal(that1.PartialExecutionInfo[i]) {
+			return false
+		}
+	}
+	return true
+}
+func (this *PartialExecutionInfo) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*PartialExecutionInfo)
+	if !ok {
+		that2, ok := that.(PartialExecutionInfo)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.NotarizedAtDestinationMetaNonce != that1.NotarizedAtDestinationMetaNonce {
+		return false
+	}
+	if !bytes.Equal(this.NotarizedAtDestinationInMetaHash, that1.NotarizedAtDestinationInMetaHash) {
+		return false
+	}
+	if this.LastProcessedTxIndex != that1.LastProcessedTxIndex {
+		return false
+	}
 	return true
 }
 func (this *MiniblockMetadata) GoString() string {
 	if this == nil {
 		return "nil"
 	}
-	s := make([]string, 0, 17)
+	s := make([]string, 0, 18)
 	s = append(s, "&dblookupext.MiniblockMetadata{")
 	s = append(s, "SourceShardID: "+fmt.Sprintf("%#v", this.SourceShardID)+",\n")
 	s = append(s, "DestinationShardID: "+fmt.Sprintf("%#v", this.DestinationShardID)+",\n")
@@ -278,6 +386,21 @@ func (this *MiniblockMetadata) GoString() string {
 	s = append(s, "NotarizedAtSourceInMetaHash: "+fmt.Sprintf("%#v", this.NotarizedAtSourceInMetaHash)+",\n")
 	s = append(s, "NotarizedAtDestinationInMetaHash: "+fmt.Sprintf("%#v", this.NotarizedAtDestinationInMetaHash)+",\n")
 	s = append(s, "Type: "+fmt.Sprintf("%#v", this.Type)+",\n")
+	if this.PartialExecutionInfo != nil {
+		s = append(s, "PartialExecutionInfo: "+fmt.Sprintf("%#v", this.PartialExecutionInfo)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *PartialExecutionInfo) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 7)
+	s = append(s, "&dblookupext.PartialExecutionInfo{")
+	s = append(s, "NotarizedAtDestinationMetaNonce: "+fmt.Sprintf("%#v", this.NotarizedAtDestinationMetaNonce)+",\n")
+	s = append(s, "NotarizedAtDestinationInMetaHash: "+fmt.Sprintf("%#v", this.NotarizedAtDestinationInMetaHash)+",\n")
+	s = append(s, "LastProcessedTxIndex: "+fmt.Sprintf("%#v", this.LastProcessedTxIndex)+",\n")
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
@@ -309,6 +432,20 @@ func (m *MiniblockMetadata) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.PartialExecutionInfo) > 0 {
+		for iNdEx := len(m.PartialExecutionInfo) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.PartialExecutionInfo[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintMiniblockMetadata(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x72
+		}
+	}
 	if m.Type != 0 {
 		i = encodeVarintMiniblockMetadata(dAtA, i, uint64(m.Type))
 		i--
@@ -387,6 +524,46 @@ func (m *MiniblockMetadata) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *PartialExecutionInfo) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *PartialExecutionInfo) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *PartialExecutionInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.LastProcessedTxIndex != 0 {
+		i = encodeVarintMiniblockMetadata(dAtA, i, uint64(m.LastProcessedTxIndex))
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.NotarizedAtDestinationInMetaHash) > 0 {
+		i -= len(m.NotarizedAtDestinationInMetaHash)
+		copy(dAtA[i:], m.NotarizedAtDestinationInMetaHash)
+		i = encodeVarintMiniblockMetadata(dAtA, i, uint64(len(m.NotarizedAtDestinationInMetaHash)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.NotarizedAtDestinationMetaNonce != 0 {
+		i = encodeVarintMiniblockMetadata(dAtA, i, uint64(m.NotarizedAtDestinationMetaNonce))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintMiniblockMetadata(dAtA []byte, offset int, v uint64) int {
 	offset -= sovMiniblockMetadata(v)
 	base := offset
@@ -448,6 +625,31 @@ func (m *MiniblockMetadata) Size() (n int) {
 	if m.Type != 0 {
 		n += 1 + sovMiniblockMetadata(uint64(m.Type))
 	}
+	if len(m.PartialExecutionInfo) > 0 {
+		for _, e := range m.PartialExecutionInfo {
+			l = e.Size()
+			n += 1 + l + sovMiniblockMetadata(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *PartialExecutionInfo) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.NotarizedAtDestinationMetaNonce != 0 {
+		n += 1 + sovMiniblockMetadata(uint64(m.NotarizedAtDestinationMetaNonce))
+	}
+	l = len(m.NotarizedAtDestinationInMetaHash)
+	if l > 0 {
+		n += 1 + l + sovMiniblockMetadata(uint64(l))
+	}
+	if m.LastProcessedTxIndex != 0 {
+		n += 1 + sovMiniblockMetadata(uint64(m.LastProcessedTxIndex))
+	}
 	return n
 }
 
@@ -461,6 +663,11 @@ func (this *MiniblockMetadata) String() string {
 	if this == nil {
 		return "nil"
 	}
+	repeatedStringForPartialExecutionInfo := "[]*PartialExecutionInfo{"
+	for _, f := range this.PartialExecutionInfo {
+		repeatedStringForPartialExecutionInfo += strings.Replace(f.String(), "PartialExecutionInfo", "PartialExecutionInfo", 1) + ","
+	}
+	repeatedStringForPartialExecutionInfo += "}"
 	s := strings.Join([]string{`&MiniblockMetadata{`,
 		`SourceShardID:` + fmt.Sprintf("%v", this.SourceShardID) + `,`,
 		`DestinationShardID:` + fmt.Sprintf("%v", this.DestinationShardID) + `,`,
@@ -475,6 +682,19 @@ func (this *MiniblockMetadata) String() string {
 		`NotarizedAtSourceInMetaHash:` + fmt.Sprintf("%v", this.NotarizedAtSourceInMetaHash) + `,`,
 		`NotarizedAtDestinationInMetaHash:` + fmt.Sprintf("%v", this.NotarizedAtDestinationInMetaHash) + `,`,
 		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
+		`PartialExecutionInfo:` + repeatedStringForPartialExecutionInfo + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *PartialExecutionInfo) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&PartialExecutionInfo{`,
+		`NotarizedAtDestinationMetaNonce:` + fmt.Sprintf("%v", this.NotarizedAtDestinationMetaNonce) + `,`,
+		`NotarizedAtDestinationInMetaHash:` + fmt.Sprintf("%v", this.NotarizedAtDestinationInMetaHash) + `,`,
+		`LastProcessedTxIndex:` + fmt.Sprintf("%v", this.LastProcessedTxIndex) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -834,6 +1054,165 @@ func (m *MiniblockMetadata) Unmarshal(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.Type |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 14:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PartialExecutionInfo", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMiniblockMetadata
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMiniblockMetadata
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMiniblockMetadata
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PartialExecutionInfo = append(m.PartialExecutionInfo, &PartialExecutionInfo{})
+			if err := m.PartialExecutionInfo[len(m.PartialExecutionInfo)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMiniblockMetadata(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthMiniblockMetadata
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthMiniblockMetadata
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *PartialExecutionInfo) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMiniblockMetadata
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PartialExecutionInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PartialExecutionInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NotarizedAtDestinationMetaNonce", wireType)
+			}
+			m.NotarizedAtDestinationMetaNonce = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMiniblockMetadata
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.NotarizedAtDestinationMetaNonce |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NotarizedAtDestinationInMetaHash", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMiniblockMetadata
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthMiniblockMetadata
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMiniblockMetadata
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NotarizedAtDestinationInMetaHash = append(m.NotarizedAtDestinationInMetaHash[:0], dAtA[iNdEx:postIndex]...)
+			if m.NotarizedAtDestinationInMetaHash == nil {
+				m.NotarizedAtDestinationInMetaHash = []byte{}
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LastProcessedTxIndex", wireType)
+			}
+			m.LastProcessedTxIndex = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMiniblockMetadata
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.LastProcessedTxIndex |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/dblookupext/miniblockMetadata.proto
+++ b/dblookupext/miniblockMetadata.proto
@@ -22,5 +22,13 @@ message MiniblockMetadata {
     bytes NotarizedAtSourceInMetaHash           = 11;
     bytes NotarizedAtDestinationInMetaHash      = 12;
     int32 Type                                  = 13;
+    repeated PartialExecutionInfo PartialExecutionInfo = 14;
+}
+
+// PartialExecutionInfo is used to store information about partial executed miniblock
+message PartialExecutionInfo {
+    uint64  NotarizedAtDestinationMetaNonce = 1;
+    bytes  NotarizedAtDestinationInMetaHash = 2;
+    int32 LastProcessedTxIndex              = 3;
 }
 

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -585,6 +585,8 @@ func putMiniblockFieldsInTransaction(tx *transaction.ApiTransactionResult, minib
 	tx.NotarizedAtDestinationInMetaNonce = miniblockMetadata.NotarizedAtDestinationInMetaNonce
 	tx.NotarizedAtDestinationInMetaHash = hex.EncodeToString(miniblockMetadata.NotarizedAtDestinationInMetaHash)
 
+	// get miniblock from storage to set Notarized in Meta Nonce and Hash
+
 	return tx
 }
 

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -604,18 +604,7 @@ func (atp *apiTransactionProcessor) setNotarizationAtDestinationFields(tx *trans
 		return nil
 	}
 
-	miniBlocksStorer, err := atp.storageService.GetStorer(dataRetriever.MiniBlockUnit)
-	if err != nil {
-		return err
-	}
-
-	miniblockBytes, err := miniBlocksStorer.GetFromEpoch(miniblockMetadata.MiniblockHash, miniblockMetadata.Epoch)
-	if err != nil {
-		return err
-	}
-
-	miniblock := &block.MiniBlock{}
-	err = atp.marshalizer.Unmarshal(miniblock, miniblockBytes)
+	miniblock, err := atp.getMiniblock(miniblockMetadata.MiniblockHash, miniblockMetadata.Epoch)
 	if err != nil {
 		return err
 	}
@@ -638,6 +627,26 @@ func (atp *apiTransactionProcessor) setNotarizationAtDestinationFields(tx *trans
 	}
 
 	return nil
+}
+
+func (atp *apiTransactionProcessor) getMiniblock(hash []byte, epoch uint32) (*block.MiniBlock, error) {
+	miniBlocksStorer, err := atp.storageService.GetStorer(dataRetriever.MiniBlockUnit)
+	if err != nil {
+		return nil, err
+	}
+
+	miniblockBytes, err := miniBlocksStorer.GetFromEpoch(hash, epoch)
+	if err != nil {
+		return nil, err
+	}
+
+	miniblock := &block.MiniBlock{}
+	err = atp.marshalizer.Unmarshal(miniblock, miniblockBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return miniblock, nil
 }
 
 func (atp *apiTransactionProcessor) getTransactionFromStorage(hash []byte) (*transaction.ApiTransactionResult, error) {

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -761,8 +761,9 @@ func TestNode_PutHistoryFieldsInTransaction(t *testing.T) {
 		NotarizedAtDestinationInMetaNonce: 4253,
 		NotarizedAtDestinationInMetaHash:  []byte{12},
 	}
+	n, _, _, _ := createAPITransactionProc(t, 42, true)
 
-	putMiniblockFieldsInTransaction(tx, metadata)
+	n.putMiniblockFieldsInTransaction(tx, metadata)
 
 	require.Equal(t, 42, int(tx.Epoch))
 	require.Equal(t, 4321, int(tx.Round))


### PR DESCRIPTION
## Reasoning behind the pull request
- Fixed the problem related to the wrong hyper block nonce on a transaction that is returned by API
  
## Proposed changes
- Extended the MiniBlockMetadata structure with extra information about the partial execution
- This change was needed because some fields from the transaction structure were populated with wrong values

## Testing procedure
- Check if the endpoint /transaction/:hash return the correct value for fields `notarizedAtDestinationInMetaNonce`, `notarizedAtDestinationInMetaHash`, `hyperblockNonce`, and `hyperblockHash`

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
