### PR TITLE
check shard data only on meta nodes in interceptor

### DIFF
--- a/process/block/interceptedBlocks/common.go
+++ b/process/block/interceptedBlocks/common.go
@@ -126,6 +126,10 @@ func checkMetaShardInfo(
 	coordinator sharding.Coordinator,
 	headerSigVerifier process.InterceptedHeaderSigVerifier,
 ) error {
+	if coordinator.SelfId() != core.MetachainShardId {
+		return nil
+	}
+
 	wgProofsVerification := sync.WaitGroup{}
 
 	errChan := make(chan error, len(shardInfo))

--- a/process/block/interceptedBlocks/common_test.go
+++ b/process/block/interceptedBlocks/common_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-go/process"
@@ -346,10 +347,33 @@ func TestCheckMetaShardInfo_WithNilOrEmptyShouldReturnNil(t *testing.T) {
 	assert.Nil(t, err2)
 }
 
+func TestCheckMetaShardInfo_ShouldNotCheckShardInfoForShards(t *testing.T) {
+	t.Parallel()
+
+	shardCoordinator := mock.NewOneShardCoordinatorMock()
+	shardCoordinator.SetSelfId(1)
+
+	sd := block.ShardData{}
+
+	wasCalled := false
+	verifier := &consensus.HeaderSigVerifierMock{
+		VerifyHeaderProofCalled: func(proofHandler data.HeaderProofHandler) error {
+			wasCalled = true
+			return nil
+		},
+	}
+
+	err := checkMetaShardInfo([]data.ShardDataHandler{&sd}, shardCoordinator, verifier)
+
+	assert.Nil(t, err)
+	assert.False(t, wasCalled)
+}
+
 func TestCheckMetaShardInfo_WrongShardIdShouldErr(t *testing.T) {
 	t.Parallel()
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
+	shardCoordinator.SetSelfId(core.MetachainShardId)
 	wrongShardId := uint32(2)
 	sd := block.ShardData{
 		ShardID:               wrongShardId,
@@ -367,6 +391,7 @@ func TestCheckMetaShardInfo_WrongMiniblockSenderShardIdShouldErr(t *testing.T) {
 	t.Parallel()
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
+	shardCoordinator.SetSelfId(core.MetachainShardId)
 	wrongShardId := uint32(2)
 	miniBlock := block.MiniBlockHeader{
 		Hash:            make([]byte, 0),
@@ -391,6 +416,7 @@ func TestCheckMetaShardInfo_WrongMiniblockReceiverShardIdShouldErr(t *testing.T)
 	t.Parallel()
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
+	shardCoordinator.SetSelfId(core.MetachainShardId)
 	wrongShardId := uint32(2)
 	miniBlock := block.MiniBlockHeader{
 		Hash:            make([]byte, 0),
@@ -415,6 +441,8 @@ func TestCheckMetaShardInfo_ReservedPopulatedShouldErr(t *testing.T) {
 	t.Parallel()
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
+	shardCoordinator.SetSelfId(core.MetachainShardId)
+
 	miniBlock := block.MiniBlockHeader{
 		Hash:            make([]byte, 0),
 		ReceiverShardID: shardCoordinator.SelfId(),
@@ -439,6 +467,7 @@ func TestCheckMetaShardInfo_OkValsShouldWork(t *testing.T) {
 	t.Parallel()
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
+	shardCoordinator.SetSelfId(core.MetachainShardId)
 	miniBlock := block.MiniBlockHeader{
 		Hash:            make([]byte, 0),
 		ReceiverShardID: shardCoordinator.SelfId(),
@@ -469,6 +498,7 @@ func TestCheckMetaShardInfo_WithMultipleShardData(t *testing.T) {
 		t.Parallel()
 
 		shardCoordinator := mock.NewOneShardCoordinatorMock()
+		shardCoordinator.SetSelfId(core.MetachainShardId)
 		wrongShardId := uint32(2)
 		miniBlock1 := block.MiniBlockHeader{
 			Hash:            make([]byte, 0),
@@ -515,6 +545,7 @@ func TestCheckMetaShardInfo_WithMultipleShardData(t *testing.T) {
 		t.Parallel()
 
 		shardCoordinator := mock.NewOneShardCoordinatorMock()
+		shardCoordinator.SetSelfId(core.MetachainShardId)
 		miniBlock1 := block.MiniBlockHeader{
 			Hash:            make([]byte, 0),
 			ReceiverShardID: shardCoordinator.SelfId(),
@@ -566,6 +597,7 @@ func TestCheckMetaShardInfo_FewShardDataErrorShouldReturnError(t *testing.T) {
 	t.Parallel()
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
+	shardCoordinator.SetSelfId(core.MetachainShardId)
 	miniBlock := block.MiniBlockHeader{
 		Hash:            make([]byte, 0),
 		ReceiverShardID: shardCoordinator.SelfId(),

--- a/process/block/interceptedBlocks/common_test.go
+++ b/process/block/interceptedBlocks/common_test.go
@@ -351,7 +351,7 @@ func TestCheckMetaShardInfo_ShouldNotCheckShardInfoForShards(t *testing.T) {
 	t.Parallel()
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
-	shardCoordinator.SetSelfId(1)
+	_ = shardCoordinator.SetSelfId(1)
 
 	sd := block.ShardData{}
 
@@ -373,7 +373,7 @@ func TestCheckMetaShardInfo_WrongShardIdShouldErr(t *testing.T) {
 	t.Parallel()
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
-	shardCoordinator.SetSelfId(core.MetachainShardId)
+	_ = shardCoordinator.SetSelfId(core.MetachainShardId)
 	wrongShardId := uint32(2)
 	sd := block.ShardData{
 		ShardID:               wrongShardId,
@@ -391,7 +391,7 @@ func TestCheckMetaShardInfo_WrongMiniblockSenderShardIdShouldErr(t *testing.T) {
 	t.Parallel()
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
-	shardCoordinator.SetSelfId(core.MetachainShardId)
+	_ = shardCoordinator.SetSelfId(core.MetachainShardId)
 	wrongShardId := uint32(2)
 	miniBlock := block.MiniBlockHeader{
 		Hash:            make([]byte, 0),
@@ -416,7 +416,7 @@ func TestCheckMetaShardInfo_WrongMiniblockReceiverShardIdShouldErr(t *testing.T)
 	t.Parallel()
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
-	shardCoordinator.SetSelfId(core.MetachainShardId)
+	_ = shardCoordinator.SetSelfId(core.MetachainShardId)
 	wrongShardId := uint32(2)
 	miniBlock := block.MiniBlockHeader{
 		Hash:            make([]byte, 0),
@@ -441,7 +441,7 @@ func TestCheckMetaShardInfo_ReservedPopulatedShouldErr(t *testing.T) {
 	t.Parallel()
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
-	shardCoordinator.SetSelfId(core.MetachainShardId)
+	_ = shardCoordinator.SetSelfId(core.MetachainShardId)
 
 	miniBlock := block.MiniBlockHeader{
 		Hash:            make([]byte, 0),
@@ -467,7 +467,7 @@ func TestCheckMetaShardInfo_OkValsShouldWork(t *testing.T) {
 	t.Parallel()
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
-	shardCoordinator.SetSelfId(core.MetachainShardId)
+	_ = shardCoordinator.SetSelfId(core.MetachainShardId)
 	miniBlock := block.MiniBlockHeader{
 		Hash:            make([]byte, 0),
 		ReceiverShardID: shardCoordinator.SelfId(),
@@ -498,7 +498,7 @@ func TestCheckMetaShardInfo_WithMultipleShardData(t *testing.T) {
 		t.Parallel()
 
 		shardCoordinator := mock.NewOneShardCoordinatorMock()
-		shardCoordinator.SetSelfId(core.MetachainShardId)
+		_ = shardCoordinator.SetSelfId(core.MetachainShardId)
 		wrongShardId := uint32(2)
 		miniBlock1 := block.MiniBlockHeader{
 			Hash:            make([]byte, 0),
@@ -545,7 +545,7 @@ func TestCheckMetaShardInfo_WithMultipleShardData(t *testing.T) {
 		t.Parallel()
 
 		shardCoordinator := mock.NewOneShardCoordinatorMock()
-		shardCoordinator.SetSelfId(core.MetachainShardId)
+		_ = shardCoordinator.SetSelfId(core.MetachainShardId)
 		miniBlock1 := block.MiniBlockHeader{
 			Hash:            make([]byte, 0),
 			ReceiverShardID: shardCoordinator.SelfId(),
@@ -597,7 +597,7 @@ func TestCheckMetaShardInfo_FewShardDataErrorShouldReturnError(t *testing.T) {
 	t.Parallel()
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
-	shardCoordinator.SetSelfId(core.MetachainShardId)
+	_ = shardCoordinator.SetSelfId(core.MetachainShardId)
 	miniBlock := block.MiniBlockHeader{
 		Hash:            make([]byte, 0),
 		ReceiverShardID: shardCoordinator.SelfId(),

--- a/process/block/interceptedBlocks/interceptedMetaBlockHeader_test.go
+++ b/process/block/interceptedBlocks/interceptedMetaBlockHeader_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
 	dataBlock "github.com/multiversx/mx-chain-core-go/data/block"
@@ -14,13 +15,19 @@ import (
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/block/interceptedBlocks"
 	"github.com/multiversx/mx-chain-go/process/mock"
+	"github.com/multiversx/mx-chain-go/sharding"
 	"github.com/multiversx/mx-chain-go/testscommon/consensus"
 	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 )
 
 func createDefaultMetaArgument() *interceptedBlocks.ArgInterceptedBlockHeader {
+	shardCoordinator := mock.NewOneShardCoordinatorMock()
+	return createMetaArgumentWithShardCoordinator(shardCoordinator)
+}
+
+func createMetaArgumentWithShardCoordinator(shardCoordinator sharding.Coordinator) *interceptedBlocks.ArgInterceptedBlockHeader {
 	arg := &interceptedBlocks.ArgInterceptedBlockHeader{
-		ShardCoordinator:        mock.NewOneShardCoordinatorMock(),
+		ShardCoordinator:        shardCoordinator,
 		Hasher:                  testHasher,
 		Marshalizer:             testMarshalizer,
 		HeaderSigVerifier:       &consensus.HeaderSigVerifierMock{},
@@ -132,7 +139,10 @@ func TestInterceptedMetaHeader_ErrorInMiniBlockShouldErr(t *testing.T) {
 	}
 	buff, _ := testMarshalizer.Marshal(hdr)
 
-	arg := createDefaultMetaArgument()
+	shardCoordinator := mock.NewOneShardCoordinatorMock()
+	shardCoordinator.SetSelfId(core.MetachainShardId)
+
+	arg := createMetaArgumentWithShardCoordinator(shardCoordinator)
 	arg.HdrBuff = buff
 	inHdr, _ := interceptedBlocks.NewInterceptedMetaHeader(arg)
 

--- a/process/block/interceptedBlocks/interceptedMetaBlockHeader_test.go
+++ b/process/block/interceptedBlocks/interceptedMetaBlockHeader_test.go
@@ -140,7 +140,7 @@ func TestInterceptedMetaHeader_ErrorInMiniBlockShouldErr(t *testing.T) {
 	buff, _ := testMarshalizer.Marshal(hdr)
 
 	shardCoordinator := mock.NewOneShardCoordinatorMock()
-	shardCoordinator.SetSelfId(core.MetachainShardId)
+	_ = shardCoordinator.SetSelfId(core.MetachainShardId)
 
 	arg := createMetaArgumentWithShardCoordinator(shardCoordinator)
 	arg.HdrBuff = buff


### PR DESCRIPTION
## Reasoning behind the pull request
- Adapt meta header interceptor to check shard data proof only on metachain nodes
- On shard nodes we don't need to have these additional checks, if there is a proof for the received metachain we can conclude that it reached consensus

## Testing procedure
- TBD

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
