### PR TITLE
vm integration for get all transfers value hook, get code hash hook and internal errors masking

### DIFF
--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -337,7 +337,7 @@
     RelayedTransactionsV3EnableEpoch = 1
 
     # MaskVMInternalDependenciesErrorsEnableEpoch represents the epoch when the additional internal erorr masking in vm is enabled
-    MaskVMInternalDependenciesErrorsEnableEpoch = 10
+    MaskVMInternalDependenciesErrorsEnableEpoch = 1
 
     # BLSMultiSignerEnableEpoch represents the activation epoch for different types of BLS multi-signers
     BLSMultiSignerEnableEpoch = [

--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -337,7 +337,7 @@
     RelayedTransactionsV3EnableEpoch = 1
 
     # MaskVMInternalDependenciesErrorsEnableEpoch represents the epoch when the additional internal erorr masking in vm is enabled
-    MaskVMInternalDependenciesErrorsEnableEpoch = 1
+    MaskVMInternalDependenciesErrorsEnableEpoch = 2
 
     # BLSMultiSignerEnableEpoch represents the activation epoch for different types of BLS multi-signers
     BLSMultiSignerEnableEpoch = [

--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -336,6 +336,9 @@
     # RelayedTransactionsV3EnableEpoch represents the epoch when the relayed transactions v3 will be enabled
     RelayedTransactionsV3EnableEpoch = 1
 
+    # MaskVMInternalDependenciesErrorsEnableEpoch represents the epoch when the additional internal erorr masking in vm is enabled
+    MaskVMInternalDependenciesErrorsEnableEpoch = 10
+
     # BLSMultiSignerEnableEpoch represents the activation epoch for different types of BLS multi-signers
     BLSMultiSignerEnableEpoch = [
         { EnableEpoch = 0, Type = "no-KOSK" },

--- a/cmd/node/config/gasSchedules/gasScheduleV1.toml
+++ b/cmd/node/config/gasSchedules/gasScheduleV1.toml
@@ -111,6 +111,7 @@
     SetAsyncContextCallback = 100000
     GetCallbackClosure   = 10000
     GetCodeMetadata      = 10000
+    GetCodeHash          = 10000
     IsBuiltinFunction    = 10000
     IsReservedFunctionName = 10000
     GetRoundTime    = 1000

--- a/cmd/node/config/gasSchedules/gasScheduleV2.toml
+++ b/cmd/node/config/gasSchedules/gasScheduleV2.toml
@@ -111,6 +111,7 @@
     SetAsyncContextCallback = 100000
     GetCallbackClosure   = 10000
     GetCodeMetadata      = 10000
+    GetCodeHash          = 10000
     IsBuiltinFunction    = 10000
     IsReservedFunctionName = 10000
     GetRoundTime    = 10000

--- a/cmd/node/config/gasSchedules/gasScheduleV3.toml
+++ b/cmd/node/config/gasSchedules/gasScheduleV3.toml
@@ -111,6 +111,7 @@
     SetAsyncContextCallback = 100000
     GetCallbackClosure   = 10000
     GetCodeMetadata      = 10000
+    GetCodeHash          = 10000
     IsBuiltinFunction    = 10000
     IsReservedFunctionName = 10000
     GetRoundTime    = 10000

--- a/cmd/node/config/gasSchedules/gasScheduleV4.toml
+++ b/cmd/node/config/gasSchedules/gasScheduleV4.toml
@@ -111,6 +111,7 @@
     GetCurrentTxHash   = 10000
     GetCallbackClosure   = 10000
     GetCodeMetadata      = 10000
+    GetCodeHash          = 10000
     IsBuiltinFunction    = 10000
     IsReservedFunctionName = 10000
     GetRoundTime    = 10000

--- a/cmd/node/config/gasSchedules/gasScheduleV5.toml
+++ b/cmd/node/config/gasSchedules/gasScheduleV5.toml
@@ -111,6 +111,7 @@
     SetAsyncContextCallback = 100000
     GetCallbackClosure   = 10000
     GetCodeMetadata      = 10000
+    GetCodeHash          = 10000
     IsBuiltinFunction    = 10000
     IsReservedFunctionName = 10000
     GetRoundTime    = 10000

--- a/cmd/node/config/gasSchedules/gasScheduleV6.toml
+++ b/cmd/node/config/gasSchedules/gasScheduleV6.toml
@@ -111,6 +111,7 @@
     SetAsyncContextCallback = 100000
     GetCallbackClosure   = 10000
     GetCodeMetadata      = 10000
+    GetCodeHash          = 10000
     IsBuiltinFunction    = 10000
     IsReservedFunctionName = 10000
     GetRoundTime    = 10000

--- a/cmd/node/config/gasSchedules/gasScheduleV7.toml
+++ b/cmd/node/config/gasSchedules/gasScheduleV7.toml
@@ -112,6 +112,7 @@
     SetAsyncContextCallback = 100000
     GetCallbackClosure   = 10000
     GetCodeMetadata      = 10000
+    GetCodeHash          = 10000
     IsBuiltinFunction    = 10000
     IsReservedFunctionName = 10000
     GetRoundTime    = 10000

--- a/cmd/node/config/gasSchedules/gasScheduleV8.toml
+++ b/cmd/node/config/gasSchedules/gasScheduleV8.toml
@@ -112,6 +112,7 @@
     SetAsyncContextCallback = 100000
     GetCallbackClosure   = 10000
     GetCodeMetadata      = 10000
+    GetCodeHash          = 10000
     IsBuiltinFunction    = 10000
     IsReservedFunctionName = 10000
     GetRoundTime    = 10000

--- a/common/constants.go
+++ b/common/constants.go
@@ -1241,5 +1241,6 @@ const (
 	MultiESDTNFTTransferAndExecuteByUserFlag           core.EnableEpochFlag = "MultiESDTNFTTransferAndExecuteByUserFlag"
 	FixRelayedMoveBalanceToNonPayableSCFlag            core.EnableEpochFlag = "FixRelayedMoveBalanceToNonPayableSCFlag"
 	RelayedTransactionsV3Flag                          core.EnableEpochFlag = "RelayedTransactionsV3Flag"
+	MaskInternalDependenciesErrorsFlag                 core.EnableEpochFlag = "MaskInternalDependenciesErrorsFlag"
 	// all new flags must be added to createAllFlagsMap method, as part of enableEpochsHandler allFlagsDefined
 )

--- a/common/enablers/enableEpochsHandler.go
+++ b/common/enablers/enableEpochsHandler.go
@@ -786,6 +786,12 @@ func (handler *enableEpochsHandler) createAllFlagsMap() {
 			},
 			activationEpoch: handler.enableEpochsConfig.RelayedTransactionsV3EnableEpoch,
 		},
+		common.MaskInternalDependenciesErrorsFlag: {
+			isActiveInEpoch: func(epoch uint32) bool {
+				return epoch >= handler.enableEpochsConfig.MaskVMInternalDependenciesErrorsEnableEpoch
+			},
+			activationEpoch: handler.enableEpochsConfig.MaskVMInternalDependenciesErrorsEnableEpoch,
+		},
 	}
 }
 

--- a/config/epochConfig.go
+++ b/config/epochConfig.go
@@ -123,6 +123,7 @@ type EnableEpochs struct {
 	MultiESDTNFTTransferAndExecuteByUserEnableEpoch          uint32
 	FixRelayedMoveBalanceToNonPayableSCEnableEpoch           uint32
 	RelayedTransactionsV3EnableEpoch                         uint32
+	MaskVMInternalDependenciesErrorsEnableEpoch              uint32
 	BLSMultiSignerEnableEpoch                                []MultiSignerConfig
 }
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/multiversx/mx-chain-scenario-go v1.4.5-0.20240802080531-0906745c04b2
 	github.com/multiversx/mx-chain-storage-go v1.0.19
 	github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20241021074004-c2bdb78da54a
-	github.com/multiversx/mx-chain-vm-go v1.5.32-0.20241222212702-7f493a77b009
+	github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250204082910-96937fe57603
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20241021081333-37461f04f0de
 	github.com/multiversx/mx-chain-vm-v1_3-go v1.3.70-0.20241021081245-2ef08dbcbc2e
 	github.com/multiversx/mx-chain-vm-v1_4-go v1.4.99-0.20241021081009-82e60082ab7a

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/multiversx/mx-chain-scenario-go v1.4.5-0.20240802080531-0906745c04b2
 	github.com/multiversx/mx-chain-storage-go v1.0.19
 	github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20241021074004-c2bdb78da54a
-	github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250204082910-96937fe57603
+	github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250205124044-c1734c751e92
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20241021081333-37461f04f0de
 	github.com/multiversx/mx-chain-vm-v1_3-go v1.3.70-0.20241021081245-2ef08dbcbc2e
 	github.com/multiversx/mx-chain-vm-v1_4-go v1.4.99-0.20241021081009-82e60082ab7a

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/multiversx/mx-chain-storage-go v1.0.19 h1:2R35MoSXcuNJOFmV5xEhcXqiEGZ
 github.com/multiversx/mx-chain-storage-go v1.0.19/go.mod h1:Pb/BuVmiFqO66DSZO16KFkSUeom94x3e3Q9IloBvkYI=
 github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20241021074004-c2bdb78da54a h1:+D5GR9SkHTkKU6fIMZLdSQHeIzbDzOT6fSJfKBG80+g=
 github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20241021074004-c2bdb78da54a/go.mod h1:1rSkXreUZNXyPTTdhj47M+Fy62yjxbu3aAsXEtKN3UY=
-github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250204082910-96937fe57603 h1:QsEFBQ3671sJqOug/Kh3D8PJ00mpfVYBVpjKpa5XWWI=
-github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250204082910-96937fe57603/go.mod h1:DkzpYQIGUpKFoIe5qpW5Ncd3Unq7Fr6A4m8u419+GHU=
+github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250205124044-c1734c751e92 h1:O8Gvo59RgApIvJcm8AxnJCq+qKQ9bu5M/EvknOlMg/Q=
+github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250205124044-c1734c751e92/go.mod h1:DkzpYQIGUpKFoIe5qpW5Ncd3Unq7Fr6A4m8u419+GHU=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20241021081333-37461f04f0de h1:MxwcRm1sFME42bayUaQASyTMCNivcK9luXd64MT/Ozo=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20241021081333-37461f04f0de/go.mod h1:lwcj/pxxKRVVD9MWVrePEdZTRxxbd2XPTlIBhwnYPsA=
 github.com/multiversx/mx-chain-vm-v1_3-go v1.3.70-0.20241021081245-2ef08dbcbc2e h1:NmsXxAAFflQ3hnKjKJ5X6niFaFa4kO4wXI1uCc8nNVo=

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/multiversx/mx-chain-storage-go v1.0.19 h1:2R35MoSXcuNJOFmV5xEhcXqiEGZ
 github.com/multiversx/mx-chain-storage-go v1.0.19/go.mod h1:Pb/BuVmiFqO66DSZO16KFkSUeom94x3e3Q9IloBvkYI=
 github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20241021074004-c2bdb78da54a h1:+D5GR9SkHTkKU6fIMZLdSQHeIzbDzOT6fSJfKBG80+g=
 github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20241021074004-c2bdb78da54a/go.mod h1:1rSkXreUZNXyPTTdhj47M+Fy62yjxbu3aAsXEtKN3UY=
-github.com/multiversx/mx-chain-vm-go v1.5.32-0.20241222212702-7f493a77b009 h1:N6j71XcyQm+zy+eK8/ETc7FaRvMoTaIwoPxp5TSZIJ4=
-github.com/multiversx/mx-chain-vm-go v1.5.32-0.20241222212702-7f493a77b009/go.mod h1:DkzpYQIGUpKFoIe5qpW5Ncd3Unq7Fr6A4m8u419+GHU=
+github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250204082910-96937fe57603 h1:QsEFBQ3671sJqOug/Kh3D8PJ00mpfVYBVpjKpa5XWWI=
+github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250204082910-96937fe57603/go.mod h1:DkzpYQIGUpKFoIe5qpW5Ncd3Unq7Fr6A4m8u419+GHU=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20241021081333-37461f04f0de h1:MxwcRm1sFME42bayUaQASyTMCNivcK9luXd64MT/Ozo=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20241021081333-37461f04f0de/go.mod h1:lwcj/pxxKRVVD9MWVrePEdZTRxxbd2XPTlIBhwnYPsA=
 github.com/multiversx/mx-chain-vm-v1_3-go v1.3.70-0.20241021081245-2ef08dbcbc2e h1:NmsXxAAFflQ3hnKjKJ5X6niFaFa4kO4wXI1uCc8nNVo=


### PR DESCRIPTION
## Proposed changes
- Integrate new version of VM
- Added new VM hook (managedGetAllTransfersCallValue)
- Added new VM hook (managedGetCodeHash)
- Masked errors from libraries (that should remain internal to the VM) with activation epoch
  
## Related PRs:
- https://github.com/multiversx/mx-chain-vm-go/pull/895
- https://github.com/multiversx/mx-chain-vm-go/pull/898
- https://github.com/multiversx/mx-chain-vm-go/pull/897

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
