### PR TITLE
integrate transfer and execute with return error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/multiversx/mx-chain-scenario-go v1.5.1-0.20250218162624-877d8b9870a4
 	github.com/multiversx/mx-chain-storage-go v1.0.20-0.20250218162234-85e60acebb43
 	github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20250218162215-88938774627c
-	github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250218163500-604d44bde745
+	github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250304111815-8b8e7254cac1
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20250220133402-01591d72f671
 	github.com/multiversx/mx-chain-vm-v1_3-go v1.3.70-0.20250220133720-4abbb3b36387
 	github.com/multiversx/mx-chain-vm-v1_4-go v1.4.99-0.20250220144348-9455d2a4e6e6

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/multiversx/mx-chain-scenario-go v1.5.1-0.20250218162624-877d8b9870a4
 	github.com/multiversx/mx-chain-storage-go v1.0.20-0.20250218162234-85e60acebb43
 	github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20250218162215-88938774627c
-	github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250306091050-44c62de4acba
+	github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250314090058-95d1f8738ed8
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20250220133402-01591d72f671
 	github.com/multiversx/mx-chain-vm-v1_3-go v1.3.70-0.20250220133720-4abbb3b36387
 	github.com/multiversx/mx-chain-vm-v1_4-go v1.4.99-0.20250220144348-9455d2a4e6e6

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/multiversx/mx-chain-scenario-go v1.5.1-0.20250218162624-877d8b9870a4
 	github.com/multiversx/mx-chain-storage-go v1.0.20-0.20250218162234-85e60acebb43
 	github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20250218162215-88938774627c
-	github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250304111815-8b8e7254cac1
+	github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250306091050-44c62de4acba
 	github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20250220133402-01591d72f671
 	github.com/multiversx/mx-chain-vm-v1_3-go v1.3.70-0.20250220133720-4abbb3b36387
 	github.com/multiversx/mx-chain-vm-v1_4-go v1.4.99-0.20250220144348-9455d2a4e6e6

--- a/go.sum
+++ b/go.sum
@@ -415,8 +415,8 @@ github.com/multiversx/mx-chain-storage-go v1.0.20-0.20250218162234-85e60acebb43 
 github.com/multiversx/mx-chain-storage-go v1.0.20-0.20250218162234-85e60acebb43/go.mod h1:tTVMcXx0UWdMymMv3N8b1D1P1XSQwfyGK6xwMlRoONo=
 github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20250218162215-88938774627c h1:4L3SY1so6MwfmfO7+MGOhGtDxhVW5PtW6JG48sZmHNE=
 github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20250218162215-88938774627c/go.mod h1:NGcFCdOnbpEdk042ixTgD6xavRFQ7ap0z3kBhTXKlDQ=
-github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250304111815-8b8e7254cac1 h1:Sc+rD5V0Of0oSdA4N5Agiy33UVJbZ+oOVC6J8o/3oKg=
-github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250304111815-8b8e7254cac1/go.mod h1:ee6MdfII+4DRrfMfEEzrhLiq7r2HZ4oKr/vAGHn8En8=
+github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250306091050-44c62de4acba h1:jw+InBPex7oNs51bSvRfqeo1cKiZcjAWexi63wHldPU=
+github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250306091050-44c62de4acba/go.mod h1:ee6MdfII+4DRrfMfEEzrhLiq7r2HZ4oKr/vAGHn8En8=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20250220133402-01591d72f671 h1:xTbDPTaJQ0evqELiXQ4a1pinEAvoE7Y6/cmj4MUjzDA=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20250220133402-01591d72f671/go.mod h1:QbNaHsEseQvrAT81VtbwUTTWPMrbDCDoXRJsY0V+1KU=
 github.com/multiversx/mx-chain-vm-v1_3-go v1.3.70-0.20250220133720-4abbb3b36387 h1:B0AMhrWhUIN7HHNHTpfDJHAopTUHFjx8YVMDkb3++WA=

--- a/go.sum
+++ b/go.sum
@@ -415,8 +415,8 @@ github.com/multiversx/mx-chain-storage-go v1.0.20-0.20250218162234-85e60acebb43 
 github.com/multiversx/mx-chain-storage-go v1.0.20-0.20250218162234-85e60acebb43/go.mod h1:tTVMcXx0UWdMymMv3N8b1D1P1XSQwfyGK6xwMlRoONo=
 github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20250218162215-88938774627c h1:4L3SY1so6MwfmfO7+MGOhGtDxhVW5PtW6JG48sZmHNE=
 github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20250218162215-88938774627c/go.mod h1:NGcFCdOnbpEdk042ixTgD6xavRFQ7ap0z3kBhTXKlDQ=
-github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250218163500-604d44bde745 h1:aCKp9XDJvKQuKALq0ey0Ztqd/RyzTLTzD8jlpUOZUUA=
-github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250218163500-604d44bde745/go.mod h1:ee6MdfII+4DRrfMfEEzrhLiq7r2HZ4oKr/vAGHn8En8=
+github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250304111815-8b8e7254cac1 h1:Sc+rD5V0Of0oSdA4N5Agiy33UVJbZ+oOVC6J8o/3oKg=
+github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250304111815-8b8e7254cac1/go.mod h1:ee6MdfII+4DRrfMfEEzrhLiq7r2HZ4oKr/vAGHn8En8=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20250220133402-01591d72f671 h1:xTbDPTaJQ0evqELiXQ4a1pinEAvoE7Y6/cmj4MUjzDA=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20250220133402-01591d72f671/go.mod h1:QbNaHsEseQvrAT81VtbwUTTWPMrbDCDoXRJsY0V+1KU=
 github.com/multiversx/mx-chain-vm-v1_3-go v1.3.70-0.20250220133720-4abbb3b36387 h1:B0AMhrWhUIN7HHNHTpfDJHAopTUHFjx8YVMDkb3++WA=

--- a/go.sum
+++ b/go.sum
@@ -415,8 +415,8 @@ github.com/multiversx/mx-chain-storage-go v1.0.20-0.20250218162234-85e60acebb43 
 github.com/multiversx/mx-chain-storage-go v1.0.20-0.20250218162234-85e60acebb43/go.mod h1:tTVMcXx0UWdMymMv3N8b1D1P1XSQwfyGK6xwMlRoONo=
 github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20250218162215-88938774627c h1:4L3SY1so6MwfmfO7+MGOhGtDxhVW5PtW6JG48sZmHNE=
 github.com/multiversx/mx-chain-vm-common-go v1.5.17-0.20250218162215-88938774627c/go.mod h1:NGcFCdOnbpEdk042ixTgD6xavRFQ7ap0z3kBhTXKlDQ=
-github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250306091050-44c62de4acba h1:jw+InBPex7oNs51bSvRfqeo1cKiZcjAWexi63wHldPU=
-github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250306091050-44c62de4acba/go.mod h1:ee6MdfII+4DRrfMfEEzrhLiq7r2HZ4oKr/vAGHn8En8=
+github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250314090058-95d1f8738ed8 h1:4d3uh867GNhpMGPalUM/Ny11+mTBUgNfkQtxDZs4nY4=
+github.com/multiversx/mx-chain-vm-go v1.5.38-0.20250314090058-95d1f8738ed8/go.mod h1:ee6MdfII+4DRrfMfEEzrhLiq7r2HZ4oKr/vAGHn8En8=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20250220133402-01591d72f671 h1:xTbDPTaJQ0evqELiXQ4a1pinEAvoE7Y6/cmj4MUjzDA=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.69-0.20250220133402-01591d72f671/go.mod h1:QbNaHsEseQvrAT81VtbwUTTWPMrbDCDoXRJsY0V+1KU=
 github.com/multiversx/mx-chain-vm-v1_3-go v1.3.70-0.20250220133720-4abbb3b36387 h1:B0AMhrWhUIN7HHNHTpfDJHAopTUHFjx8YVMDkb3++WA=

--- a/integrationTests/vm/esdt/forwarderMock.go
+++ b/integrationTests/vm/esdt/forwarderMock.go
@@ -69,7 +69,9 @@ func SyncMultiTransferMock(instanceMock *mock.InstanceMock, config interface{}) 
 			big.NewInt(0),
 			[]byte(callData.Function()),
 			scAddress,
-			callData.ElementsAsBytes())
+			callData.ElementsAsBytes(),
+			true,
+		)
 
 		return instance
 	})

--- a/integrationTests/vm/esdt/localFuncs/localEsdtNft.go
+++ b/integrationTests/vm/esdt/localFuncs/localEsdtNft.go
@@ -28,7 +28,9 @@ func LocalMintMock(instanceMock *mock.InstanceMock, config interface{}) {
 			big.NewInt(0),
 			[]byte(callData.Function()),
 			scAddress,
-			callData.ElementsAsBytes())
+			callData.ElementsAsBytes(),
+			true,
+		)
 
 		return instance
 	})
@@ -54,7 +56,9 @@ func LocalBurnMock(instanceMock *mock.InstanceMock, config interface{}) {
 			big.NewInt(0),
 			[]byte(callData.Function()),
 			scAddress,
-			callData.ElementsAsBytes())
+			callData.ElementsAsBytes(),
+			true,
+		)
 
 		return instance
 	})


### PR DESCRIPTION
## Reasoning behind the pull request
- Integrate new version of VM with the new transfer and execute and return error hook.
  
## Related PRs
- https://github.com/multiversx/mx-chain-vm-go/pull/907

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
