### PR TITLE
remove unnecessary trie node encode operations and remove unused code

### DIFF
--- a/trie/interface.go
+++ b/trie/interface.go
@@ -26,9 +26,7 @@ type baseTrieNode interface {
 type node interface {
 	baseTrieNode
 	setHash(goRoutinesManager common.TrieGoroutinesManager)
-	getCollapsed() (node, error) // a collapsed node is a node that instead of the children holds the children hashes
 	getEncodedNode() ([]byte, error)
-	hashNode() ([]byte, error)
 	tryGet(key []byte, depth uint32, db common.TrieStorageInteractor) ([]byte, uint32, error)
 	getNext(key []byte, db common.TrieStorageInteractor) (node, []byte, error)
 	insert(newData []core.TrieData, goRoutinesManager common.TrieGoroutinesManager, modifiedHashes common.AtomicBytesSlice, db common.TrieStorageInteractor) node
@@ -46,10 +44,10 @@ type node interface {
 	collectLeavesForMigration(migrationArgs vmcommon.ArgsMigrateDataTrieLeaves, db common.TrieStorageInteractor, keyBuilder common.KeyBuilder) (bool, error)
 
 	commitDirty(level byte, maxTrieLevelInMemory uint, goRoutinesManager common.TrieGoroutinesManager, hashesCollector common.TrieHashesCollector, originDb common.TrieStorageInteractor, targetDb common.BaseStorer)
-	commitSnapshot(originDb common.TrieStorageInteractor, leavesChan chan core.KeyValueHolder, missingNodesChan chan []byte, ctx context.Context, stats common.TrieStatisticsHandler, idleProvider IdleNodeProvider, depthLevel int) error
+	commitSnapshot(originDb common.TrieStorageInteractor, leavesChan chan core.KeyValueHolder, missingNodesChan chan []byte, ctx context.Context, stats common.TrieStatisticsHandler, idleProvider IdleNodeProvider, nodeBytes []byte, depthLevel int) error
 
 	sizeInBytes() int
-	collectStats(handler common.TrieStatisticsHandler, depthLevel int, db common.TrieStorageInteractor) error
+	collectStats(handler common.TrieStatisticsHandler, depthLevel int, nodeSize uint64, db common.TrieStorageInteractor) error
 
 	IsInterfaceNil() bool
 }
@@ -59,7 +57,7 @@ type dbWithGetFromEpoch interface {
 }
 
 type snapshotNode interface {
-	commitSnapshot(originDb common.TrieStorageInteractor, leavesChan chan core.KeyValueHolder, missingNodesChan chan []byte, ctx context.Context, stats common.TrieStatisticsHandler, idleProvider IdleNodeProvider, depthLevel int) error
+	commitSnapshot(originDb common.TrieStorageInteractor, leavesChan chan core.KeyValueHolder, missingNodesChan chan []byte, ctx context.Context, stats common.TrieStatisticsHandler, idleProvider IdleNodeProvider, nodeBytes []byte, depthLevel int) error
 }
 
 // RequestHandler defines the methods through which request to data can be made

--- a/trie/leafNode_test.go
+++ b/trie/leafNode_test.go
@@ -62,16 +62,6 @@ func TestLeafNode_isDirty(t *testing.T) {
 	assert.Equal(t, false, ln.isDirty())
 }
 
-func TestLeafNode_getCollapsed(t *testing.T) {
-	t.Parallel()
-
-	ln := getLn(getTestMarshalizerAndHasher())
-
-	collapsed, err := ln.getCollapsed()
-	assert.Nil(t, err)
-	assert.Equal(t, ln, collapsed)
-}
-
 func TestLeafNode_setHash(t *testing.T) {
 	t.Parallel()
 
@@ -92,37 +82,6 @@ func TestLeafNode_setGivenHash(t *testing.T) {
 
 	ln.setGivenHash(expectedHash)
 	assert.Equal(t, expectedHash, ln.hash)
-}
-
-func TestLeafNode_hashNode(t *testing.T) {
-	t.Parallel()
-
-	ln := getLn(getTestMarshalizerAndHasher())
-	expectedHash, _ := encodeNodeAndGetHash(ln)
-
-	hash, err := ln.hashNode()
-	assert.Nil(t, err)
-	assert.Equal(t, expectedHash, hash)
-}
-
-func TestLeafNode_hashNodeEmptyNode(t *testing.T) {
-	t.Parallel()
-
-	ln := &leafNode{}
-
-	hash, err := ln.hashNode()
-	assert.True(t, errors.Is(err, ErrEmptyLeafNode))
-	assert.Nil(t, hash)
-}
-
-func TestLeafNode_hashNodeNilNode(t *testing.T) {
-	t.Parallel()
-
-	var ln *leafNode
-
-	hash, err := ln.hashNode()
-	assert.True(t, errors.Is(err, ErrNilLeafNode))
-	assert.Nil(t, hash)
 }
 
 func TestLeafNode_commit(t *testing.T) {
@@ -222,18 +181,6 @@ func TestLeafNode_getNextWrongKey(t *testing.T) {
 	assert.Nil(t, n)
 	assert.Nil(t, key)
 	assert.Equal(t, ErrNodeNotFound, err)
-}
-
-func TestLeafNode_getNextNilNode(t *testing.T) {
-	t.Parallel()
-
-	var ln *leafNode
-	key := []byte("dog")
-
-	n, key, err := ln.getNext(key, nil)
-	assert.Nil(t, n)
-	assert.Nil(t, key)
-	assert.True(t, errors.Is(err, ErrNilLeafNode))
 }
 
 func TestLeafNode_insertAtSameKey(t *testing.T) {
@@ -642,7 +589,7 @@ func TestLeafNode_writeNodeOnChannel(t *testing.T) {
 	assert.Equal(t, ln.Value, retrievedLn.Value())
 }
 
-func TestLeafNode_commitContextDone(t *testing.T) {
+func TestLeafNode_commitSnapshotContextDone(t *testing.T) {
 	t.Parallel()
 
 	db := testscommon.NewMemDbMock()
@@ -650,7 +597,7 @@ func TestLeafNode_commitContextDone(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := ln.commitSnapshot(db, nil, nil, ctx, statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, 0)
+	err := ln.commitSnapshot(db, nil, nil, ctx, statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, []byte("nodeBytes"), 0)
 	assert.Equal(t, core.ErrContextClosing, err)
 }
 

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -143,8 +143,9 @@ func TestNode_getNodeFromDBAndDecodeBranchNode(t *testing.T) {
 	encNode = append(encNode, branch)
 	nodeHash := bn.hasher.Compute(string(encNode))
 
-	nodeInstance, err := getNodeFromDBAndDecode(nodeHash, db, bn.marsh, bn.hasher)
+	nodeInstance, nodeBytes, err := getNodeFromDBAndDecode(nodeHash, db, bn.marsh, bn.hasher)
 	assert.Nil(t, err)
+	assert.Equal(t, encNode, nodeBytes)
 
 	h1, _ := encodeNodeAndGetHash(collapsedBn)
 	h2, _ := encodeNodeAndGetHash(nodeInstance)
@@ -163,8 +164,9 @@ func TestNode_getNodeFromDBAndDecodeExtensionNode(t *testing.T) {
 	encNode = append(encNode, extension)
 	nodeHash := en.hasher.Compute(string(encNode))
 
-	nodeInstance, err := getNodeFromDBAndDecode(nodeHash, db, en.marsh, en.hasher)
+	nodeInstance, nodeBytes, err := getNodeFromDBAndDecode(nodeHash, db, en.marsh, en.hasher)
 	assert.Nil(t, err)
+	assert.Equal(t, encNode, nodeBytes)
 
 	h1, _ := encodeNodeAndGetHash(collapsedEn)
 	h2, _ := encodeNodeAndGetHash(nodeInstance)
@@ -183,8 +185,9 @@ func TestNode_getNodeFromDBAndDecodeLeafNode(t *testing.T) {
 	encNode = append(encNode, leaf)
 	nodeHash := ln.hasher.Compute(string(encNode))
 
-	nodeInstance, err := getNodeFromDBAndDecode(nodeHash, db, ln.marsh, ln.hasher)
+	nodeInstance, nodeBytes, err := getNodeFromDBAndDecode(nodeHash, db, ln.marsh, ln.hasher)
 	assert.Nil(t, err)
+	assert.Equal(t, encNode, nodeBytes)
 
 	ln = getLn(ln.marsh, ln.hasher)
 	ln.dirty = false

--- a/trie/patriciaMerkleTrie.go
+++ b/trie/patriciaMerkleTrie.go
@@ -709,7 +709,7 @@ func (tr *patriciaMerkleTrie) GetStorageManager() common.StorageManager {
 
 // GetTrieStats will collect and return the statistics for the given rootHash
 func (tr *patriciaMerkleTrie) GetTrieStats(address string, rootHash []byte) (common.TrieStatisticsHandler, error) {
-	if len(rootHash) == 0 || bytes.Equal(rootHash, common.EmptyTrieHash) {
+	if common.IsEmptyTrie(rootHash) {
 		return statistics.NewTrieStatistics(), nil
 	}
 

--- a/trie/patriciaMerkleTrie.go
+++ b/trie/patriciaMerkleTrie.go
@@ -460,7 +460,7 @@ func (tr *patriciaMerkleTrie) recreateFromDb(rootHash []byte, tsm common.Storage
 		return nil, nil, err
 	}
 
-	newRoot, err := getNodeFromDBAndDecode(rootHash, tsm, tr.marshalizer, tr.hasher)
+	newRoot, _, err := getNodeFromDBAndDecode(rootHash, tsm, tr.marshalizer, tr.hasher)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -633,7 +633,7 @@ func (tr *patriciaMerkleTrie) GetProof(key []byte, rootHash []byte) ([][]byte, [
 		return nil, nil, ErrNilNode
 	}
 
-	rootNode, err := getNodeFromDBAndDecode(rootHash, tr.trieStorage, tr.marshalizer, tr.hasher)
+	rootNode, _, err := getNodeFromDBAndDecode(rootHash, tr.trieStorage, tr.marshalizer, tr.hasher)
 	if err != nil {
 		return nil, nil, fmt.Errorf("trie get proof error: %w", err)
 	}
@@ -709,13 +709,17 @@ func (tr *patriciaMerkleTrie) GetStorageManager() common.StorageManager {
 
 // GetTrieStats will collect and return the statistics for the given rootHash
 func (tr *patriciaMerkleTrie) GetTrieStats(address string, rootHash []byte) (common.TrieStatisticsHandler, error) {
-	newTrie, err := tr.recreate(rootHash, tr.trieStorage)
+	if len(rootHash) == 0 || bytes.Equal(rootHash, common.EmptyTrieHash) {
+		return statistics.NewTrieStatistics(), nil
+	}
+
+	rootNode, rootBytes, err := getNodeFromDBAndDecode(rootHash, tr.trieStorage, tr.marshalizer, tr.hasher)
 	if err != nil {
 		return nil, err
 	}
 
 	ts := statistics.NewTrieStatistics()
-	err = newTrie.GetRootNode().collectStats(ts, rootDepthLevel, newTrie.trieStorage)
+	err = rootNode.collectStats(ts, rootDepthLevel, uint64(len(rootBytes)), tr.trieStorage)
 	if err != nil {
 		return nil, err
 	}

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -319,7 +319,7 @@ func getNodeFromCacheOrStorage(
 		return n, nil
 	}
 
-	existingNode, err := getNodeFromDBAndDecode(hash, db, marshalizer, hasher)
+	existingNode, _, err := getNodeFromDBAndDecode(hash, db, marshalizer, hasher)
 	if err != nil {
 		return nil, ErrNodeNotFound
 	}

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -3,6 +3,7 @@ package trie
 import (
 	"context"
 	"errors"
+	"github.com/multiversx/mx-chain-go/state/hashesCollector"
 	"sync"
 	"testing"
 	"time"
@@ -224,8 +225,7 @@ func TestTrieSync_FoundInStorageShouldNotRequest(t *testing.T) {
 		},
 	}
 
-	err := bn.commitSnapshot(db, nil, nil, context.Background(), statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, 0)
-	require.Nil(t, err)
+	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
 
 	leaves, err := bn.getChildren(db)
 	require.Nil(t, err)


### PR DESCRIPTION
## Reasoning behind the pull request
- There were some unnecessary trie node encode operations
  
## Proposed changes
- Remove unnecessary encode operation from `collectStats` and `commitSnapshot`

## Testing procedure
- Normal testing procedure

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
