### PR TITLE
add state statistics for search first

### DIFF
--- a/storage/pruning/pruningStorer.go
+++ b/storage/pruning/pruningStorer.go
@@ -578,6 +578,7 @@ func (ps *PruningStorer) GetBulkFromEpoch(keys [][]byte, epoch uint32) ([]data.K
 func (ps *PruningStorer) SearchFirst(key []byte) ([]byte, error) {
 	v, ok := ps.cacher.Get(key)
 	if ok {
+		ps.stateStatsHandler.IncrementCache()
 		return v.([]byte), nil
 	}
 
@@ -589,6 +590,7 @@ func (ps *PruningStorer) SearchFirst(key []byte) ([]byte, error) {
 	for _, pd := range ps.activePersisters {
 		res, err = pd.getPersister().Get(key)
 		if err == nil {
+			ps.stateStatsHandler.IncrementPersister(pd.epoch)
 			return res, nil
 		}
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- Add state statistics for `SearchFirst` operation in PrunningStorer

## Testing procedure
- TBD

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
