### PR TITLE
On Node API, adjust processing type for relayed V3

### DIFF
--- a/integrationTests/chainSimulator/relayedTx/relayedTx_test.go
+++ b/integrationTests/chainSimulator/relayedTx/relayedTx_test.go
@@ -1002,7 +1002,8 @@ func computeTxGasAndFeeBasedOnRefund(
 		gasForFullPrice += extraGasLimitForGuarded
 	}
 
-	if result.ProcessingTypeOnSource == process.RelayedTxV3.String() {
+	isRelayedV3 := len(result.RelayerAddress) > 0
+	if isRelayedV3 {
 		gasForFullPrice += uint64(minGasLimit) // relayer fee
 	}
 	gasForDeductedPrice := initialTx.GetGasLimit() - gasForFullPrice

--- a/integrationTests/chainSimulator/relayedTx/relayedTx_test.go
+++ b/integrationTests/chainSimulator/relayedTx/relayedTx_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/config"
 	testsChainSimulator "github.com/multiversx/mx-chain-go/integrationTests/chainSimulator"
 	"github.com/multiversx/mx-chain-go/integrationTests/vm/wasm"
@@ -1002,8 +1003,7 @@ func computeTxGasAndFeeBasedOnRefund(
 		gasForFullPrice += extraGasLimitForGuarded
 	}
 
-	isRelayedV3 := len(result.RelayerAddress) > 0
-	if isRelayedV3 {
+	if common.IsRelayedTxV3(initialTx) {
 		gasForFullPrice += uint64(minGasLimit) // relayer fee
 	}
 	gasForDeductedPrice := initialTx.GetGasLimit() - gasForFullPrice

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -183,11 +183,7 @@ func (atp *apiTransactionProcessor) PopulateComputedFields(tx *transaction.ApiTr
 }
 
 func (atp *apiTransactionProcessor) populateComputedFieldsProcessingType(tx *transaction.ApiTransactionResult) {
-	typeOnSource, typeOnDestination, isRelayedV3 := atp.txTypeHandler.ComputeTransactionType(tx.Tx)
-	if isRelayedV3 {
-		typeOnSource = process.RelayedTxV3
-		typeOnDestination = process.RelayedTxV3
-	}
+	typeOnSource, typeOnDestination, _ := atp.txTypeHandler.ComputeTransactionType(tx.Tx)
 	tx.ProcessingTypeOnSource = typeOnSource.String()
 	tx.ProcessingTypeOnDestination = typeOnDestination.String()
 }

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -1356,7 +1356,7 @@ func TestApiTransactionProcessor_GetTransactionPopulatesComputedFields(t *testin
 
 	t.Run("IsRefund (true)", func(t *testing.T) {
 		scr := &smartContractResult.SmartContractResult{GasLimit: 0, Data: []byte("@6f6b"), Value: big.NewInt(500)}
-		dataPool.UnsignedTransactions().AddData([]byte{0, 4}, scr, 42, "foo")
+		dataPool.UnsignedTransactions().AddData([]byte{0, 5}, scr, 42, "foo")
 		tx, err := processor.GetTransaction("0005", true)
 
 		require.Nil(t, err)

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -1347,7 +1347,7 @@ func TestApiTransactionProcessor_GetTransactionPopulatesComputedFields(t *testin
 
 	t.Run("IsRefund (false)", func(t *testing.T) {
 		scr := &smartContractResult.SmartContractResult{GasLimit: 0, Data: []byte("@ok"), Value: big.NewInt(0)}
-		dataPool.UnsignedTransactions().AddData([]byte{0, 3}, scr, 42, "foo")
+		dataPool.UnsignedTransactions().AddData([]byte{0, 4}, scr, 42, "foo")
 		tx, err := processor.GetTransaction("0004", true)
 
 		require.Nil(t, err)

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -1332,10 +1332,23 @@ func TestApiTransactionProcessor_GetTransactionPopulatesComputedFields(t *testin
 		require.Equal(t, process.SCDeployment.String(), tx.ProcessingTypeOnDestination)
 	})
 
+	t.Run("ProcessingType (with relayed v3)", func(t *testing.T) {
+		txTypeHandler.ComputeTransactionTypeCalled = func(data.TransactionHandler) (process.TransactionType, process.TransactionType, bool) {
+			return process.MoveBalance, process.SCDeployment, true
+		}
+
+		dataPool.Transactions().AddData([]byte{0, 2}, &transaction.Transaction{Nonce: 7, SndAddr: []byte("alice"), RcvAddr: []byte("bob")}, 42, "1")
+		tx, err := processor.GetTransaction("0003", true)
+
+		require.Nil(t, err)
+		require.Equal(t, process.MoveBalance.String(), tx.ProcessingTypeOnSource)
+		require.Equal(t, process.SCDeployment.String(), tx.ProcessingTypeOnDestination)
+	})
+
 	t.Run("IsRefund (false)", func(t *testing.T) {
 		scr := &smartContractResult.SmartContractResult{GasLimit: 0, Data: []byte("@ok"), Value: big.NewInt(0)}
 		dataPool.UnsignedTransactions().AddData([]byte{0, 3}, scr, 42, "foo")
-		tx, err := processor.GetTransaction("0003", true)
+		tx, err := processor.GetTransaction("0004", true)
 
 		require.Nil(t, err)
 		require.Equal(t, false, tx.IsRefund)
@@ -1344,7 +1357,7 @@ func TestApiTransactionProcessor_GetTransactionPopulatesComputedFields(t *testin
 	t.Run("IsRefund (true)", func(t *testing.T) {
 		scr := &smartContractResult.SmartContractResult{GasLimit: 0, Data: []byte("@6f6b"), Value: big.NewInt(500)}
 		dataPool.UnsignedTransactions().AddData([]byte{0, 4}, scr, 42, "foo")
-		tx, err := processor.GetTransaction("0004", true)
+		tx, err := processor.GetTransaction("0005", true)
 
 		require.Nil(t, err)
 		require.Equal(t, true, tx.IsRefund)

--- a/node/external/transactionAPI/apiTransactionProcessor_test.go
+++ b/node/external/transactionAPI/apiTransactionProcessor_test.go
@@ -1337,7 +1337,7 @@ func TestApiTransactionProcessor_GetTransactionPopulatesComputedFields(t *testin
 			return process.MoveBalance, process.SCDeployment, true
 		}
 
-		dataPool.Transactions().AddData([]byte{0, 2}, &transaction.Transaction{Nonce: 7, SndAddr: []byte("alice"), RcvAddr: []byte("bob")}, 42, "1")
+		dataPool.Transactions().AddData([]byte{0, 3}, &transaction.Transaction{Nonce: 7, SndAddr: []byte("alice"), RcvAddr: []byte("bob")}, 42, "1")
 		tx, err := processor.GetTransaction("0003", true)
 
 		require.Nil(t, err)

--- a/process/constants.go
+++ b/process/constants.go
@@ -37,8 +37,6 @@ const (
 	RelayedTx
 	// RelayedTxV2 defines the ID of a slim relayed transaction version
 	RelayedTxV2
-	// RelayedTxV3 defines the ID of a relayed transaction v3
-	RelayedTxV3
 	// RewardTx defines ID of a reward transaction
 	RewardTx
 	// InvalidTransaction defines unknown transaction type
@@ -59,8 +57,6 @@ func (transactionType TransactionType) String() string {
 		return "RelayedTx"
 	case RelayedTxV2:
 		return "RelayedTxV2"
-	case RelayedTxV3:
-		return "RelayedTxV3"
 	case RewardTx:
 		return "RewardTx"
 	case InvalidTransaction:


### PR DESCRIPTION
## Reasoning behind the pull request
- Some Node API clients are interested into a precise value of `tx.ProcessingTypeOnSource` and `tx.ProcessingTypeOnDestination` (in the context of GET transaction).
  
## Proposed changes
- Do not override the aforementioned fields when the transaction is relayed V3.

## Testing procedure
- Standard testing.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
