### PR TITLE
count all refunds if more than one scr exists

### DIFF
--- a/node/external/transactionAPI/gasUsedAndFeeProcessor.go
+++ b/node/external/transactionAPI/gasUsedAndFeeProcessor.go
@@ -60,6 +60,7 @@ func (gfp *gasUsedAndFeeProcessor) computeAndAttachGasUsedAndFee(tx *transaction
 
 	isRelayedV3 := common.IsValidRelayedTxV3(tx.Tx)
 	hasRefundForSender := false
+	totalRefunds := big.NewInt(0)
 	for _, scr := range tx.SmartContractResults {
 		if !scr.IsRefund {
 			continue
@@ -71,9 +72,12 @@ func (gfp *gasUsedAndFeeProcessor) computeAndAttachGasUsedAndFee(tx *transaction
 			continue
 		}
 
-		gfp.setGasUsedAndFeeBaseOnRefundValue(tx, userTx, scr.Value)
 		hasRefundForSender = true
-		break
+		totalRefunds.Add(totalRefunds, scr.Value)
+	}
+
+	if totalRefunds.Cmp(big.NewInt(0)) > 0 {
+		gfp.setGasUsedAndFeeBaseOnRefundValue(tx, userTx, totalRefunds)
 	}
 
 	gfp.prepareTxWithResultsBasedOnLogs(tx, userTx, hasRefundForSender)

--- a/node/external/transactionAPI/testData/relayedV3WithMultipleRefunds.json
+++ b/node/external/transactionAPI/testData/relayedV3WithMultipleRefunds.json
@@ -1,0 +1,159 @@
+{
+  "type": "normal",
+  "processingTypeOnSource": "SCInvoking",
+  "processingTypeOnDestination": "SCInvoking",
+  "value": "0",
+  "receiver": "erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3",
+  "sender": "erd1at9keal0jfhamc67ulq4csmchh33eek87yf5hhzcvlw8e5qlx8zq5hjwjl",
+  "gasPrice": 1000000000,
+  "gasLimit": 15000000,
+  "gasUsed": 14536537,
+  "data": "Zm9yd2FyZEAwMUAwMDAwMDAwMDAwMDAwMDAwMDUwMGMxMzVlMjc2NmM3MDcyMTA2ZjIzYjAzNWIzODUxZDYzZDdmNjIxYzY5NmRhQDAwQDYxNjQ2NDQwMzAzMUAwMDdmZmZmZg==",
+  "signature": "645d88221a50bbf5173a9a46a70308f0c272d9b4701fe935ae2565147a32b484c4ea695bcaa102a299877f7e7699bb7990c491a601ae636851f5485dd59fe10b",
+  "smartContractResults": [
+    {
+      "hash": "16b05474872d51840ca9270d8790fc65d50f5d076bb491388344f5095f6f0df0",
+      "nonce": 24,
+      "value": 4634630000000,
+      "receiver": "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
+      "sender": "erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3",
+      "prevTxHash": "8fe5133b33d315392006d11dbeb2ea9c0d5f1eb0856aaf3044e9f55118656843",
+      "originalTxHash": "8fe5133b33d315392006d11dbeb2ea9c0d5f1eb0856aaf3044e9f55118656843",
+      "gasLimit": 0,
+      "gasPrice": 1000000000,
+      "callType": 0,
+      "returnMessage": "gas refund for relayer",
+      "originalSender": "erd1at9keal0jfhamc67ulq4csmchh33eek87yf5hhzcvlw8e5qlx8zq5hjwjl",
+      "logs": {
+        "address": "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
+        "events": [
+          {
+            "address": "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
+            "identifier": "completedTxEvent",
+            "topics": [
+              "j+UTOzPTFTkgBtEdvrLqnA1fHrCFaq8wROn1URhlaEM="
+            ],
+            "data": null,
+            "additionalData": null
+          }
+        ]
+      },
+      "operation": "transfer",
+      "isRefund": true
+    },
+    {
+      "hash": "9090261203cf20e3b51e4c921ce27fa595fcca3f37c83543c7a4a57733139f4d",
+      "nonce": 1,
+      "value": 103160900000000,
+      "receiver": "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
+      "sender": "erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3",
+      "prevTxHash": "a74d26756c58c522637b3c73b299828901533c93d5ccd75d6ec6a3410755d3e4",
+      "originalTxHash": "8fe5133b33d315392006d11dbeb2ea9c0d5f1eb0856aaf3044e9f55118656843",
+      "gasLimit": 0,
+      "gasPrice": 1000000000,
+      "callType": 0,
+      "returnMessage": "gas refund for relayer",
+      "originalSender": "erd1at9keal0jfhamc67ulq4csmchh33eek87yf5hhzcvlw8e5qlx8zq5hjwjl",
+      "logs": {
+        "address": "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
+        "events": [
+          {
+            "address": "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
+            "identifier": "completedTxEvent",
+            "topics": [
+              "p00mdWxYxSJjezxzspmCiQFTPJPVzNddbsajQQdV0+Q="
+            ],
+            "data": null,
+            "additionalData": null
+          }
+        ]
+      },
+      "operation": "transfer",
+      "isRefund": true
+    },
+    {
+      "hash": "5fb1c0d5d04b80331839de417523dff45a1be9489d4d84f9c5535314e0542525",
+      "nonce": 0,
+      "value": 0,
+      "receiver": "erd1qqqqqqqqqqqqqpgqcy67yanvwpepqmerkq6m8pgav0tlvgwxjmdq4hukxw",
+      "sender": "erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3",
+      "relayerAddress": "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
+      "relayedValue": 0,
+      "data": "add@01@21fdaf01f965469c1bebf13c3c49a18f0dde9d8e380cec78cea065246fabb2d9@8fe5133b33d315392006d11dbeb2ea9c0d5f1eb0856aaf3044e9f55118656843@4185d4",
+      "prevTxHash": "8fe5133b33d315392006d11dbeb2ea9c0d5f1eb0856aaf3044e9f55118656843",
+      "originalTxHash": "8fe5133b33d315392006d11dbeb2ea9c0d5f1eb0856aaf3044e9f55118656843",
+      "gasLimit": 12682707,
+      "gasPrice": 1000000000,
+      "callType": 1,
+      "originalSender": "erd1at9keal0jfhamc67ulq4csmchh33eek87yf5hhzcvlw8e5qlx8zq5hjwjl",
+      "operation": "transfer",
+      "function": "add"
+    },
+    {
+      "hash": "a74d26756c58c522637b3c73b299828901533c93d5ccd75d6ec6a3410755d3e4",
+      "nonce": 0,
+      "value": 0,
+      "receiver": "erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3",
+      "sender": "erd1qqqqqqqqqqqqqpgqcy67yanvwpepqmerkq6m8pgav0tlvgwxjmdq4hukxw",
+      "relayerAddress": "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
+      "relayedValue": 0,
+      "data": "@00@95a836710c0857f995e670bf3aa944263473534c8c5f4b7959c938045f62023b@21fdaf01f965469c1bebf13c3c49a18f0dde9d8e380cec78cea065246fabb2d9@8fe5133b33d315392006d11dbeb2ea9c0d5f1eb0856aaf3044e9f55118656843@00",
+      "prevTxHash": "5fb1c0d5d04b80331839de417523dff45a1be9489d4d84f9c5535314e0542525",
+      "originalTxHash": "8fe5133b33d315392006d11dbeb2ea9c0d5f1eb0856aaf3044e9f55118656843",
+      "gasLimit": 11512215,
+      "gasPrice": 1000000000,
+      "callType": 2,
+      "originalSender": "erd1at9keal0jfhamc67ulq4csmchh33eek87yf5hhzcvlw8e5qlx8zq5hjwjl",
+      "logs": {
+        "address": "erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3",
+        "events": [
+          {
+            "address": "erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3",
+            "identifier": "writeLog",
+            "topics": [
+              "AAAAAAAAAAAFAO2OJalO+oN6rg5ZMRLPuwG0SHVQaeE="
+            ],
+            "data": "QDZmNmJAMDBjYTc3YmFjNEAwNjBjY2U1NQ==",
+            "additionalData": [
+              "QDZmNmJAMDBjYTc3YmFjNEAwNjBjY2U1NQ=="
+            ]
+          }
+        ]
+      },
+      "operation": "transfer"
+    }
+  ],
+  "logs": {
+    "address": "erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3",
+    "events": [
+      {
+        "address": "erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3",
+        "identifier": "transferValueOnly",
+        "topics": [
+          "",
+          "AAAAAAAAAAAFAME14nZscHIQbyOwNbOFHWPX9iHGlto="
+        ],
+        "data": "QXN5bmNDYWxs",
+        "additionalData": [
+          "QXN5bmNDYWxs",
+          "YWRk",
+          "AQ=="
+        ]
+      },
+      {
+        "address": "erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3",
+        "identifier": "writeLog",
+        "topics": [
+          "6sts9++Sb93jXufBXEN4veMc5sfxE0vcWGfcfNAfMcQ="
+        ],
+        "data": "QDZmNmI=",
+        "additionalData": [
+          "QDZmNmI="
+        ]
+      }
+    ]
+  },
+  "isRelayed": true,
+  "relayerAddress": "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
+  "relayerSignature": "dfb60f7d13c024335ec9586b7af579ed47da002a23313272069711bceebddc2d9216b7cc1395c37a1c328288fcc774d5cbeb610db2900f76647307d35a593e08"
+}


### PR DESCRIPTION
## Reasoning behind the pull request
- if more than one refund scrs are generated for a tx, only one is considered while computing the fee field on node api
  
## Proposed changes
- take into account all refund scrs for node api

## Testing procedure
- with feat branch, send a tx that generate multiple refunds 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
