### PR TITLE
fix state changes collector index out of bounds

### DIFF
--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -538,7 +538,7 @@ func (adb *AccountsDB) saveDataTrie(accountHandler baseAccountHandler) ([]*state
 		return nil, err
 	}
 	accountHandler.SetRootHash(rootHash)
-	log.Trace("saveDataTrie: rootHash changed", "address", accountHandler.AddressBytes())
+	log.Trace("saveDataTrie: rootHash changed", "address", accountHandler.AddressBytes(), "rootHash", rootHash)
 
 	if check.IfNil(adb.dataTries.Get(accountHandler.AddressBytes())) {
 		trie, ok := accountHandler.DataTrie().(common.Trie)

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -1147,7 +1147,13 @@ func (adb *AccountsDB) journalize(entry JournalEntry) {
 		"entry type", fmt.Sprintf("%T", entry),
 	)
 
-	_ = adb.stateChangesCollector.SetIndexToLastStateChange(len(adb.entries))
+	err := adb.stateChangesCollector.SetIndexToLastStateChange(len(adb.entries))
+	if err != nil {
+		log.Trace("failed to set index to last state change",
+			"num journal entries", len(adb.entries),
+			"error", err.Error(),
+		)
+	}
 
 	if len(adb.entries) == 1 {
 		adb.stackDebug = debug.Stack()

--- a/state/accountsDB_test.go
+++ b/state/accountsDB_test.go
@@ -1701,6 +1701,11 @@ func TestAccountsDB_saveCode_OldCodeIsNilAndNewCodeIsNotNilAndRevert(t *testing.
 	hasher := &hashingMocks.HasherMock{}
 	tr, adb := getDefaultTrieAndAccountsDb()
 
+	dummyAcc, err := adb.LoadAccount(bytes.Repeat([]byte{1}, 32))
+	assert.Nil(t, err)
+	err = adb.SaveAccount(dummyAcc)
+	assert.Nil(t, err)
+
 	addr := make([]byte, 32)
 	acc, _ := adb.LoadAccount(addr)
 	userAcc := acc.(state.UserAccountHandler)
@@ -1709,7 +1714,7 @@ func TestAccountsDB_saveCode_OldCodeIsNilAndNewCodeIsNotNilAndRevert(t *testing.
 	userAcc.SetCode(code)
 	expectedCodeHash := hasher.Compute(string(code))
 
-	err := adb.SaveAccount(userAcc)
+	err = adb.SaveAccount(userAcc)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedCodeHash, userAcc.GetCodeHash())
 

--- a/state/journalEntries.go
+++ b/state/journalEntries.go
@@ -193,13 +193,15 @@ func (jedtu *journalEntryDataTrieUpdates) Revert() (vmcommon.AccountHandler, err
 		return nil, fmt.Errorf("invalid trie, type is %T", jedtu.account.DataTrie())
 	}
 
-	for _, trieUpdate := range jedtu.trieUpdates {
+	for i := len(jedtu.trieUpdates) - 1; i >= 0; i-- {
+		trieUpdate := jedtu.trieUpdates[i]
 		err := trie.UpdateWithVersion(trieUpdate.Key, trieUpdate.Value, trieUpdate.Version)
 		if err != nil {
 			return nil, err
 		}
 
 		log.Trace("revert data trie update",
+			"address", jedtu.account.AddressBytes(),
 			"key", trieUpdate.Key,
 			"val", trieUpdate.Value,
 			"version", trieUpdate.Version,

--- a/state/stateChanges/collector.go
+++ b/state/stateChanges/collector.go
@@ -208,8 +208,13 @@ func (c *collector) SetIndexToLastStateChange(index int) error {
 		return nil
 	}
 
-	log.Trace("set index to last state change", "index", index)
-	c.stateChanges[len(c.stateChanges)-1].SetIndex(int32(index))
+	for i := len(c.stateChanges) - 1; i >= 0; i-- {
+		if c.stateChanges[i].GetIndex() != 0 {
+			return nil
+		}
+		log.Trace("set index to last state change", "stateChange num", i, "index", index)
+		c.stateChanges[i].SetIndex(int32(index))
+	}
 
 	return nil
 }

--- a/state/stateChanges/collector.go
+++ b/state/stateChanges/collector.go
@@ -200,7 +200,7 @@ func (c *collector) SetIndexToLastStateChange(index int) error {
 	c.stateChangesMut.Lock()
 	defer c.stateChangesMut.Unlock()
 
-	if index > len(c.stateChanges) || index < 0 {
+	if index < 0 {
 		return fmt.Errorf("SetIndexToLastStateChange: %w for index %v, num state changes %v", state.ErrStateChangesIndexOutOfBounds, index, len(c.stateChanges))
 	}
 
@@ -216,7 +216,7 @@ func (c *collector) SetIndexToLastStateChange(index int) error {
 
 // RevertToIndex will revert to index
 func (c *collector) RevertToIndex(index int) error {
-	if index > len(c.stateChanges) || index < 0 {
+	if index < 0 {
 		return fmt.Errorf("RevertToIndex: %w for index %v, num state changes %v", state.ErrStateChangesIndexOutOfBounds, index, len(c.stateChanges))
 	}
 

--- a/state/stateChanges/collector.go
+++ b/state/stateChanges/collector.go
@@ -231,7 +231,7 @@ func (c *collector) RevertToIndex(index int) error {
 	log.Trace("num state changes before revert", "num", len(c.stateChanges))
 	for i := len(c.stateChanges) - 1; i >= 0; i-- {
 		if c.stateChanges[i].GetIndex() == int32(index) {
-			c.stateChanges = c.stateChanges[:i]
+			c.stateChanges = c.stateChanges[:i+1]
 			log.Trace("reverted to index", "index", index, "num state changes after revert", len(c.stateChanges))
 			break
 		}

--- a/state/stateChanges/collector_test.go
+++ b/state/stateChanges/collector_test.go
@@ -205,7 +205,7 @@ func TestStateChangesCollector_RevertToIndex_FailIfWrongIndex(t *testing.T) {
 	require.True(t, errors.Is(err, state.ErrStateChangesIndexOutOfBounds))
 
 	err = c.RevertToIndex(numStateChanges + 1)
-	require.True(t, errors.Is(err, state.ErrStateChangesIndexOutOfBounds))
+	require.Nil(t, err)
 }
 
 func TestStateChangesCollector_RevertToIndex(t *testing.T) {
@@ -254,7 +254,7 @@ func TestStateChangesCollector_RevertToIndex(t *testing.T) {
 func TestStateChangesCollector_SetIndexToLastStateChange(t *testing.T) {
 	t.Parallel()
 
-	t.Run("should fail if valid index", func(t *testing.T) {
+	t.Run("should fail if invalid index", func(t *testing.T) {
 		t.Parallel()
 
 		c := NewCollector(WithCollectWrite())
@@ -264,7 +264,7 @@ func TestStateChangesCollector_SetIndexToLastStateChange(t *testing.T) {
 
 		numStateChanges := len(c.stateChanges)
 		err = c.SetIndexToLastStateChange(numStateChanges + 1)
-		require.True(t, errors.Is(err, state.ErrStateChangesIndexOutOfBounds))
+		require.Nil(t, err)
 	})
 
 	t.Run("should work", func(t *testing.T) {

--- a/state/stateChanges/collector_test.go
+++ b/state/stateChanges/collector_test.go
@@ -232,19 +232,19 @@ func TestStateChangesCollector_RevertToIndex(t *testing.T) {
 
 	err = c.RevertToIndex(numStateChanges)
 	require.Nil(t, err)
-	assert.Equal(t, numStateChanges*2-1, len(c.stateChanges))
+	assert.Equal(t, numStateChanges*2, len(c.stateChanges))
 
 	err = c.RevertToIndex(numStateChanges - 1)
 	require.Nil(t, err)
-	assert.Equal(t, numStateChanges-1, len(c.stateChanges))
+	assert.Equal(t, numStateChanges, len(c.stateChanges))
 
 	err = c.RevertToIndex(numStateChanges / 2)
 	require.Nil(t, err)
-	assert.Equal(t, numStateChanges/2, len(c.stateChanges))
+	assert.Equal(t, numStateChanges/2+1, len(c.stateChanges))
 
 	err = c.RevertToIndex(1)
 	require.Nil(t, err)
-	assert.Equal(t, 1, len(c.stateChanges))
+	assert.Equal(t, 2, len(c.stateChanges))
 
 	err = c.RevertToIndex(0)
 	require.Nil(t, err)

--- a/state/trackableDataTrie/trackableDataTrie.go
+++ b/state/trackableDataTrie/trackableDataTrie.go
@@ -107,21 +107,6 @@ func (tdt *trackableDataTrie) RetrieveValue(key []byte) ([]byte, uint32, error) 
 
 	log.Trace("retrieve value from trie", "key", key, "value", val, "account", tdt.identifier)
 
-	sc := &stateChange.StateChange{
-		Type:        stateChange.Read,
-		MainTrieKey: tdt.identifier,
-		MainTrieVal: nil,
-		DataTrieChanges: []*stateChange.DataTrieChange{
-			{
-				Type:    stateChange.Read,
-				Key:     key,
-				Val:     val,
-				Version: uint32(trieValue.Version),
-			},
-		},
-	}
-	tdt.stateChangesCollector.AddStateChange(sc)
-
 	return val, depth, nil
 }
 
@@ -164,6 +149,7 @@ func (tdt *trackableDataTrie) MigrateDataTrieLeaves(args vmcommon.ArgsMigrateDat
 	dataToBeMigrated := args.TrieMigrator.GetLeavesToBeMigrated()
 	log.Debug("num leaves to be migrated", "num", len(dataToBeMigrated), "account", tdt.identifier)
 	for _, leafData := range dataToBeMigrated {
+		tdt.collectReadOperation(leafData.Key, leafData.Value, uint32(leafData.Version))
 		val, err := tdt.getValueWithoutMetadata(leafData.Key, leafData)
 		if err != nil {
 			return err
@@ -354,6 +340,23 @@ func (tdt *trackableDataTrie) updateTrie(dtr state.DataTrie) ([]*stateChange.Dat
 	return stateChanges, oldValues, nil
 }
 
+func (tdt *trackableDataTrie) collectReadOperation(key []byte, val []byte, version uint32) {
+	sc := &stateChange.StateChange{
+		Type:        stateChange.Read,
+		MainTrieKey: tdt.identifier,
+		MainTrieVal: nil,
+		DataTrieChanges: []*stateChange.DataTrieChange{
+			{
+				Type:    stateChange.Read,
+				Key:     key,
+				Val:     val,
+				Version: version,
+			},
+		},
+	}
+	tdt.stateChangesCollector.AddStateChange(sc)
+}
+
 func (tdt *trackableDataTrie) retrieveValueFromTrie(key []byte) (core.TrieData, uint32, error) {
 	if tdt.enableEpochsHandler.IsFlagEnabled(common.AutoBalanceDataTriesFlag) {
 		hashedKey := tdt.hasher.Compute(string(key))
@@ -361,6 +364,9 @@ func (tdt *trackableDataTrie) retrieveValueFromTrie(key []byte) (core.TrieData, 
 		if err != nil {
 			return core.TrieData{}, 0, err
 		}
+
+		tdt.collectReadOperation(hashedKey, valWithMetadata, uint32(core.AutoBalanceEnabled))
+
 		if len(valWithMetadata) != 0 {
 			trieValue := core.TrieData{
 				Key:     hashedKey,
@@ -376,6 +382,7 @@ func (tdt *trackableDataTrie) retrieveValueFromTrie(key []byte) (core.TrieData, 
 	if err != nil {
 		return core.TrieData{}, 0, err
 	}
+	tdt.collectReadOperation(key, valWithMetadata, uint32(core.NotSpecified))
 	if len(valWithMetadata) != 0 {
 		trieValue := core.TrieData{
 			Key:     key,


### PR DESCRIPTION
## Reasoning behind the pull request
- State changes collector should not return err if snapshot ID number if higher than number of collected state changes, it should just set snapshot ID index to last collected state change

## Testing procedure
- to be tested with feature branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
