### PR TITLE
fixed the computed fee for outport for relayed v3

### DIFF
--- a/node/external/transactionAPI/gasUsedAndFeeProcessor.go
+++ b/node/external/transactionAPI/gasUsedAndFeeProcessor.go
@@ -58,9 +58,7 @@ func (gfp *gasUsedAndFeeProcessor) computeAndAttachGasUsedAndFee(tx *transaction
 		tx.GasUsed = big.NewInt(0).Div(initialTotalFee, big.NewInt(0).SetUint64(tx.GasPrice)).Uint64()
 	}
 
-	hasValidRelayer := len(tx.RelayerAddress) == len(tx.Sender) && len(tx.RelayerAddress) > 0
-	hasValidRelayerSignature := len(tx.RelayerSignature) == len(tx.Signature) && len(tx.RelayerSignature) > 0
-	isRelayedV3 := hasValidRelayer && hasValidRelayerSignature
+	isRelayedV3 := common.IsValidRelayedTxV3(tx.Tx)
 	hasRefundForSender := false
 	for _, scr := range tx.SmartContractResults {
 		if !scr.IsRefund {
@@ -86,9 +84,7 @@ func (gfp *gasUsedAndFeeProcessor) getFeeOfRelayedV1V2(tx *transaction.ApiTransa
 		return nil, nil, false
 	}
 
-	hasValidRelayer := len(tx.RelayerAddress) == len(tx.Sender) && len(tx.RelayerAddress) > 0
-	hasValidRelayerSignature := len(tx.RelayerSignature) == len(tx.Signature) && len(tx.RelayerSignature) > 0
-	isRelayedV3 := hasValidRelayer && hasValidRelayerSignature
+	isRelayedV3 := common.IsValidRelayedTxV3(tx.Tx)
 	if isRelayedV3 {
 		return nil, nil, false
 	}

--- a/outport/process/transactionsfee/transactionChecker.go
+++ b/outport/process/transactionsfee/transactionChecker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
+	"github.com/multiversx/mx-chain-go/common"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
@@ -47,11 +48,25 @@ func isSCRForSenderWithRefund(scr *smartContractResult.SmartContractResult, txHa
 }
 
 func isRefundForRelayed(dbScResult *smartContractResult.SmartContractResult, tx data.TransactionHandler) bool {
+	isRelayedV3 := common.IsRelayedTxV3(tx)
 	isForRelayed := string(dbScResult.ReturnMessage) == core.GasRefundForRelayerMessage
 	isForSender := bytes.Equal(dbScResult.RcvAddr, tx.GetSndAddr())
+	isForRelayerV3 := isForRelayerOfV3(dbScResult, tx)
 	differentHash := !bytes.Equal(dbScResult.OriginalTxHash, dbScResult.PrevTxHash)
 
-	return isForRelayed && isForSender && differentHash
+	isRefundForRelayedV1V2 := isForRelayed && isForSender && differentHash && !isRelayedV3
+	isRefundForRelayedV3 := isForRelayed && isForRelayerV3 && isRelayedV3
+
+	return isRefundForRelayedV1V2 || isRefundForRelayedV3
+}
+
+func isForRelayerOfV3(scr *smartContractResult.SmartContractResult, tx data.TransactionHandler) bool {
+	relayedTx, isRelayedV3 := tx.(data.RelayedTransactionHandler)
+	if !isRelayedV3 {
+		return false
+	}
+
+	return bytes.Equal(relayedTx.GetRelayerAddr(), scr.RcvAddr)
 }
 
 func isDataOk(data []byte) bool {

--- a/outport/process/transactionsfee/transactionsFeeProcessor_test.go
+++ b/outport/process/transactionsfee/transactionsFeeProcessor_test.go
@@ -10,10 +10,13 @@ import (
 	outportcore "github.com/multiversx/mx-chain-core-go/data/outport"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/outport/mock"
 	"github.com/multiversx/mx-chain-go/process"
+	"github.com/multiversx/mx-chain-go/process/economics"
 	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
+	"github.com/multiversx/mx-chain-go/testscommon/epochNotifier"
 	"github.com/multiversx/mx-chain-go/testscommon/genericMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
 	logger "github.com/multiversx/mx-chain-logger-go"
@@ -21,6 +24,18 @@ import (
 )
 
 var pubKeyConverter, _ = pubkeyConverter.NewBech32PubkeyConverter(32, "erd")
+
+func createEconomicsData(enableEpochsHandler common.EnableEpochsHandler) process.EconomicsDataHandler {
+	economicsConfig := testscommon.GetEconomicsConfig()
+	economicsData, _ := economics.NewEconomicsData(economics.ArgsNewEconomicsData{
+		Economics:           &economicsConfig,
+		EnableEpochsHandler: enableEpochsHandler,
+		TxVersionChecker:    &testscommon.TxVersionCheckerStub{},
+		EpochNotifier:       &epochNotifier.EpochNotifierStub{},
+	})
+
+	return economicsData
+}
 
 func prepareMockArg() ArgTransactionsFeeProcessor {
 	return ArgTransactionsFeeProcessor{
@@ -596,4 +611,66 @@ func TestMoveBalanceWithSignalError(t *testing.T) {
 	err = txsFeeProc.PutFeeAndGasUsed(pool, 0)
 	require.Nil(t, err)
 	require.Equal(t, uint64(225_500), initialTx.GetFeeInfo().GetGasUsed())
+}
+
+func TestPutFeeAndGasUsedRelayedTxV3(t *testing.T) {
+	t.Parallel()
+
+	txHash := []byte("relayedTxV3")
+	scrWithRefund := []byte("scrWithRefund")
+	refundValueBig, _ := big.NewInt(0).SetString("37105580000000", 10)
+	initialTx := &outportcore.TxInfo{
+		Transaction: &transaction.Transaction{
+			Nonce:       9,
+			SndAddr:     []byte("erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"),
+			RcvAddr:     []byte("erd1qqqqqqqqqqqqqpgq2nfn5uxjjkjlrzad3jrak8p3p30v79pseddsm73zpw"),
+			RelayerAddr: []byte("erd1at9keal0jfhamc67ulq4csmchh33eek87yf5hhzcvlw8e5qlx8zq5hjwjl"),
+			GasLimit:    5000000,
+			GasPrice:    1000000000,
+			Data:        []byte("add@01"),
+			Value:       big.NewInt(0),
+		},
+		FeeInfo: &outportcore.FeeInfo{Fee: big.NewInt(0)},
+	}
+
+	pool := &outportcore.TransactionPool{
+		Transactions: map[string]*outportcore.TxInfo{
+			hex.EncodeToString(txHash): initialTx,
+		},
+		SmartContractResults: map[string]*outportcore.SCRInfo{
+			hex.EncodeToString(scrWithRefund): {
+				SmartContractResult: &smartContractResult.SmartContractResult{
+					Nonce:          10,
+					GasPrice:       1000000000,
+					GasLimit:       0,
+					Value:          refundValueBig,
+					SndAddr:        []byte("erd1qqqqqqqqqqqqqpgq2nfn5uxjjkjlrzad3jrak8p3p30v79pseddsm73zpw"),
+					RcvAddr:        []byte("erd1at9keal0jfhamc67ulq4csmchh33eek87yf5hhzcvlw8e5qlx8zq5hjwjl"),
+					Data:           []byte(""),
+					PrevTxHash:     txHash,
+					OriginalTxHash: txHash,
+					ReturnMessage:  []byte("gas refund for relayer"),
+				},
+				FeeInfo: &outportcore.FeeInfo{
+					Fee: big.NewInt(0),
+				},
+			},
+		},
+	}
+
+	arg := prepareMockArg()
+	arg.TxFeeCalculator = createEconomicsData(&enableEpochsHandlerMock.EnableEpochsHandlerStub{
+		IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+			return true
+		},
+	})
+	txsFeeProc, err := NewTransactionsFeeProcessor(arg)
+	require.NotNil(t, txsFeeProc)
+	require.Nil(t, err)
+
+	err = txsFeeProc.PutFeeAndGasUsed(pool, 0)
+	require.Nil(t, err)
+	require.Equal(t, big.NewInt(120804420000000), initialTx.GetFeeInfo().GetFee())
+	require.Equal(t, uint64(1289442), initialTx.GetFeeInfo().GetGasUsed())
+	require.Equal(t, "157910000000000", initialTx.GetFeeInfo().GetInitialPaidFee().String())
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- the fee fomr indexer was not the correct one
  
## Proposed changes
- outport fee handling needs special treatment for relayed v3, similar as for transaction api of the node

## Testing procedure
- with feat branch, comparison between gateway and explorer/api results

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
