### PR TITLE
fix relayed v3 with relayer one of the participants leading to free txs

### DIFF
--- a/process/smartContract/processorV2/processV2.go
+++ b/process/smartContract/processorV2/processV2.go
@@ -1973,7 +1973,7 @@ func (sc *scProcessor) getFeePayer(tx data.TransactionHandler, acntSnd state.Use
 		return acntSnd, nil
 	}
 
-	relayerIsSender := bytes.Compare(relayedTx.GetRelayerAddr(), tx.GetSndAddr()) == 0
+	relayerIsSender := bytes.Equal(relayedTx.GetRelayerAddr(), tx.GetSndAddr())
 	if relayerIsSender {
 		return acntSnd, nil // do not load the same account twice
 	}

--- a/process/transaction/baseProcess.go
+++ b/process/transaction/baseProcess.go
@@ -248,7 +248,7 @@ func (txProc *baseTxProcessor) getFeePayer(
 
 	relayerIsSender := bytes.Compare(tx.RelayerAddr, tx.SndAddr) == 0
 	if relayerIsSender {
-		return destinationAccount, true, nil // do not load the same account twice
+		return senderAccount, true, nil // do not load the same account twice
 	}
 
 	relayerIsDestination := bytes.Compare(tx.RelayerAddr, tx.RcvAddr) == 0

--- a/process/transaction/baseProcess.go
+++ b/process/transaction/baseProcess.go
@@ -246,12 +246,12 @@ func (txProc *baseTxProcessor) getFeePayer(
 		return senderAccount, false, nil
 	}
 
-	relayerIsSender := bytes.Compare(tx.RelayerAddr, tx.SndAddr) == 0
+	relayerIsSender := bytes.Equal(tx.RelayerAddr, tx.SndAddr)
 	if relayerIsSender {
 		return senderAccount, true, nil // do not load the same account twice
 	}
 
-	relayerIsDestination := bytes.Compare(tx.RelayerAddr, tx.RcvAddr) == 0
+	relayerIsDestination := bytes.Equal(tx.RelayerAddr, tx.RcvAddr)
 	if relayerIsDestination {
 		return destinationAccount, true, nil // do not load the same account twice
 	}

--- a/process/transaction/baseProcess.go
+++ b/process/transaction/baseProcess.go
@@ -239,10 +239,21 @@ func (txProc *baseTxProcessor) checkUserTxOfRelayedV3Values(
 
 func (txProc *baseTxProcessor) getFeePayer(
 	tx *transaction.Transaction,
-	acntSnd state.UserAccountHandler,
+	senderAccount state.UserAccountHandler,
+	destinationAccount state.UserAccountHandler,
 ) (state.UserAccountHandler, bool, error) {
 	if !common.IsRelayedTxV3(tx) {
-		return acntSnd, false, nil
+		return senderAccount, false, nil
+	}
+
+	relayerIsSender := bytes.Compare(tx.RelayerAddr, tx.SndAddr) == 0
+	if relayerIsSender {
+		return destinationAccount, true, nil // do not load the same account twice
+	}
+
+	relayerIsDestination := bytes.Compare(tx.RelayerAddr, tx.RcvAddr) == 0
+	if relayerIsDestination {
+		return destinationAccount, true, nil // do not load the same account twice
 	}
 
 	acntRelayer, err := txProc.getAccountFromAddress(tx.RelayerAddr)

--- a/process/transaction/shardProcess.go
+++ b/process/transaction/shardProcess.go
@@ -200,14 +200,14 @@ func (txProc *txProcessor) ProcessTransaction(tx *transaction.Transaction) (vmco
 	err = txProc.checkTxValues(tx, acntSnd, acntDst, false)
 	if err != nil {
 		if errors.Is(err, process.ErrInsufficientFunds) {
-			receiptErr := txProc.executingFailedTransaction(tx, acntSnd, err)
+			receiptErr := txProc.executingFailedTransaction(tx, acntSnd, acntDst, err)
 			if receiptErr != nil {
 				return 0, receiptErr
 			}
 		}
 
 		if errors.Is(err, process.ErrUserNameDoesNotMatch) && txProc.enableEpochsHandler.IsFlagEnabled(common.RelayedTransactionsFlag) {
-			receiptErr := txProc.executingFailedTransaction(tx, acntSnd, err)
+			receiptErr := txProc.executingFailedTransaction(tx, acntSnd, acntDst, err)
 			if receiptErr != nil {
 				return vmcommon.UserError, receiptErr
 			}
@@ -249,7 +249,7 @@ func (txProc *txProcessor) ProcessTransaction(tx *transaction.Transaction) (vmco
 		return txProc.processRelayedTxV2(tx, acntSnd, acntDst)
 	}
 
-	return vmcommon.UserError, txProc.executingFailedTransaction(tx, acntSnd, process.ErrWrongTransaction)
+	return vmcommon.UserError, txProc.executingFailedTransaction(tx, acntSnd, acntDst, process.ErrWrongTransaction)
 }
 
 func (txProc *txProcessor) executeAfterFailedMoveBalanceTransaction(
@@ -296,13 +296,14 @@ func (txProc *txProcessor) executeAfterFailedMoveBalanceTransaction(
 func (txProc *txProcessor) executingFailedTransaction(
 	tx *transaction.Transaction,
 	acntSnd state.UserAccountHandler,
+	acntDst state.UserAccountHandler,
 	txError error,
 ) error {
 	if check.IfNil(acntSnd) {
 		return nil
 	}
 
-	feePayer, isRelayedV3, err := txProc.getFeePayer(tx, acntSnd)
+	feePayer, isRelayedV3, err := txProc.getFeePayer(tx, acntSnd, acntDst)
 	if err != nil {
 		return err
 	}
@@ -486,7 +487,7 @@ func (txProc *txProcessor) processMoveBalance(
 	isUserTxOfRelayed bool,
 ) error {
 
-	feePayer, _, err := txProc.getFeePayer(tx, acntSrc)
+	feePayer, _, err := txProc.getFeePayer(tx, acntSrc, acntDst)
 	if err != nil {
 		return nil
 	}
@@ -735,18 +736,18 @@ func (txProc *txProcessor) processRelayedTxV2(
 	relayerAcnt, acntDst state.UserAccountHandler,
 ) (vmcommon.ReturnCode, error) {
 	if !txProc.enableEpochsHandler.IsFlagEnabled(common.RelayedTransactionsV2Flag) {
-		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, process.ErrRelayedTxV2Disabled)
+		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, acntDst, process.ErrRelayedTxV2Disabled)
 	}
 	if tx.GetValue().Cmp(big.NewInt(0)) != 0 {
-		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, process.ErrRelayedTxV2ZeroVal)
+		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, acntDst, process.ErrRelayedTxV2ZeroVal)
 	}
 
 	_, args, err := txProc.argsParser.ParseCallData(string(tx.GetData()))
 	if err != nil {
-		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, err)
+		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, acntDst, err)
 	}
 	if len(args) != 4 {
-		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, process.ErrInvalidArguments)
+		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, acntDst, process.ErrInvalidArguments)
 	}
 
 	userTx := makeUserTxFromRelayedTxV2Args(args)
@@ -767,31 +768,31 @@ func (txProc *txProcessor) processRelayedTx(
 		return 0, err
 	}
 	if len(args) != 1 {
-		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, process.ErrInvalidArguments)
+		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, acntDst, process.ErrInvalidArguments)
 	}
 	if !txProc.enableEpochsHandler.IsFlagEnabled(common.RelayedTransactionsFlag) {
-		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, process.ErrRelayedTxDisabled)
+		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, acntDst, process.ErrRelayedTxDisabled)
 	}
 
 	userTx := &transaction.Transaction{}
 	err = txProc.signMarshalizer.Unmarshal(userTx, args[0])
 	if err != nil {
-		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, err)
+		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, acntDst, err)
 	}
 	if !bytes.Equal(userTx.SndAddr, tx.RcvAddr) {
-		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, process.ErrRelayedTxBeneficiaryDoesNotMatchReceiver)
+		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, acntDst, process.ErrRelayedTxBeneficiaryDoesNotMatchReceiver)
 	}
 
 	if userTx.Value.Cmp(tx.Value) < 0 {
-		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, process.ErrRelayedTxValueHigherThenUserTxValue)
+		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, acntDst, process.ErrRelayedTxValueHigherThenUserTxValue)
 	}
 	if userTx.GasPrice != tx.GasPrice {
-		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, process.ErrRelayedGasPriceMissmatch)
+		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, acntDst, process.ErrRelayedGasPriceMissmatch)
 	}
 
 	remainingGasLimit := tx.GasLimit - txProc.economicsFee.ComputeGasLimit(tx)
 	if userTx.GasLimit != remainingGasLimit {
-		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, process.ErrRelayedTxGasLimitMissmatch)
+		return vmcommon.UserError, txProc.executingFailedTransaction(tx, relayerAcnt, acntDst, process.ErrRelayedTxGasLimitMissmatch)
 	}
 
 	return txProc.finishExecutionOfRelayedTx(relayerAcnt, acntDst, tx, userTx)


### PR DESCRIPTION
## Reasoning behind the pull request
- txs v3 relayed by one of the parties do not consume the fee 
  
## Proposed changes
- fixed this edge case by only loading the account once if the relayer is one of the participants

## Testing procedure
- with feat branch + scenario

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
