### PR TITLE
refactor trie constructor

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -661,6 +661,7 @@
     PeerStatePruningEnabled = true
     MaxStateTrieLevelInMemory = 5
     MaxPeerTrieLevelInMemory = 5
+    MaxNumGoroutines = 100
     StateStatisticsEnabled = false
 
 [BlockSizeThrottleConfig]

--- a/config/config.go
+++ b/config/config.go
@@ -311,6 +311,7 @@ type StateTriesConfig struct {
 	PeerStatePruningEnabled     bool
 	MaxStateTrieLevelInMemory   uint
 	MaxPeerTrieLevelInMemory    uint
+	MaxNumGoroutines            uint
 	StateStatisticsEnabled      bool
 }
 

--- a/factory/api/apiResolverFactory.go
+++ b/factory/api/apiResolverFactory.go
@@ -587,6 +587,7 @@ func createNewAccountsAdapterApi(args scQueryElementArgs, chainHandler data.Chai
 		Identifier:          dataRetriever.UserAccountsUnit.String(),
 		EnableEpochsHandler: args.coreComponents.EnableEpochsHandler(),
 		StatsCollector:      args.statusCoreComponents.StateStatsHandler(),
+		NumGoRoutines:       args.generalConfig.StateTriesConfig.MaxNumGoroutines,
 	}
 	trieStorageManager, merkleTrie, err := trFactory.Create(trieCreatorArgs)
 	if err != nil {

--- a/factory/processing/blockProcessorCreator_test.go
+++ b/factory/processing/blockProcessorCreator_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/core/throttler"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
@@ -198,7 +199,16 @@ func createAccountAdapter(
 	trieStorage common.StorageManager,
 	handler common.EnableEpochsHandler,
 ) (state.AccountsAdapter, error) {
-	tr, err := trie.NewTrie(trieStorage, marshaller, hasher, handler, 5)
+	thr, _ := throttler.NewNumGoRoutinesThrottler(10)
+	trieArgs := trie.TrieArgs{
+		TrieStorage:          trieStorage,
+		Marshalizer:          marshaller,
+		Hasher:               hasher,
+		EnableEpochsHandler:  handler,
+		MaxTrieLevelInMemory: 5,
+		Throttler:            thr,
+	}
+	tr, err := trie.NewTrie(trieArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/genesis/process/memoryComponents.go
+++ b/genesis/process/memoryComponents.go
@@ -21,7 +21,15 @@ func createAccountAdapter(
 	addressConverter core.PubkeyConverter,
 	enableEpochsHandler common.EnableEpochsHandler,
 ) (state.AccountsAdapter, error) {
-	tr, err := trie.NewTrie(trieStorage, marshaller, hasher, enableEpochsHandler, maxTrieLevelInMemory)
+	tr, err := trie.NewTrie(
+		trie.TrieArgs{
+			TrieStorage:          trieStorage,
+			Marshalizer:          marshaller,
+			Hasher:               hasher,
+			EnableEpochsHandler:  enableEpochsHandler,
+			MaxTrieLevelInMemory: maxTrieLevelInMemory,
+			Throttler:            trie.NewDisabledTrieGoRoutinesThrottler(),
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/integrationTests/state/stateTrie/stateTrie_test.go
+++ b/integrationTests/state/stateTrie/stateTrie_test.go
@@ -273,8 +273,7 @@ func TestTrieDB_RecreateFromStorageShouldWork(t *testing.T) {
 	args.Hasher = hasher
 	trieStorage, _ := trie.NewTrieStorageManager(args)
 
-	maxTrieLevelInMemory := uint(5)
-	tr1, _ := trie.NewTrie(trieStorage, integrationTests.TestMarshalizer, hasher, &enableEpochsHandlerMock.EnableEpochsHandlerStub{}, maxTrieLevelInMemory)
+	tr1, _ := trie.NewTrie(integrationTests.GetTrieArgs(trieStorage))
 
 	key := hasher.Compute("key")
 	value := hasher.Compute("value")
@@ -1061,8 +1060,8 @@ func createAccounts(
 	args := testStorage.GetStorageManagerArgs()
 	args.MainStorer = store
 	trieStorage, _ := trie.NewTrieStorageManager(args)
-	maxTrieLevelInMemory := uint(5)
-	tr, _ := trie.NewTrie(trieStorage, integrationTests.TestMarshalizer, integrationTests.TestHasher, &enableEpochsHandlerMock.EnableEpochsHandlerStub{}, maxTrieLevelInMemory)
+
+	tr, _ := trie.NewTrie(integrationTests.GetTrieArgs(trieStorage))
 	spm, _ := storagePruningManager.NewStoragePruningManager(ewl, 10)
 	argsAccCreator := factory.ArgsAccountCreator{
 		Hasher:              integrationTests.TestHasher,
@@ -2708,8 +2707,7 @@ func createAccountsDBTestSetup() *state.AccountsDB {
 	args := testStorage.GetStorageManagerArgs()
 	args.GeneralConfig = generalCfg
 	trieStorage, _ := trie.NewTrieStorageManager(args)
-	maxTrieLevelInMemory := uint(5)
-	tr, _ := trie.NewTrie(trieStorage, integrationTests.TestMarshalizer, integrationTests.TestHasher, &enableEpochsHandlerMock.EnableEpochsHandlerStub{}, maxTrieLevelInMemory)
+	tr, _ := trie.NewTrie(integrationTests.GetTrieArgs(trieStorage))
 	spm, _ := storagePruningManager.NewStoragePruningManager(ewl, 10)
 	argsAccCreator := factory.ArgsAccountCreator{
 		Hasher:              integrationTests.TestHasher,

--- a/integrationTests/state/stateTrieClose/stateTrieClose_test.go
+++ b/integrationTests/state/stateTrieClose/stateTrieClose_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/state/hashesCollector"
 	"github.com/multiversx/mx-chain-go/state/parsers"
-	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 	"github.com/multiversx/mx-chain-go/testscommon/goroutines"
 	"github.com/multiversx/mx-chain-go/testscommon/storage"
 	"github.com/multiversx/mx-chain-go/trie"
@@ -24,7 +23,7 @@ import (
 func TestPatriciaMerkleTrie_Close(t *testing.T) {
 	numLeavesToAdd := 200
 	trieStorage, _ := integrationTests.CreateTrieStorageManager(integrationTests.CreateMemUnit())
-	tr, _ := trie.NewTrie(trieStorage, integrationTests.TestMarshalizer, integrationTests.TestHasher, &enableEpochsHandlerMock.EnableEpochsHandlerStub{}, 5)
+	tr, _ := trie.NewTrie(integrationTests.GetTrieArgs(trieStorage))
 
 	for i := 0; i < numLeavesToAdd; i++ {
 		_ = tr.Update([]byte(strconv.Itoa(i)), []byte(strconv.Itoa(i)))

--- a/integrationTests/testInitializer.go
+++ b/integrationTests/testInitializer.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/core/throttler"
 	"github.com/multiversx/mx-chain-core-go/data"
 	dataBlock "github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
@@ -124,6 +125,20 @@ const (
 )
 
 const defaultChancesSelection = 1
+
+// GetTrieArgs returns the trie arguments for the tests
+func GetTrieArgs(trieStorage common.StorageManager) trie.TrieArgs {
+	thr, _ := throttler.NewNumGoRoutinesThrottler(10)
+	maxTrieLevelInMemory := uint(5)
+	return trie.TrieArgs{
+		TrieStorage:          trieStorage,
+		Marshalizer:          TestMarshalizer,
+		Hasher:               TestHasher,
+		EnableEpochsHandler:  &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
+		MaxTrieLevelInMemory: maxTrieLevelInMemory,
+		Throttler:            thr,
+	}
+}
 
 // GetConnectableAddress returns a non circuit, non windows default connectable address for provided messenger
 func GetConnectableAddress(mes p2p.Messenger) string {
@@ -456,7 +471,9 @@ func CreateAccountsDBWithEnableEpochsHandler(
 	trieStorageManager common.StorageManager,
 	enableEpochsHandler common.EnableEpochsHandler,
 ) (*state.AccountsDB, common.Trie) {
-	tr, _ := trie.NewTrie(trieStorageManager, TestMarshalizer, TestHasher, enableEpochsHandler, maxTrieLevelInMemory)
+	trieArgs := GetTrieArgs(trieStorageManager)
+	trieArgs.EnableEpochsHandler = enableEpochsHandler
+	tr, _ := trie.NewTrie(trieArgs)
 
 	ewlArgs := evictionWaitingList.MemoryEvictionWaitingListArgs{
 		RootHashesSize: 100,
@@ -1078,7 +1095,16 @@ func CreateNewDefaultTrie() common.Trie {
 
 	trieStorage, _ := trie.NewTrieStorageManager(args)
 
-	tr, _ := trie.NewTrie(trieStorage, TestMarshalizer, TestHasher, &enableEpochsHandlerMock.EnableEpochsHandlerStub{}, maxTrieLevelInMemory)
+	thr, _ := throttler.NewNumGoRoutinesThrottler(10)
+	trieArgs := trie.TrieArgs{
+		TrieStorage:          trieStorage,
+		Marshalizer:          TestMarshalizer,
+		Hasher:               TestHasher,
+		EnableEpochsHandler:  &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
+		MaxTrieLevelInMemory: maxTrieLevelInMemory,
+		Throttler:            thr,
+	}
+	tr, _ := trie.NewTrie(trieArgs)
 	return tr
 }
 

--- a/integrationTests/vm/staking/componentsHolderCreator.go
+++ b/integrationTests/vm/staking/componentsHolderCreator.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/nodetype"
+	"github.com/multiversx/mx-chain-core-go/core/throttler"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/endProcess"
@@ -193,13 +194,16 @@ func createAccountsDB(
 	accountFactory state.AccountFactory,
 	trieStorageManager common.StorageManager,
 ) *state.AccountsDB {
-	tr, _ := trie.NewTrie(
-		trieStorageManager,
-		coreComponents.InternalMarshalizer(),
-		coreComponents.Hasher(),
-		coreComponents.EnableEpochsHandler(),
-		5,
-	)
+	th, _ := throttler.NewNumGoRoutinesThrottler(10)
+	trieArgs := trie.TrieArgs{
+		TrieStorage:          trieStorageManager,
+		Marshalizer:          coreComponents.InternalMarshalizer(),
+		Hasher:               coreComponents.Hasher(),
+		EnableEpochsHandler:  coreComponents.EnableEpochsHandler(),
+		MaxTrieLevelInMemory: 5,
+		Throttler:            th,
+	}
+	tr, _ := trie.NewTrie(trieArgs)
 
 	argsEvictionWaitingList := evictionWaitingList.MemoryEvictionWaitingListArgs{
 		RootHashesSize: 10,

--- a/state/storagePruningManager/storagePruningManager_test.go
+++ b/state/storagePruningManager/storagePruningManager_test.go
@@ -2,7 +2,8 @@ package storagePruningManager
 
 import (
 	"testing"
-
+	
+	"github.com/multiversx/mx-chain-core-go/core/throttler"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/holders"
 	"github.com/multiversx/mx-chain-go/common/statistics"
@@ -32,7 +33,16 @@ func getDefaultTrieAndAccountsDbAndStoragePruningManager() (common.Trie, *state.
 	hasher := &hashingMocks.HasherMock{}
 	args := storage.GetStorageManagerArgs()
 	trieStorage, _ := trie.NewTrieStorageManager(args)
-	tr, _ := trie.NewTrie(trieStorage, marshaller, hasher, &enableEpochsHandlerMock.EnableEpochsHandlerStub{}, 5)
+	th, _ := throttler.NewNumGoRoutinesThrottler(10)
+	trieArgs := trie.TrieArgs{
+		TrieStorage:          trieStorage,
+		Marshalizer:          marshaller,
+		Hasher:               hasher,
+		EnableEpochsHandler:  &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
+		MaxTrieLevelInMemory: 5,
+		Throttler:            th,
+	}
+	tr, _ := trie.NewTrie(trieArgs)
 	ewlArgs := evictionWaitingList.MemoryEvictionWaitingListArgs{
 		RootHashesSize: 100,
 		HashesSize:     10000,

--- a/state/syncer/baseAccountsSyncer.go
+++ b/state/syncer/baseAccountsSyncer.go
@@ -217,7 +217,15 @@ func (b *baseAccountsSyncer) GetSyncedTries() map[string]common.Trie {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
-	dataTrie, err := trie.NewTrie(b.trieStorageManager, b.marshalizer, b.hasher, b.enableEpochsHandler, b.maxTrieLevelInMemory)
+	trieArgs := trie.TrieArgs{
+		TrieStorage:          b.trieStorageManager,
+		Marshalizer:          b.marshalizer,
+		Hasher:               b.hasher,
+		EnableEpochsHandler:  b.enableEpochsHandler,
+		MaxTrieLevelInMemory: b.maxTrieLevelInMemory,
+		Throttler:            trie.NewDisabledTrieGoRoutinesThrottler(),
+	}
+	dataTrie, err := trie.NewTrie(trieArgs)
 	if err != nil {
 		log.Warn("error creating a new trie in baseAccountsSyncer.GetSyncedTries", "error", err)
 		return make(map[string]common.Trie)

--- a/state/syncer/userAccountSyncer_test.go
+++ b/state/syncer/userAccountSyncer_test.go
@@ -3,7 +3,8 @@ package syncer
 import (
 	"testing"
 	"time"
-
+	
+	"github.com/multiversx/mx-chain-core-go/core/throttler"
 	"github.com/multiversx/mx-chain-go/dataRetriever/mock"
 	"github.com/multiversx/mx-chain-go/state/hashesCollector"
 	"github.com/multiversx/mx-chain-go/testscommon"
@@ -89,7 +90,16 @@ func TestUserAccountsSyncer_MissingDataTrieNodeFound(t *testing.T) {
 		},
 	}
 
-	tr, _ := trie.NewTrie(tsm, args.Marshalizer, args.Hasher, &enableEpochsHandlerMock.EnableEpochsHandlerStub{}, 5)
+	th, _ := throttler.NewNumGoRoutinesThrottler(10)
+	trieArgs := trie.TrieArgs{
+		TrieStorage:          tsm,
+		Marshalizer:          args.Marshalizer,
+		Hasher:               args.Hasher,
+		EnableEpochsHandler:  &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
+		MaxTrieLevelInMemory: 5,
+		Throttler:            th,
+	}
+	tr, _ := trie.NewTrie(trieArgs)
 	key := []byte("key")
 	value := []byte("value")
 	_ = tr.Update(key, value)

--- a/testscommon/components/components.go
+++ b/testscommon/components/components.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/multiversx/mx-chain-core-go/core/throttler"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/endProcess"
 	"github.com/multiversx/mx-chain-core-go/data/outport"
@@ -343,8 +344,18 @@ func GetStateFactoryArgs(coreComponents factory.CoreComponentsHolder, statusCore
 	trieStorageManagers[dataRetriever.PeerAccountsUnit.String()] = storageManagerPeer
 
 	triesHolder := state.NewDataTriesHolder()
-	trieUsers, _ := trie.NewTrie(storageManagerUser, coreComponents.InternalMarshalizer(), coreComponents.Hasher(), coreComponents.EnableEpochsHandler(), 5)
-	triePeers, _ := trie.NewTrie(storageManagerPeer, coreComponents.InternalMarshalizer(), coreComponents.Hasher(), coreComponents.EnableEpochsHandler(), 5)
+	th, _ := throttler.NewNumGoRoutinesThrottler(10)
+	trieArgs := trie.TrieArgs{
+		TrieStorage:          storageManagerUser,
+		Marshalizer:          coreComponents.InternalMarshalizer(),
+		Hasher:               coreComponents.Hasher(),
+		EnableEpochsHandler:  coreComponents.EnableEpochsHandler(),
+		MaxTrieLevelInMemory: 5,
+		Throttler:            th,
+	}
+	trieUsers, _ := trie.NewTrie(trieArgs)
+	trieArgs.TrieStorage = storageManagerPeer
+	triePeers, _ := trie.NewTrie(trieArgs)
 	triesHolder.Put([]byte(dataRetriever.UserAccountsUnit.String()), trieUsers)
 	triesHolder.Put([]byte(dataRetriever.PeerAccountsUnit.String()), triePeers)
 

--- a/testscommon/integrationtests/factory.go
+++ b/testscommon/integrationtests/factory.go
@@ -1,6 +1,7 @@
 package integrationtests
 
 import (
+	"github.com/multiversx/mx-chain-core-go/core/throttler"
 	"github.com/multiversx/mx-chain-core-go/hashing/sha256"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
@@ -100,7 +101,16 @@ func CreateAccountsDB(db storage.Storer, enableEpochs common.EnableEpochsHandler
 
 	trieStorage, _ := trie.NewTrieStorageManager(args)
 
-	tr, _ := trie.NewTrie(trieStorage, TestMarshalizer, TestHasher, enableEpochs, MaxTrieLevelInMemory)
+	th, _ := throttler.NewNumGoRoutinesThrottler(10)
+	trieArgs := trie.TrieArgs{
+		TrieStorage:          trieStorage,
+		Marshalizer:          TestMarshalizer,
+		Hasher:               TestHasher,
+		EnableEpochsHandler:  enableEpochs,
+		MaxTrieLevelInMemory: MaxTrieLevelInMemory,
+		Throttler:            th,
+	}
+	tr, _ := trie.NewTrie(trieArgs)
 	spm, _ := storagePruningManager.NewStoragePruningManager(ewl, 10)
 
 	argsAccCreator := accountFactory.ArgsAccountCreator{

--- a/trie/branchNode_test.go
+++ b/trie/branchNode_test.go
@@ -86,6 +86,7 @@ func emptyDirtyBranchNode() *branchNode {
 func newEmptyTrie() (*patriciaMerkleTrie, *trieStorageManager) {
 	args := GetDefaultTrieStorageManagerParameters()
 	trieStorage, _ := NewTrieStorageManager(args)
+	thr, _ := throttler.NewNumGoRoutinesThrottler(10)
 	tr := &patriciaMerkleTrie{
 		trieStorage:             trieStorage,
 		marshalizer:             args.Marshalizer,
@@ -97,6 +98,7 @@ func newEmptyTrie() (*patriciaMerkleTrie, *trieStorageManager) {
 		goRoutinesManager:       getTestGoroutinesManager(),
 		RootManager:             NewRootManager(),
 		trieOperationInProgress: &atomic.Flag{},
+		throttler:               thr,
 	}
 
 	return tr, trieStorage

--- a/trie/disabledTrieGoRoutinesThrottler.go
+++ b/trie/disabledTrieGoRoutinesThrottler.go
@@ -1,0 +1,27 @@
+package trie
+
+type disabledTrieGoRoutinesThrottler struct {
+}
+
+// NewDisabledTrieGoRoutinesThrottler returns a new instance of a disabledTrieGoRoutinesThrottler
+func NewDisabledTrieGoRoutinesThrottler() *disabledTrieGoRoutinesThrottler {
+	return &disabledTrieGoRoutinesThrottler{}
+}
+
+// CanProcess will always return false
+func (d *disabledTrieGoRoutinesThrottler) CanProcess() bool {
+	return false
+}
+
+// StartProcessing won't do anything
+func (d *disabledTrieGoRoutinesThrottler) StartProcessing() {
+}
+
+// EndProcessing won't do anything
+func (d *disabledTrieGoRoutinesThrottler) EndProcessing() {
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (d *disabledTrieGoRoutinesThrottler) IsInterfaceNil() bool {
+	return d == nil
+}

--- a/trie/factory/trieCreator.go
+++ b/trie/factory/trieCreator.go
@@ -1,7 +1,9 @@
 package factory
 
 import (
+	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/core/throttler"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
@@ -22,6 +24,7 @@ type TrieCreateArgs struct {
 	Identifier          string
 	EnableEpochsHandler common.EnableEpochsHandler
 	StatsCollector      common.StateStatisticsHandler
+	NumGoRoutines       uint
 }
 
 type trieCreator struct {
@@ -78,12 +81,34 @@ func (tc *trieCreator) Create(args TrieCreateArgs) (common.StorageManager, commo
 		return nil, nil, err
 	}
 
-	newTrie, err := trie.NewTrie(trieStorage, tc.marshalizer, tc.hasher, args.EnableEpochsHandler, args.MaxTrieLevelInMem)
+	goRoutinesThrottler, err := getGoRoutinesThrottler(args.NumGoRoutines)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	trArgs := trie.TrieArgs{
+		TrieStorage:          trieStorage,
+		Marshalizer:          tc.marshalizer,
+		Hasher:               tc.hasher,
+		EnableEpochsHandler:  args.EnableEpochsHandler,
+		MaxTrieLevelInMemory: args.MaxTrieLevelInMem,
+		Throttler:            goRoutinesThrottler,
+	}
+
+	newTrie, err := trie.NewTrie(trArgs)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return trieStorage, newTrie, nil
+}
+
+func getGoRoutinesThrottler(numGoroutines uint) (core.Throttler, error) {
+	if numGoroutines == 0 {
+		return trie.NewDisabledTrieGoRoutinesThrottler(), nil
+	}
+
+	return throttler.NewNumGoRoutinesThrottler(int32(numGoroutines))
 }
 
 // IsInterfaceNil returns true if there is no value under the interface
@@ -123,6 +148,7 @@ func CreateTriesComponentsForShardId(
 		Identifier:          dataRetriever.UserAccountsUnit.String(),
 		EnableEpochsHandler: coreComponentsHolder.EnableEpochsHandler(),
 		StatsCollector:      stateStatsHandler,
+		NumGoRoutines:       generalConfig.StateTriesConfig.MaxNumGoroutines,
 	}
 	userStorageManager, userAccountTrie, err := trFactory.Create(args)
 	if err != nil {
@@ -149,6 +175,7 @@ func CreateTriesComponentsForShardId(
 		Identifier:          dataRetriever.PeerAccountsUnit.String(),
 		EnableEpochsHandler: coreComponentsHolder.EnableEpochsHandler(),
 		StatsCollector:      stateStatsHandler,
+		NumGoRoutines:       generalConfig.StateTriesConfig.MaxNumGoroutines,
 	}
 	peerStorageManager, peerAccountsTrie, err := trFactory.Create(args)
 	if err != nil {

--- a/trie/factory/trieCreator_test.go
+++ b/trie/factory/trieCreator_test.go
@@ -41,6 +41,7 @@ func getCreateArgs() factory.TrieCreateArgs {
 		Identifier:          dataRetriever.UserAccountsUnit.String(),
 		EnableEpochsHandler: &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
 		StatsCollector:      disabled.NewStateStatistics(),
+		NumGoRoutines:       10,
 	}
 }
 

--- a/update/factory/dataTrieFactory.go
+++ b/update/factory/dataTrieFactory.go
@@ -142,7 +142,15 @@ func (d *dataTrieFactory) Create() (common.TriesHolder, error) {
 }
 
 func (d *dataTrieFactory) createAndAddOneTrie(shId uint32, accType genesis.Type, container common.TriesHolder) error {
-	dataTrie, err := trie.NewTrie(d.trieStorage, d.marshalizer, d.hasher, d.enableEpochsHandler, d.maxTrieLevelInMemory)
+	trieArgs := trie.TrieArgs{
+		TrieStorage:          d.trieStorage,
+		Marshalizer:          d.marshalizer,
+		Hasher:               d.hasher,
+		EnableEpochsHandler:  d.enableEpochsHandler,
+		MaxTrieLevelInMemory: d.maxTrieLevelInMemory,
+		Throttler:            trie.NewDisabledTrieGoRoutinesThrottler(),
+	}
+	dataTrie, err := trie.NewTrie(trieArgs)
 	if err != nil {
 		return err
 	}

--- a/update/genesis/import.go
+++ b/update/genesis/import.go
@@ -315,7 +315,15 @@ func (si *stateImport) getTrie(shardID uint32, accType Type) (common.Trie, error
 		trieStorageManager = si.trieStorageManagers[dataRetriever.PeerAccountsUnit.String()]
 	}
 
-	trieForShard, err := trie.NewTrie(trieStorageManager, si.marshalizer, si.hasher, si.enableEpochsHandler, maxTrieLevelInMemory)
+	trieArgs := trie.TrieArgs{
+		TrieStorage:          trieStorageManager,
+		Marshalizer:          si.marshalizer,
+		Hasher:               si.hasher,
+		EnableEpochsHandler:  si.enableEpochsHandler,
+		MaxTrieLevelInMemory: maxTrieLevelInMemory,
+		Throttler:            trie.NewDisabledTrieGoRoutinesThrottler(),
+	}
+	trieForShard, err := trie.NewTrie(trieArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -347,7 +355,15 @@ func (si *stateImport) importDataTrie(identifier string, shID uint32, keys [][]b
 		return fmt.Errorf("%w wanted a roothash", update.ErrWrongTypeAssertion)
 	}
 
-	dataTrie, err := trie.NewTrie(si.trieStorageManagers[dataRetriever.UserAccountsUnit.String()], si.marshalizer, si.hasher, si.enableEpochsHandler, maxTrieLevelInMemory)
+	trieArgs := trie.TrieArgs{
+		TrieStorage:          si.trieStorageManagers[dataRetriever.UserAccountsUnit.String()],
+		Marshalizer:          si.marshalizer,
+		Hasher:               si.hasher,
+		EnableEpochsHandler:  si.enableEpochsHandler,
+		MaxTrieLevelInMemory: maxTrieLevelInMemory,
+		Throttler:            trie.NewDisabledTrieGoRoutinesThrottler(),
+	}
+	dataTrie, err := trie.NewTrie(trieArgs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- The trie constructor needs a lot of parameter
  
## Proposed changes
- Instead of passing each parameter for the trie constructor, pass an `args` struct
- Pass a `goRoutinesThrottler` to the trie constructor. On trie recreate, use the same throttler. This will prevent us from opening an unlimited number of goroutines for trie operations
- Add a new config val to the `[StateTriesConfig]` - `MaxNumGoroutines`

## Testing procedure
- This will be tested when testing the feature branch it is targeted to

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
