### PR TITLE
Fix shard stuck

### DIFF
--- a/consensus/spos/bls/v2/subroundEndRound.go
+++ b/consensus/spos/bls/v2/subroundEndRound.go
@@ -254,17 +254,17 @@ func (sr *subroundEndRound) doEndRoundJobByNode() bool {
 		return false
 	}
 
-	err := sr.commitBlock()
-	if err != nil {
-		return false
-	}
-
 	// if proof not nil, it was created and broadcasted so it has to be added to the pool
 	if proof != nil {
 		ok := sr.EquivalentProofsPool().AddProof(proof)
 		if !ok {
 			log.Trace("doEndRoundJobByNode.AddProof", "added", ok)
 		}
+	}
+
+	err := sr.commitBlock()
+	if err != nil {
+		return false
 	}
 
 	sr.SetStatus(sr.Current(), spos.SsFinished)

--- a/consensus/spos/bls/v2/subroundEndRound.go
+++ b/consensus/spos/bls/v2/subroundEndRound.go
@@ -255,7 +255,7 @@ func (sr *subroundEndRound) doEndRoundJobByNode() bool {
 func (sr *subroundEndRound) waitForProof() bool {
 	shardID := sr.ShardCoordinator().SelfId()
 	headerHash := sr.GetData()
-	if sr.EquivalentProofsPool().HasProof(sr.ShardCoordinator().SelfId(), sr.GetData()) {
+	if sr.EquivalentProofsPool().HasProof(shardID, headerHash) {
 		return true
 	}
 
@@ -332,7 +332,7 @@ func (sr *subroundEndRound) sendProof() {
 	}
 
 	// broadcast header proof
-	_, err = sr.createAndBroadcastProof(sig, bitmap)
+	err = sr.createAndBroadcastProof(sig, bitmap)
 	if err != nil {
 		log.Warn("sendProof.createAndBroadcastProof", "error", err.Error())
 	}
@@ -543,7 +543,7 @@ func (sr *subroundEndRound) computeAggSigOnValidNodes() ([]byte, []byte, error) 
 	return bitmap, sig, nil
 }
 
-func (sr *subroundEndRound) createAndBroadcastProof(signature []byte, bitmap []byte) (*block.HeaderProof, error) {
+func (sr *subroundEndRound) createAndBroadcastProof(signature []byte, bitmap []byte) error {
 	headerProof := &block.HeaderProof{
 		PubKeysBitmap:       bitmap,
 		AggregatedSignature: signature,
@@ -557,14 +557,14 @@ func (sr *subroundEndRound) createAndBroadcastProof(signature []byte, bitmap []b
 
 	err := sr.BroadcastMessenger().BroadcastEquivalentProof(headerProof, []byte(sr.SelfPubKey()))
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	log.Debug("step 3: block header proof has been sent",
 		"PubKeysBitmap", bitmap,
 		"AggregateSignature", signature)
 
-	return headerProof, nil
+	return nil
 }
 
 func (sr *subroundEndRound) createAndBroadcastInvalidSigners(invalidSigners []byte) {

--- a/consensus/spos/bls/v2/subroundEndRound_test.go
+++ b/consensus/spos/bls/v2/subroundEndRound_test.go
@@ -1181,8 +1181,13 @@ func TestSubroundEndRound_DoEndRoundJobByNode(t *testing.T) {
 		t.Parallel()
 
 		container := consensusMocks.InitConsensusCore()
+		numCalls := 0
 		container.SetEquivalentProofsPool(&dataRetriever.ProofsPoolMock{
 			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				if numCalls <= 1 {
+					numCalls++
+					return false
+				}
 				return true
 			},
 		})

--- a/consensus/spos/bls/v2/subroundEndRound_test.go
+++ b/consensus/spos/bls/v2/subroundEndRound_test.go
@@ -1227,8 +1227,6 @@ func TestSubroundEndRound_DoEndRoundJobByNode(t *testing.T) {
 	t.Run("should work with equivalent messages flag active", func(t *testing.T) {
 		t.Parallel()
 
-		providedPrevSig := []byte("prev sig")
-		providedPrevBitmap := []byte{1, 1, 1, 1, 1, 1, 1, 1, 1}
 		container := consensusMocks.InitConsensusCore()
 		container.SetBlockchain(&testscommon.ChainHandlerStub{
 			GetGenesisHeaderCalled: func() data.HeaderHandler {
@@ -1241,16 +1239,7 @@ func TestSubroundEndRound_DoEndRoundJobByNode(t *testing.T) {
 			},
 		}
 		container.SetEnableEpochsHandler(enableEpochsHandler)
-
-		wasSetCurrentHeaderProofCalled := false
-		container.SetEquivalentProofsPool(&dataRetriever.ProofsPoolMock{
-			AddProofCalled: func(headerProof data.HeaderProofHandler) bool {
-				wasSetCurrentHeaderProofCalled = true
-				require.NotEqual(t, providedPrevSig, headerProof.GetAggregatedSignature())
-				require.NotEqual(t, providedPrevBitmap, headerProof.GetPubKeysBitmap())
-				return true
-			},
-		})
+		container.SetEquivalentProofsPool(&dataRetriever.ProofsPoolMock{})
 
 		ch := make(chan bool, 1)
 		consensusState := initializers.InitConsensusState()
@@ -1295,7 +1284,6 @@ func TestSubroundEndRound_DoEndRoundJobByNode(t *testing.T) {
 
 		r := srEndRound.DoEndRoundJobByNode()
 		require.True(t, r)
-		require.True(t, wasSetCurrentHeaderProofCalled)
 	})
 }
 

--- a/consensus/spos/bls/v2/subroundEndRound_test.go
+++ b/consensus/spos/bls/v2/subroundEndRound_test.go
@@ -572,6 +572,11 @@ func TestSubroundEndRound_DoEndRoundJobAllOK(t *testing.T) {
 	t.Parallel()
 
 	container := consensusMocks.InitConsensusCore()
+	container.SetEquivalentProofsPool(&dataRetriever.ProofsPoolMock{
+		HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+			return true
+		},
+	})
 	sr := initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
 	sr.SetSelfPubKey("A")
 
@@ -1176,6 +1181,11 @@ func TestSubroundEndRound_DoEndRoundJobByNode(t *testing.T) {
 		t.Parallel()
 
 		container := consensusMocks.InitConsensusCore()
+		container.SetEquivalentProofsPool(&dataRetriever.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return true
+			},
+		})
 		sr := initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
 
 		verifySigShareNumCalls := 0
@@ -1233,13 +1243,17 @@ func TestSubroundEndRound_DoEndRoundJobByNode(t *testing.T) {
 				return &block.HeaderV2{}
 			},
 		})
+		container.SetEquivalentProofsPool(&dataRetriever.ProofsPoolMock{
+			HasProofCalled: func(shardID uint32, headerHash []byte) bool {
+				return true
+			},
+		})
 		enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
 			IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
 				return flag == common.EquivalentMessagesFlag
 			},
 		}
 		container.SetEnableEpochsHandler(enableEpochsHandler)
-		container.SetEquivalentProofsPool(&dataRetriever.ProofsPoolMock{})
 
 		ch := make(chan bool, 1)
 		consensusState := initializers.InitConsensusState()

--- a/process/sync/baseForkDetector.go
+++ b/process/sync/baseForkDetector.go
@@ -760,11 +760,13 @@ func (bfd *baseForkDetector) processReceivedBlock(
 	bfd.setHighestNonceReceived(header.GetNonce())
 
 	if state == process.BHProposed || !hasProof {
+		log.Trace("forkDetector.processReceivedBlock: block is proposed or has no proof", "state", state, "has proof", hasProof)
 		return
 	}
 
 	isHeaderReceivedTooLate := bfd.isHeaderReceivedTooLate(header, state, process.BlockFinality)
 	if isHeaderReceivedTooLate {
+		log.Trace("forkDetector.processReceivedBlock: block is received too late", "initial state", state)
 		state = process.BHReceivedTooLate
 	}
 
@@ -778,6 +780,7 @@ func (bfd *baseForkDetector) processReceivedBlock(
 	}
 
 	if !bfd.append(hInfo) {
+		log.Trace("forkDetector.processReceivedBlock: header not appended", "nonce", hInfo.nonce, "hash", hInfo.hash)
 		return
 	}
 

--- a/process/sync/metaForkDetector.go
+++ b/process/sync/metaForkDetector.go
@@ -108,7 +108,11 @@ func (mfd *metaForkDetector) doJobOnBHProcessed(
 	_ [][]byte,
 ) {
 	mfd.setFinalCheckpoint(mfd.lastCheckpoint())
-	mfd.addCheckpoint(&checkpointInfo{nonce: header.GetNonce(), round: header.GetRound(), hash: headerHash})
+	newCheckpoint := &checkpointInfo{nonce: header.GetNonce(), round: header.GetRound(), hash: headerHash}
+	mfd.addCheckpoint(newCheckpoint)
+	if mfd.enableEpochsHandler.IsFlagEnabledInEpoch(common.EquivalentMessagesFlag, header.GetEpoch()) {
+		mfd.setFinalCheckpoint(newCheckpoint)
+	}
 	mfd.removePastOrInvalidRecords()
 }
 

--- a/process/sync/shardForkDetector.go
+++ b/process/sync/shardForkDetector.go
@@ -112,7 +112,11 @@ func (sfd *shardForkDetector) doJobOnBHProcessed(
 ) {
 	_ = sfd.appendSelfNotarizedHeaders(selfNotarizedHeaders, selfNotarizedHeadersHashes, core.MetachainShardId)
 	sfd.computeFinalCheckpoint()
-	sfd.addCheckpoint(&checkpointInfo{nonce: header.GetNonce(), round: header.GetRound(), hash: headerHash})
+	newCheckpoint := &checkpointInfo{nonce: header.GetNonce(), round: header.GetRound(), hash: headerHash}
+	sfd.addCheckpoint(newCheckpoint)
+	if sfd.enableEpochsHandler.IsFlagEnabledInEpoch(common.EquivalentMessagesFlag, header.GetEpoch()) {
+		sfd.setFinalCheckpoint(newCheckpoint)
+	}
 	sfd.removePastOrInvalidRecords()
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request
- During testing the shard nodes falsely detects from time to time that metachain is falling behind with notarization
  
## Proposed changes
- Fork detector should be updated with the final blocks based on the new rules
- Consensus subround EndRound needs to be updated to commit the block only once the proof is stored, otherwise the fork detector would wrongly compute the last notarized blocks

## Testing procedure
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
