### PR TITLE
vm integration for backtransfers improvements

### DIFF
--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -339,6 +339,9 @@
     # MaskVMInternalDependenciesErrorsEnableEpoch represents the epoch when the additional internal erorr masking in vm is enabled
     MaskVMInternalDependenciesErrorsEnableEpoch = 2
 
+    # FixBackTransferOPCODEEnableEpoch represents the epoch when the fix for back transfers opcode will be enabled
+    FixBackTransferOPCODEEnableEpoch = 2
+
     # BLSMultiSignerEnableEpoch represents the activation epoch for different types of BLS multi-signers
     BLSMultiSignerEnableEpoch = [
         { EnableEpoch = 0, Type = "no-KOSK" },

--- a/common/constants.go
+++ b/common/constants.go
@@ -743,6 +743,12 @@ const (
 	// MetricRelayedTransactionsV3EnableEpoch represents the epoch when the relayed transactions v3 are enabled
 	MetricRelayedTransactionsV3EnableEpoch = "erd_relayed_transactions_v3_enable_epoch"
 
+	// MetricMaskVMInternalDependenciesErrorsEnableEpoch represents the epoch when the additional internal erorr masking in vm is enabled
+	MetricMaskVMInternalDependenciesErrorsEnableEpoch = "erd_mask_vm_internal_dependencies_errors_enable_epoch"
+
+	// MetricFixBackTransferOPCODEEnableEpoch represents the epoch when the fix for back transfers opcode will be enabled
+	MetricFixBackTransferOPCODEEnableEpoch = "erd_fix_back_transfer_opcode_enable_epoch"
+
 	// MetricMaxNodesChangeEnableEpoch holds configuration for changing the maximum number of nodes and the enabling epoch
 	MetricMaxNodesChangeEnableEpoch = "erd_max_nodes_change_enable_epoch"
 

--- a/common/constants.go
+++ b/common/constants.go
@@ -1242,5 +1242,6 @@ const (
 	FixRelayedMoveBalanceToNonPayableSCFlag            core.EnableEpochFlag = "FixRelayedMoveBalanceToNonPayableSCFlag"
 	RelayedTransactionsV3Flag                          core.EnableEpochFlag = "RelayedTransactionsV3Flag"
 	MaskInternalDependenciesErrorsFlag                 core.EnableEpochFlag = "MaskInternalDependenciesErrorsFlag"
+	FixBackTransferOPCODEFlag                          core.EnableEpochFlag = "FixBackTransferOPCODEFlag"
 	// all new flags must be added to createAllFlagsMap method, as part of enableEpochsHandler allFlagsDefined
 )

--- a/common/enablers/enableEpochsHandler.go
+++ b/common/enablers/enableEpochsHandler.go
@@ -792,6 +792,12 @@ func (handler *enableEpochsHandler) createAllFlagsMap() {
 			},
 			activationEpoch: handler.enableEpochsConfig.MaskVMInternalDependenciesErrorsEnableEpoch,
 		},
+		common.FixBackTransferOPCODEFlag: {
+			isActiveInEpoch: func(epoch uint32) bool {
+				return epoch >= handler.enableEpochsConfig.FixBackTransferOPCODEEnableEpoch
+			},
+			activationEpoch: handler.enableEpochsConfig.FixBackTransferOPCODEEnableEpoch,
+		},
 	}
 }
 

--- a/common/enablers/enableEpochsHandler_test.go
+++ b/common/enablers/enableEpochsHandler_test.go
@@ -124,6 +124,8 @@ func createEnableEpochsConfig() config.EnableEpochs {
 		FixRelayedMoveBalanceToNonPayableSCEnableEpoch:           107,
 		UseGasBoundedShouldFailExecutionEnableEpoch:              108,
 		RelayedTransactionsV3EnableEpoch:                         109,
+		MaskVMInternalDependenciesErrorsEnableEpoch:              110,
+		FixBackTransferOPCODEEnableEpoch:                         111,
 	}
 }
 
@@ -450,6 +452,8 @@ func TestEnableEpochsHandler_GetActivationEpoch(t *testing.T) {
 	require.Equal(t, cfg.MultiESDTNFTTransferAndExecuteByUserEnableEpoch, handler.GetActivationEpoch(common.MultiESDTNFTTransferAndExecuteByUserFlag))
 	require.Equal(t, cfg.FixRelayedMoveBalanceToNonPayableSCEnableEpoch, handler.GetActivationEpoch(common.FixRelayedMoveBalanceToNonPayableSCFlag))
 	require.Equal(t, cfg.RelayedTransactionsV3EnableEpoch, handler.GetActivationEpoch(common.RelayedTransactionsV3Flag))
+	require.Equal(t, cfg.MaskVMInternalDependenciesErrorsEnableEpoch, handler.GetActivationEpoch(common.MaskInternalDependenciesErrorsFlag))
+	require.Equal(t, cfg.FixBackTransferOPCODEEnableEpoch, handler.GetActivationEpoch(common.FixBackTransferOPCODEFlag))
 }
 
 func TestEnableEpochsHandler_IsInterfaceNil(t *testing.T) {

--- a/config/epochConfig.go
+++ b/config/epochConfig.go
@@ -124,6 +124,7 @@ type EnableEpochs struct {
 	FixRelayedMoveBalanceToNonPayableSCEnableEpoch           uint32
 	RelayedTransactionsV3EnableEpoch                         uint32
 	MaskVMInternalDependenciesErrorsEnableEpoch              uint32
+	FixBackTransferOPCODEEnableEpoch                         uint32
 	BLSMultiSignerEnableEpoch                                []MultiSignerConfig
 }
 

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -890,6 +890,12 @@ func TestEnableEpochConfig(t *testing.T) {
 	# RelayedTransactionsV3EnableEpoch represents the epoch when the relayed transactions v3 will be enabled
     RelayedTransactionsV3EnableEpoch = 103
 
+	# MaskVMInternalDependenciesErrorsEnableEpoch represents the epoch when the additional internal erorr masking in vm is enabled
+	MaskVMInternalDependenciesErrorsEnableEpoch = 104
+
+	# FixBackTransferOPCODEEnableEpoch represents the epoch when the fix for back transfers opcode will be enabled
+	FixBackTransferOPCODEEnableEpoch = 105
+
     # MaxNodesChangeEnableEpoch holds configuration for changing the maximum number of nodes and the enabling epoch
     MaxNodesChangeEnableEpoch = [
         { EpochEnable = 44, MaxNumNodes = 2169, NodesToShufflePerShard = 80 },
@@ -1011,6 +1017,8 @@ func TestEnableEpochConfig(t *testing.T) {
 			MultiESDTNFTTransferAndExecuteByUserEnableEpoch:          101,
 			FixRelayedMoveBalanceToNonPayableSCEnableEpoch:           102,
 			RelayedTransactionsV3EnableEpoch:                         103,
+			MaskVMInternalDependenciesErrorsEnableEpoch:              104,
+			FixBackTransferOPCODEEnableEpoch:                         105,
 			MaxNodesChangeEnableEpoch: []MaxNodesChangeConfig{
 				{
 					EpochEnable:            44,

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/multiversx/mx-chain-scenario-go v1.4.5-0.20240802080531-0906745c04b2
 	github.com/multiversx/mx-chain-storage-go v1.0.19
 	github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20241021074004-c2bdb78da54a
-	github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250205124044-c1734c751e92
+	github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250210130748-6543e4ca65ea
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20241021081333-37461f04f0de
 	github.com/multiversx/mx-chain-vm-v1_3-go v1.3.70-0.20241021081245-2ef08dbcbc2e
 	github.com/multiversx/mx-chain-vm-v1_4-go v1.4.99-0.20241021081009-82e60082ab7a

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/multiversx/mx-chain-storage-go v1.0.19 h1:2R35MoSXcuNJOFmV5xEhcXqiEGZ
 github.com/multiversx/mx-chain-storage-go v1.0.19/go.mod h1:Pb/BuVmiFqO66DSZO16KFkSUeom94x3e3Q9IloBvkYI=
 github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20241021074004-c2bdb78da54a h1:+D5GR9SkHTkKU6fIMZLdSQHeIzbDzOT6fSJfKBG80+g=
 github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20241021074004-c2bdb78da54a/go.mod h1:1rSkXreUZNXyPTTdhj47M+Fy62yjxbu3aAsXEtKN3UY=
-github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250205124044-c1734c751e92 h1:O8Gvo59RgApIvJcm8AxnJCq+qKQ9bu5M/EvknOlMg/Q=
-github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250205124044-c1734c751e92/go.mod h1:DkzpYQIGUpKFoIe5qpW5Ncd3Unq7Fr6A4m8u419+GHU=
+github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250210130748-6543e4ca65ea h1:j8R/l/tWPQ68ebpuBCxtbdS5uRHPZY3cbwsjnPNcQH8=
+github.com/multiversx/mx-chain-vm-go v1.5.32-0.20250210130748-6543e4ca65ea/go.mod h1:DkzpYQIGUpKFoIe5qpW5Ncd3Unq7Fr6A4m8u419+GHU=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20241021081333-37461f04f0de h1:MxwcRm1sFME42bayUaQASyTMCNivcK9luXd64MT/Ozo=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20241021081333-37461f04f0de/go.mod h1:lwcj/pxxKRVVD9MWVrePEdZTRxxbd2XPTlIBhwnYPsA=
 github.com/multiversx/mx-chain-vm-v1_3-go v1.3.70-0.20241021081245-2ef08dbcbc2e h1:NmsXxAAFflQ3hnKjKJ5X6niFaFa4kO4wXI1uCc8nNVo=

--- a/node/metrics/metrics.go
+++ b/node/metrics/metrics.go
@@ -203,6 +203,8 @@ func InitConfigMetrics(
 	appStatusHandler.SetUInt64Value(common.MetricMultiESDTNFTTransferAndExecuteByUserEnableEpoch, uint64(enableEpochs.MultiESDTNFTTransferAndExecuteByUserEnableEpoch))
 	appStatusHandler.SetUInt64Value(common.MetricFixRelayedMoveBalanceToNonPayableSCEnableEpoch, uint64(enableEpochs.FixRelayedMoveBalanceToNonPayableSCEnableEpoch))
 	appStatusHandler.SetUInt64Value(common.MetricRelayedTransactionsV3EnableEpoch, uint64(enableEpochs.RelayedTransactionsV3EnableEpoch))
+	appStatusHandler.SetUInt64Value(common.MetricMaskVMInternalDependenciesErrorsEnableEpoch, uint64(enableEpochs.MaskVMInternalDependenciesErrorsEnableEpoch))
+	appStatusHandler.SetUInt64Value(common.MetricFixBackTransferOPCODEEnableEpoch, uint64(enableEpochs.FixBackTransferOPCODEEnableEpoch))
 
 	for i, nodesChangeConfig := range enableEpochs.MaxNodesChangeEnableEpoch {
 		epochEnable := fmt.Sprintf("%s%d%s", common.MetricMaxNodesChangeEnableEpoch, i, common.EpochEnableSuffix)

--- a/node/metrics/metrics_test.go
+++ b/node/metrics/metrics_test.go
@@ -212,6 +212,8 @@ func TestInitConfigMetrics(t *testing.T) {
 			MultiESDTNFTTransferAndExecuteByUserEnableEpoch:          105,
 			FixRelayedMoveBalanceToNonPayableSCEnableEpoch:           106,
 			RelayedTransactionsV3EnableEpoch:                         107,
+			MaskVMInternalDependenciesErrorsEnableEpoch:              108,
+			FixBackTransferOPCODEEnableEpoch:                         109,
 			MaxNodesChangeEnableEpoch: []config.MaxNodesChangeConfig{
 				{
 					EpochEnable:            0,
@@ -334,6 +336,8 @@ func TestInitConfigMetrics(t *testing.T) {
 		"erd_multi_esdt_transfer_execute_by_user_enable_epoch":                 uint32(105),
 		"erd_fix_relayed_move_balance_to_non_payable_sc_enable_epoch":          uint32(106),
 		"erd_relayed_transactions_v3_enable_epoch":                             uint32(107),
+		"erd_mask_vm_internal_dependencies_errors_enable_epoch":                uint32(108),
+		"erd_fix_back_transfer_opcode_enable_epoch":                            uint32(109),
 		"erd_max_nodes_change_enable_epoch":                                    nil,
 		"erd_total_supply":                                                     "12345",
 		"erd_hysteresis":                                                       "0.100000",

--- a/statusHandler/statusMetricsProvider.go
+++ b/statusHandler/statusMetricsProvider.go
@@ -381,6 +381,8 @@ func (sm *statusMetrics) EnableEpochsMetrics() (map[string]interface{}, error) {
 	enableEpochsMetrics[common.MetricMultiESDTNFTTransferAndExecuteByUserEnableEpoch] = sm.uint64Metrics[common.MetricMultiESDTNFTTransferAndExecuteByUserEnableEpoch]
 	enableEpochsMetrics[common.MetricFixRelayedMoveBalanceToNonPayableSCEnableEpoch] = sm.uint64Metrics[common.MetricFixRelayedMoveBalanceToNonPayableSCEnableEpoch]
 	enableEpochsMetrics[common.MetricRelayedTransactionsV3EnableEpoch] = sm.uint64Metrics[common.MetricRelayedTransactionsV3EnableEpoch]
+	enableEpochsMetrics[common.MetricMaskVMInternalDependenciesErrorsEnableEpoch] = sm.uint64Metrics[common.MetricMaskVMInternalDependenciesErrorsEnableEpoch]
+	enableEpochsMetrics[common.MetricFixBackTransferOPCODEEnableEpoch] = sm.uint64Metrics[common.MetricFixBackTransferOPCODEEnableEpoch]
 
 	numNodesChangeConfig := sm.uint64Metrics[common.MetricMaxNodesChangeEnableEpoch+"_count"]
 

--- a/statusHandler/statusMetricsProvider_test.go
+++ b/statusHandler/statusMetricsProvider_test.go
@@ -405,6 +405,8 @@ func TestStatusMetrics_EnableEpochMetrics(t *testing.T) {
 	sm.SetUInt64Value(common.MetricMultiESDTNFTTransferAndExecuteByUserEnableEpoch, uint64(4))
 	sm.SetUInt64Value(common.MetricFixRelayedMoveBalanceToNonPayableSCEnableEpoch, uint64(4))
 	sm.SetUInt64Value(common.MetricRelayedTransactionsV3EnableEpoch, uint64(4))
+	sm.SetUInt64Value(common.MetricMaskVMInternalDependenciesErrorsEnableEpoch, uint64(4))
+	sm.SetUInt64Value(common.MetricFixBackTransferOPCODEEnableEpoch, uint64(4))
 
 	maxNodesChangeConfig := []map[string]uint64{
 		{
@@ -537,6 +539,8 @@ func TestStatusMetrics_EnableEpochMetrics(t *testing.T) {
 		common.MetricMultiESDTNFTTransferAndExecuteByUserEnableEpoch:          uint64(4),
 		common.MetricFixRelayedMoveBalanceToNonPayableSCEnableEpoch:           uint64(4),
 		common.MetricRelayedTransactionsV3EnableEpoch:                         uint64(4),
+		common.MetricMaskVMInternalDependenciesErrorsEnableEpoch:              uint64(4),
+		common.MetricFixBackTransferOPCODEEnableEpoch:                         uint64(4),
 
 		common.MetricMaxNodesChangeEnableEpoch: []map[string]interface{}{
 			{


### PR DESCRIPTION
## Reasoning behind the pull request
- Integrate new VM with backtransfer OPCODE improvements/fixes

## Related PRs:
- https://github.com/multiversx/mx-chain-vm-go/pull/899

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
