### PR TITLE
Fix some long tests

### DIFF
--- a/integrationTests/chainSimulator/mempool/mempool_test.go
+++ b/integrationTests/chainSimulator/mempool/mempool_test.go
@@ -324,7 +324,8 @@ func TestMempoolWithChainSimulator_Eviction(t *testing.T) {
 		Signature: []byte("signature"),
 	})
 
-	time.Sleep(2 * time.Second)
+	// Allow the eviction to complete (even if it's quite fast).
+	time.Sleep(3 * time.Second)
 
 	expectedNumTransactionsInPool := 300_000 + 1 + 1 - int(storage.TxPoolSourceMeNumItemsToPreemptivelyEvict)
 	require.Equal(t, expectedNumTransactionsInPool, getNumTransactionsInPool(simulator, shard))

--- a/integrationTests/chainSimulator/mempool/testutils_test.go
+++ b/integrationTests/chainSimulator/mempool/testutils_test.go
@@ -24,8 +24,8 @@ import (
 var (
 	oneEGLD                   = big.NewInt(1000000000000000000)
 	oneQuarterOfEGLD          = big.NewInt(250000000000000000)
-	durationWaitAfterSendMany = 1500 * time.Millisecond
-	durationWaitAfterSendSome = 50 * time.Millisecond
+	durationWaitAfterSendMany = 3000 * time.Millisecond
+	durationWaitAfterSendSome = 300 * time.Millisecond
 )
 
 func startChainSimulator(t *testing.T, alterConfigsFunction func(cfg *config.Configs)) testsChainSimulator.ChainSimulator {

--- a/integrationTests/vm/wasm/queries/queries_test.go
+++ b/integrationTests/vm/wasm/queries/queries_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-go/integrationTests"
@@ -132,6 +133,9 @@ func deploy(t *testing.T, network *integrationTests.MiniNetwork, sender []byte, 
 	)
 	require.NoError(t, err)
 
+	// Allow the transaction to reach the mempool.
+	time.Sleep(100 * time.Millisecond)
+
 	scAddress, _ := network.ShardNode.BlockchainHook.NewAddress(sender, 0, factory.WasmVirtualMachine)
 	return scAddress
 }
@@ -148,6 +152,9 @@ func setState(t *testing.T, network *integrationTests.MiniNetwork, scAddress []b
 	)
 
 	require.NoError(t, err)
+
+	// Allow the transaction to reach the mempool.
+	time.Sleep(100 * time.Millisecond)
 }
 
 func getState(t *testing.T, node *integrationTests.TestProcessorNode, scAddress []byte, blockNonce core.OptionalUint64) int {


### PR DESCRIPTION
## Reasoning behind the pull request
- Some long tests were failing at times (flaky).
  
## Proposed changes
- Increase some sleep times, to allow test transactions to fully propagate / reach mempool.

Changes were verified by running the tests in question in a loop:

```
while go clean -testcache && go test ./...; do sleep 1; done
```

## Testing procedure
- No additional testing is needed.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
