### PR TITLE
set fork detector checkpoints on bootstrapper applyBlock

### DIFF
--- a/epochStart/shardchain/trigger.go
+++ b/epochStart/shardchain/trigger.go
@@ -585,6 +585,11 @@ func (t *trigger) receivedProof(headerProof data.HeaderProofHandler) {
 // upon receiving checks if trigger can be updated
 func (t *trigger) receivedMetaBlock(headerHandler data.HeaderHandler, metaBlockHash []byte) {
 	if t.enableEpochsHandler.IsFlagEnabledInEpoch(common.EquivalentMessagesFlag, headerHandler.GetEpoch()) {
+		proof, err := t.proofsPool.GetProof(headerHandler.GetShardID(), metaBlockHash)
+		if err != nil {
+			return
+		}
+		t.checkMetaHeaderForEpochTriggerEquivalentProofs(headerHandler, proof.GetHeaderHash())
 		return
 	}
 

--- a/epochStart/shardchain/trigger.go
+++ b/epochStart/shardchain/trigger.go
@@ -589,7 +589,10 @@ func (t *trigger) receivedMetaBlock(headerHandler data.HeaderHandler, metaBlockH
 		if err != nil {
 			return
 		}
+
+		t.mutTrigger.Lock()
 		t.checkMetaHeaderForEpochTriggerEquivalentProofs(headerHandler, proof.GetHeaderHash())
+		t.mutTrigger.Unlock()
 		return
 	}
 

--- a/factory/consensus/consensusComponents.go
+++ b/factory/consensus/consensusComponents.go
@@ -445,6 +445,7 @@ func (ccf *consensusComponentsFactory) createShardBootstrapper() (process.Bootst
 		EpochNotifier:                ccf.coreComponents.EpochNotifier(),
 		ProcessedMiniBlocksTracker:   ccf.processComponents.ProcessedMiniBlocksTracker(),
 		AppStatusHandler:             ccf.statusCoreComponents.AppStatusHandler(),
+		EnableEpochsHandler:          ccf.coreComponents.EnableEpochsHandler(),
 	}
 
 	argsShardStorageBootstrapper := storageBootstrap.ArgsShardStorageBootstrapper{
@@ -579,6 +580,7 @@ func (ccf *consensusComponentsFactory) createMetaChainBootstrapper() (process.Bo
 		EpochNotifier:                ccf.coreComponents.EpochNotifier(),
 		ProcessedMiniBlocksTracker:   ccf.processComponents.ProcessedMiniBlocksTracker(),
 		AppStatusHandler:             ccf.statusCoreComponents.AppStatusHandler(),
+		EnableEpochsHandler:          ccf.coreComponents.EnableEpochsHandler(),
 	}
 
 	argsMetaStorageBootstrapper := storageBootstrap.ArgsMetaStorageBootstrapper{

--- a/factory/mock/forkDetectorMock.go
+++ b/factory/mock/forkDetectorMock.go
@@ -21,6 +21,7 @@ type ForkDetectorMock struct {
 	ResetProbableHighestNonceCalled func()
 	SetFinalToLastCheckpointCalled  func()
 	ReceivedProofCalled             func(proof data.HeaderProofHandler)
+	AddCheckpointCalled             func(nonce uint64, round uint64, hash []byte)
 }
 
 // RestoreToGenesis -
@@ -117,6 +118,13 @@ func (fdm *ForkDetectorMock) SetFinalToLastCheckpoint() {
 func (fdm *ForkDetectorMock) ReceivedProof(proof data.HeaderProofHandler) {
 	if fdm.ReceivedProofCalled != nil {
 		fdm.ReceivedProofCalled(proof)
+	}
+}
+
+// AddCheckpoint -
+func (fdm *ForkDetectorMock) AddCheckpoint(nonce uint64, round uint64, hash []byte) {
+	if fdm.AddCheckpointCalled != nil {
+		fdm.AddCheckpointCalled(nonce, round, hash)
 	}
 }
 

--- a/integrationTests/mock/forkDetectorStub.go
+++ b/integrationTests/mock/forkDetectorStub.go
@@ -21,6 +21,7 @@ type ForkDetectorStub struct {
 	ResetProbableHighestNonceCalled func()
 	SetFinalToLastCheckpointCalled  func()
 	ReceivedProofCalled             func(proof data.HeaderProofHandler)
+	AddCheckpointCalled             func(nonce uint64, round uint64, hash []byte)
 }
 
 // RestoreToGenesis -
@@ -120,6 +121,13 @@ func (fdm *ForkDetectorStub) SetFinalToLastCheckpoint() {
 func (fdm *ForkDetectorStub) ReceivedProof(proof data.HeaderProofHandler) {
 	if fdm.ReceivedProofCalled != nil {
 		fdm.ReceivedProofCalled(proof)
+	}
+}
+
+// AddCheckpoint -
+func (fdm *ForkDetectorStub) AddCheckpoint(nonce uint64, round uint64, hash []byte) {
+	if fdm.AddCheckpointCalled != nil {
+		fdm.AddCheckpointCalled(nonce, round, hash)
 	}
 }
 

--- a/integrationTests/multiShard/endOfEpoch/startInEpoch/startInEpoch_test.go
+++ b/integrationTests/multiShard/endOfEpoch/startInEpoch/startInEpoch_test.go
@@ -364,6 +364,7 @@ func testNodeStartsInEpoch(t *testing.T, shardID uint32, expectedHighestRound ui
 		EpochNotifier:                genericEpochNotifier,
 		ProcessedMiniBlocksTracker:   &testscommon.ProcessedMiniBlocksTrackerStub{},
 		AppStatusHandler:             &statusHandlerMock.AppStatusHandlerMock{},
+		EnableEpochsHandler:          enableEpochsHandler,
 	}
 
 	bootstrapper, err := getBootstrapper(shardID, argsBaseBootstrapper)

--- a/node/mock/forkDetectorMock.go
+++ b/node/mock/forkDetectorMock.go
@@ -21,6 +21,7 @@ type ForkDetectorMock struct {
 	ResetProbableHighestNonceCalled func()
 	SetFinalToLastCheckpointCalled  func()
 	ReceivedProofCalled             func(proof data.HeaderProofHandler)
+	AddCheckpointCalled             func(nonce uint64, round uint64, hash []byte)
 }
 
 // RestoreToGenesis -
@@ -79,6 +80,13 @@ func (fdm *ForkDetectorMock) GetNotarizedHeaderHash(nonce uint64) []byte {
 func (fdm *ForkDetectorMock) ResetProbableHighestNonce() {
 	if fdm.ResetProbableHighestNonceCalled != nil {
 		fdm.ResetProbableHighestNonceCalled()
+	}
+}
+
+// AddCheckpoint -
+func (fdm *ForkDetectorMock) AddCheckpoint(nonce uint64, round uint64, hash []byte) {
+	if fdm.AddCheckpointCalled != nil {
+		fdm.AddCheckpointCalled(nonce, round, hash)
 	}
 }
 

--- a/process/interface.go
+++ b/process/interface.go
@@ -384,6 +384,7 @@ type ForkDetector interface {
 	RestoreToGenesis()
 	GetNotarizedHeaderHash(nonce uint64) []byte
 	ResetProbableHighestNonce()
+	AddCheckpoint(nonce uint64, round uint64, hash []byte)
 	SetFinalToLastCheckpoint()
 	ReceivedProof(proof data.HeaderProofHandler)
 	IsInterfaceNil() bool

--- a/process/mock/forkDetectorMock.go
+++ b/process/mock/forkDetectorMock.go
@@ -21,6 +21,7 @@ type ForkDetectorMock struct {
 	ResetProbableHighestNonceCalled func()
 	SetFinalToLastCheckpointCalled  func()
 	ReceivedProofCalled             func(proof data.HeaderProofHandler)
+	AddCheckpointCalled             func(nonce uint64, round uint64, hash []byte)
 }
 
 // RestoreToGenesis -
@@ -120,6 +121,13 @@ func (fdm *ForkDetectorMock) SetFinalToLastCheckpoint() {
 func (fdm *ForkDetectorMock) ReceivedProof(proof data.HeaderProofHandler) {
 	if fdm.ReceivedProofCalled != nil {
 		fdm.ReceivedProofCalled(proof)
+	}
+}
+
+// AddCheckpoint -
+func (fdm *ForkDetectorMock) AddCheckpoint(nonce uint64, round uint64, hash []byte) {
+	if fdm.AddCheckpointCalled != nil {
+		fdm.AddCheckpointCalled(nonce, round, hash)
 	}
 }
 

--- a/process/sync/baseForkDetector.go
+++ b/process/sync/baseForkDetector.go
@@ -366,6 +366,16 @@ func (bfd *baseForkDetector) addCheckpoint(checkpoint *checkpointInfo) {
 	bfd.mutFork.Unlock()
 }
 
+// AddCheckpoint adds a new checkpoint in the list
+func (bfd *baseForkDetector) AddCheckpoint(nonce uint64, round uint64, hash []byte) {
+	checkpoint := &checkpointInfo{
+		nonce: nonce,
+		round: round,
+		hash:  hash,
+	}
+	bfd.addCheckpoint(checkpoint)
+}
+
 func (bfd *baseForkDetector) lastCheckpoint() *checkpointInfo {
 	bfd.mutFork.RLock()
 	lastIndex := len(bfd.fork.checkpoint) - 1

--- a/process/sync/interface.go
+++ b/process/sync/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/multiversx/mx-chain-core-go/data"
+
 	"github.com/multiversx/mx-chain-go/storage"
 )
 

--- a/process/sync/storageBootstrap/baseStorageBootstrapper.go
+++ b/process/sync/storageBootstrap/baseStorageBootstrapper.go
@@ -449,9 +449,12 @@ func (st *storageBootstrapper) applyBlock(headerHash []byte, header data.HeaderH
 	}
 
 	st.blkc.SetCurrentBlockHeaderHash(headerHash)
+	if !st.enableEpochsHandler.IsFlagEnabledInEpoch(common.EquivalentMessagesFlag, header.GetEpoch()) {
+		return nil
+	}
 
-	if common.ShouldBlockHavePrevProof(header, st.enableEpochsHandler, common.EquivalentMessagesFlag) {
-		st.forkDetector.AddCheckpoint(header.GetNonce(), header.GetRound(), headerHash)
+	st.forkDetector.AddCheckpoint(header.GetNonce(), header.GetRound(), headerHash)
+	if header.GetShardID() == core.MetachainShardId || !check.IfNilReflect(header.GetPreviousProof()) {
 		st.forkDetector.SetFinalToLastCheckpoint()
 	}
 	return nil

--- a/process/sync/storageBootstrap/baseStorageBootstrapper.go
+++ b/process/sync/storageBootstrap/baseStorageBootstrapper.go
@@ -9,6 +9,9 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/typeConverters"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+	logger "github.com/multiversx/mx-chain-logger-go"
+
+	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
@@ -17,7 +20,6 @@ import (
 	"github.com/multiversx/mx-chain-go/sharding"
 	"github.com/multiversx/mx-chain-go/sharding/nodesCoordinator"
 	"github.com/multiversx/mx-chain-go/storage"
-	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
 var log = logger.GetOrCreate("process/sync")
@@ -44,6 +46,7 @@ type ArgsBaseStorageBootstrapper struct {
 	EpochNotifier                process.EpochNotifier
 	ProcessedMiniBlocksTracker   process.ProcessedMiniBlocksTracker
 	AppStatusHandler             core.AppStatusHandler
+	EnableEpochsHandler          common.EnableEpochsHandler
 }
 
 // ArgsShardStorageBootstrapper is structure used to create a new storage bootstrapper for shard
@@ -79,6 +82,7 @@ type storageBootstrapper struct {
 	epochNotifier                process.EpochNotifier
 	processedMiniBlocksTracker   process.ProcessedMiniBlocksTracker
 	appStatusHandler             core.AppStatusHandler
+	enableEpochsHandler          common.EnableEpochsHandler
 }
 
 func (st *storageBootstrapper) loadBlocks() error {
@@ -446,6 +450,10 @@ func (st *storageBootstrapper) applyBlock(headerHash []byte, header data.HeaderH
 
 	st.blkc.SetCurrentBlockHeaderHash(headerHash)
 
+	if st.enableEpochsHandler.IsFlagEnabledInEpoch(common.EquivalentMessagesFlag, header.GetEpoch()) {
+		st.forkDetector.AddCheckpoint(header.GetNonce(), header.GetRound(), headerHash)
+		st.forkDetector.SetFinalToLastCheckpoint()
+	}
 	return nil
 }
 
@@ -512,6 +520,9 @@ func checkBaseStorageBootstrapperArguments(args ArgsBaseStorageBootstrapper) err
 	}
 	if check.IfNil(args.AppStatusHandler) {
 		return process.ErrNilAppStatusHandler
+	}
+	if check.IfNil(args.EnableEpochsHandler) {
+		return process.ErrNilEnableEpochsHandler
 	}
 
 	return nil

--- a/process/sync/storageBootstrap/baseStorageBootstrapper.go
+++ b/process/sync/storageBootstrap/baseStorageBootstrapper.go
@@ -450,7 +450,7 @@ func (st *storageBootstrapper) applyBlock(headerHash []byte, header data.HeaderH
 
 	st.blkc.SetCurrentBlockHeaderHash(headerHash)
 
-	if st.enableEpochsHandler.IsFlagEnabledInEpoch(common.EquivalentMessagesFlag, header.GetEpoch()) {
+	if common.ShouldBlockHavePrevProof(header, st.enableEpochsHandler, common.EquivalentMessagesFlag) {
 		st.forkDetector.AddCheckpoint(header.GetNonce(), header.GetRound(), headerHash)
 		st.forkDetector.SetFinalToLastCheckpoint()
 	}

--- a/process/sync/storageBootstrap/baseStorageBootstrapper_test.go
+++ b/process/sync/storageBootstrap/baseStorageBootstrapper_test.go
@@ -7,20 +7,22 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/mock"
 	"github.com/multiversx/mx-chain-go/storage"
 	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 	epochNotifierMock "github.com/multiversx/mx-chain-go/testscommon/epochNotifier"
 	"github.com/multiversx/mx-chain-go/testscommon/genericMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/shardingMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/statusHandler"
 	storageStubs "github.com/multiversx/mx-chain-go/testscommon/storage"
-	"github.com/stretchr/testify/assert"
 )
 
-func createMockShardStorageBoostrapperArgs() ArgsBaseStorageBootstrapper {
+func createMockShardStorageBootstrapperArgs() ArgsBaseStorageBootstrapper {
 	argsBaseBootstrapper := ArgsBaseStorageBootstrapper{
 		BootStorer:     &mock.BoostrapStorerMock{},
 		ForkDetector:   &mock.ForkDetectorMock{},
@@ -44,6 +46,7 @@ func createMockShardStorageBoostrapperArgs() ArgsBaseStorageBootstrapper {
 		EpochNotifier:                &epochNotifierMock.EpochNotifierStub{},
 		ProcessedMiniBlocksTracker:   &testscommon.ProcessedMiniBlocksTrackerStub{},
 		AppStatusHandler:             &statusHandler.AppStatusHandlerMock{},
+		EnableEpochsHandler:          &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
 	}
 
 	return argsBaseBootstrapper
@@ -55,7 +58,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil bootstorer should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.BootStorer = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -64,7 +67,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil fork detector should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.ForkDetector = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -73,7 +76,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil block processor should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.BlockProcessor = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -82,7 +85,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil chain handler should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.ChainHandler = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -91,7 +94,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil marshaller should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.Marshalizer = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -100,7 +103,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil store should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.Store = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -109,7 +112,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil uint64 converter should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.Uint64Converter = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -118,7 +121,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil shard coordinator should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.ShardCoordinator = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -127,7 +130,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil nodes coordinator should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.NodesCoordinator = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -136,7 +139,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil epoch start trigger should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.EpochStartTrigger = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -145,7 +148,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil block tracker should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.BlockTracker = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -154,7 +157,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil scheduled txs execution should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.ScheduledTxsExecutionHandler = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -163,7 +166,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil miniblocks provider should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.MiniblocksProvider = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -172,7 +175,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil epoch notifier should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.EpochNotifier = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -181,7 +184,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil processed mini blocks tracker should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.ProcessedMiniBlocksTracker = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -190,7 +193,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 	t.Run("nil app status handler - should error", func(t *testing.T) {
 		t.Parallel()
 
-		args := createMockShardStorageBoostrapperArgs()
+		args := createMockShardStorageBootstrapperArgs()
 		args.AppStatusHandler = nil
 
 		err := checkBaseStorageBootstrapperArguments(args)
@@ -201,7 +204,7 @@ func TestBaseStorageBootstrapper_CheckBaseStorageBootstrapperArguments(t *testin
 func TestBaseStorageBootstrapper_RestoreBlockBodyIntoPoolsShouldErrMissingHeader(t *testing.T) {
 	t.Parallel()
 
-	baseArgs := createMockShardStorageBoostrapperArgs()
+	baseArgs := createMockShardStorageBootstrapperArgs()
 	baseArgs.Store = &storageStubs.ChainStorerStub{
 		GetStorerCalled: func(unitType dataRetriever.UnitType) (storage.Storer, error) {
 			return &storageStubs.StorerStub{
@@ -228,7 +231,7 @@ func TestBaseStorageBootstrapper_RestoreBlockBodyIntoPoolsShouldErrMissingBody(t
 	headerHash := []byte("header_hash")
 	header := &block.Header{}
 
-	baseArgs := createMockShardStorageBoostrapperArgs()
+	baseArgs := createMockShardStorageBootstrapperArgs()
 	baseArgs.MiniblocksProvider = &mock.MiniBlocksProviderStub{
 		GetMiniBlocksFromStorerCalled: func(hashes [][]byte) ([]*block.MiniblockAndHash, [][]byte) {
 			return nil, [][]byte{[]byte("missing_hash")}
@@ -258,7 +261,7 @@ func TestBaseStorageBootstrapper_RestoreBlockBodyIntoPoolsShouldErrWhenRestoreBl
 	headerHash := []byte("header_hash")
 	header := &block.Header{}
 
-	baseArgs := createMockShardStorageBoostrapperArgs()
+	baseArgs := createMockShardStorageBootstrapperArgs()
 	baseArgs.MiniblocksProvider = &mock.MiniBlocksProviderStub{
 		GetMiniBlocksFromStorerCalled: func(hashes [][]byte) ([]*block.MiniblockAndHash, [][]byte) {
 			return nil, nil
@@ -292,7 +295,7 @@ func TestBaseStorageBootstrapper_RestoreBlockBodyIntoPoolsShouldWork(t *testing.
 	headerHash := []byte("header_hash")
 	header := &block.Header{}
 
-	baseArgs := createMockShardStorageBoostrapperArgs()
+	baseArgs := createMockShardStorageBootstrapperArgs()
 	baseArgs.MiniblocksProvider = &mock.MiniBlocksProviderStub{
 		GetMiniBlocksFromStorerCalled: func(hashes [][]byte) ([]*block.MiniblockAndHash, [][]byte) {
 			return nil, nil
@@ -325,7 +328,7 @@ func TestBaseStorageBootstrapper_GetBlockBodyShouldErrMissingBody(t *testing.T) 
 
 	header := &block.Header{}
 
-	baseArgs := createMockShardStorageBoostrapperArgs()
+	baseArgs := createMockShardStorageBootstrapperArgs()
 	baseArgs.MiniblocksProvider = &mock.MiniBlocksProviderStub{
 		GetMiniBlocksFromStorerCalled: func(hashes [][]byte) ([]*block.MiniblockAndHash, [][]byte) {
 			return nil, [][]byte{[]byte("missing_hash")}
@@ -370,7 +373,7 @@ func TestBaseStorageBootstrapper_GetBlockBodyShouldWork(t *testing.T) {
 	}
 	header := &block.Header{}
 
-	baseArgs := createMockShardStorageBoostrapperArgs()
+	baseArgs := createMockShardStorageBootstrapperArgs()
 	baseArgs.MiniblocksProvider = &mock.MiniBlocksProviderStub{
 		GetMiniBlocksFromStorerCalled: func(hashes [][]byte) ([]*block.MiniblockAndHash, [][]byte) {
 			return mbAndHashes, nil

--- a/process/sync/storageBootstrap/metaStorageBootstrapper.go
+++ b/process/sync/storageBootstrap/metaStorageBootstrapper.go
@@ -3,6 +3,7 @@ package storageBootstrap
 import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
+
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
@@ -41,6 +42,7 @@ func NewMetaStorageBootstrapper(arguments ArgsMetaStorageBootstrapper) (*metaSto
 		epochNotifier:                arguments.EpochNotifier,
 		processedMiniBlocksTracker:   arguments.ProcessedMiniBlocksTracker,
 		appStatusHandler:             arguments.AppStatusHandler,
+		enableEpochsHandler:          arguments.EnableEpochsHandler,
 	}
 
 	boot := metaStorageBootstrapper{

--- a/process/sync/storageBootstrap/shardStorageBootstrapper.go
+++ b/process/sync/storageBootstrap/shardStorageBootstrapper.go
@@ -4,6 +4,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
@@ -42,6 +43,7 @@ func NewShardStorageBootstrapper(arguments ArgsShardStorageBootstrapper) (*shard
 		epochNotifier:                arguments.EpochNotifier,
 		processedMiniBlocksTracker:   arguments.ProcessedMiniBlocksTracker,
 		appStatusHandler:             arguments.AppStatusHandler,
+		enableEpochsHandler:          arguments.EnableEpochsHandler,
 	}
 
 	boot := shardStorageBootstrapper{

--- a/process/sync/storageBootstrap/shardStorageBootstrapper_test.go
+++ b/process/sync/storageBootstrap/shardStorageBootstrapper_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
@@ -15,14 +18,13 @@ import (
 	"github.com/multiversx/mx-chain-go/process/sync"
 	"github.com/multiversx/mx-chain-go/storage"
 	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 	epochNotifierMock "github.com/multiversx/mx-chain-go/testscommon/epochNotifier"
 	"github.com/multiversx/mx-chain-go/testscommon/genericMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
 	"github.com/multiversx/mx-chain-go/testscommon/shardingMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/statusHandler"
 	storageMock "github.com/multiversx/mx-chain-go/testscommon/storage"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestShardStorageBootstrapper_LoadFromStorageShouldWork(t *testing.T) {
@@ -136,6 +138,7 @@ func TestShardStorageBootstrapper_LoadFromStorageShouldWork(t *testing.T) {
 			},
 			ProcessedMiniBlocksTracker: &testscommon.ProcessedMiniBlocksTrackerStub{},
 			AppStatusHandler:           &statusHandler.AppStatusHandlerMock{},
+			EnableEpochsHandler:        &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
 		},
 	}
 
@@ -153,7 +156,7 @@ func TestShardStorageBootstrapper_LoadFromStorageShouldWork(t *testing.T) {
 }
 
 func TestShardStorageBootstrapper_CleanupNotarizedStorageForHigherNoncesIfExist(t *testing.T) {
-	baseArgs := createMockShardStorageBoostrapperArgs()
+	baseArgs := createMockShardStorageBootstrapperArgs()
 
 	bForceError := true
 	numCalled := 0

--- a/testscommon/processMocks/forkDetectorStub.go
+++ b/testscommon/processMocks/forkDetectorStub.go
@@ -21,6 +21,7 @@ type ForkDetectorStub struct {
 	ResetProbableHighestNonceCalled func()
 	SetFinalToLastCheckpointCalled  func()
 	ReceivedProofCalled             func(proof data.HeaderProofHandler)
+	AddCheckpointCalled             func(nonce uint64, round uint64, hash []byte)
 }
 
 // RestoreToGenesis -
@@ -99,6 +100,13 @@ func (fdm *ForkDetectorStub) SetFinalToLastCheckpoint() {
 func (fdm *ForkDetectorStub) ReceivedProof(proof data.HeaderProofHandler) {
 	if fdm.ReceivedProofCalled != nil {
 		fdm.ReceivedProofCalled(proof)
+	}
+}
+
+// AddCheckpoint -
+func (fdm *ForkDetectorStub) AddCheckpoint(nonce uint64, round uint64, hash []byte) {
+	if fdm.AddCheckpointCalled != nil {
+		fdm.AddCheckpointCalled(nonce, round, hash)
 	}
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request
- bootstrapping after shuffling to other shards with equivalent proofs does not always succeed
  
## Proposed changes
- after applying the previously stored block, if this block has proofs, set the fork detector correspondingly.

## Testing procedure
- 


## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
