### PR TITLE
Mempool: sketch new endpoint for PPU histogram

### DIFF
--- a/api/mock/facadeStub.go
+++ b/api/mock/facadeStub.go
@@ -83,6 +83,7 @@ type FacadeStub struct {
 	GetTransactionsPoolForSenderCalled          func(sender, fields string) (*common.TransactionsPoolForSenderApiResponse, error)
 	GetLastPoolNonceForSenderCalled             func(sender string) (uint64, error)
 	GetTransactionsPoolNonceGapsForSenderCalled func(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error)
+	BuildTransactionsPPUHistogramCalled         func() (*common.TransactionsPPUHistogram, error)
 	GetGasConfigsCalled                         func() (map[string]map[string]uint64, error)
 	RestApiInterfaceCalled                      func() string
 	RestAPIServerDebugModeCalled                func() bool
@@ -647,6 +648,15 @@ func (f *FacadeStub) GetLastPoolNonceForSender(sender string) (uint64, error) {
 func (f *FacadeStub) GetTransactionsPoolNonceGapsForSender(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
 	if f.GetTransactionsPoolNonceGapsForSenderCalled != nil {
 		return f.GetTransactionsPoolNonceGapsForSenderCalled(sender)
+	}
+
+	return nil, nil
+}
+
+// BuildTransactionsPPUHistogram -
+func (f *FacadeStub) BuildTransactionsPPUHistogram() (*common.TransactionsPPUHistogram, error) {
+	if f.BuildTransactionsPPUHistogramCalled != nil {
+		return f.BuildTransactionsPPUHistogramCalled()
 	}
 
 	return nil, nil

--- a/api/shared/interface.go
+++ b/api/shared/interface.go
@@ -128,6 +128,7 @@ type FacadeHandler interface {
 	GetTransactionsPoolForSender(sender, fields string) (*common.TransactionsPoolForSenderApiResponse, error)
 	GetLastPoolNonceForSender(sender string) (uint64, error)
 	GetTransactionsPoolNonceGapsForSender(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error)
+	BuildTransactionsPPUHistogram() (*common.TransactionsPPUHistogram, error)
 	IsDataTrieMigrated(address string, options api.AccountQueryOptions) (bool, error)
 	GetManagedKeysCount() int
 	GetManagedKeys() []string

--- a/cmd/node/config/api.toml
+++ b/cmd/node/config/api.toml
@@ -219,6 +219,9 @@
         # /transaction/pool?by-sender=erd1...&nonce-gaps=true will return all nonce gaps for the sender from the pool, if applicable
         { Name = "/pool", Open = true },
 
+        # /pool/ppu-histogram will return the PPU histogram for transactions in the pool
+        { Name = "/pool/ppu-histogram", Open = true },
+
         # /transaction/:txhash will return the transaction in JSON format based on its hash
         { Name = "/:txhash", Open = true },
 

--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -590,7 +590,8 @@
     EndpointsThrottlers = [{ Endpoint = "/transaction/:hash", MaxNumGoRoutines = 10 },
                            { Endpoint = "/transaction/send", MaxNumGoRoutines = 2 },
                            { Endpoint = "/transaction/simulate", MaxNumGoRoutines = 1 },
-                           { Endpoint = "/transaction/send-multiple", MaxNumGoRoutines = 2 }]
+                           { Endpoint = "/transaction/send-multiple", MaxNumGoRoutines = 2 },
+                           { Endpoint = "/pool/ppu-histogram", MaxNumGoRoutines = 1 }]
 
 [AddressPubkeyConverter]
     Length = 32

--- a/common/dtos.go
+++ b/common/dtos.go
@@ -42,6 +42,18 @@ type TransactionsPoolNonceGapsForSenderApiResponse struct {
 	Gaps   []NonceGapApiResponse `json:"gaps"`
 }
 
+// TransactionsPPUHistogram is a struct that holds the data to be returned when getting the transactions PPU histogram
+type TransactionsPPUHistogram struct {
+	Bins []TransactionsPPUHistogramBin `json:"bins"`
+}
+
+// TransactionsPPUHistogramBin is a struct that holds the data for a bin of the transactions PPU histogram
+type TransactionsPPUHistogramBin struct {
+	FromPPU  uint64 `json:"from"`
+	ToPPU    uint64 `json:"to"`
+	TotalGas uint64 `json:"gas"`
+}
+
 // DelegationDataAPI will be used when requesting the genesis balances from API
 type DelegationDataAPI struct {
 	Address string `json:"address"`

--- a/facade/initial/initialNodeFacade.go
+++ b/facade/initial/initialNodeFacade.go
@@ -411,6 +411,11 @@ func (inf *initialNodeFacade) GetTransactionsPoolForSender(_, _ string) (*common
 	return nil, errNodeStarting
 }
 
+// BuildTransactionsPPUHistogram returns nil and error
+func (inf *initialNodeFacade) BuildTransactionsPPUHistogram() (*common.TransactionsPPUHistogram, error) {
+	return nil, errNodeStarting
+}
+
 // GetGasConfigs return a nil map and error
 func (inf *initialNodeFacade) GetGasConfigs() (map[string]map[string]uint64, error) {
 	return nil, errNodeStarting

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -132,6 +132,7 @@ type ApiResolver interface {
 	GetTransactionsPoolForSender(sender, fields string) (*common.TransactionsPoolForSenderApiResponse, error)
 	GetLastPoolNonceForSender(sender string) (uint64, error)
 	GetTransactionsPoolNonceGapsForSender(sender string, senderAccountNonce uint64) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error)
+	BuildTransactionsPPUHistogram() (*common.TransactionsPPUHistogram, error)
 	GetBlockByHash(hash string, options api.BlockQueryOptions) (*api.Block, error)
 	GetBlockByNonce(nonce uint64, options api.BlockQueryOptions) (*api.Block, error)
 	GetBlockByRound(round uint64, options api.BlockQueryOptions) (*api.Block, error)

--- a/facade/mock/apiResolverStub.go
+++ b/facade/mock/apiResolverStub.go
@@ -43,6 +43,7 @@ type ApiResolverStub struct {
 	GetTransactionsPoolForSenderCalled          func(sender, fields string) (*common.TransactionsPoolForSenderApiResponse, error)
 	GetLastPoolNonceForSenderCalled             func(sender string) (uint64, error)
 	GetTransactionsPoolNonceGapsForSenderCalled func(sender string, senderAccountNonce uint64) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error)
+	BuildTransactionsPPUHistogramCalled         func() (*common.TransactionsPPUHistogram, error)
 	GetGasConfigsCalled                         func() map[string]map[string]uint64
 	GetManagedKeysCountCalled                   func() int
 	GetManagedKeysCalled                        func() []string
@@ -232,6 +233,15 @@ func (ars *ApiResolverStub) GetLastPoolNonceForSender(sender string) (uint64, er
 func (ars *ApiResolverStub) GetTransactionsPoolNonceGapsForSender(sender string, senderAccountNonce uint64) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
 	if ars.GetTransactionsPoolNonceGapsForSenderCalled != nil {
 		return ars.GetTransactionsPoolNonceGapsForSenderCalled(sender, senderAccountNonce)
+	}
+
+	return nil, nil
+}
+
+// BuildTransactionsPPUHistogram -
+func (ars *ApiResolverStub) BuildTransactionsPPUHistogram() (*common.TransactionsPPUHistogram, error) {
+	if ars.BuildTransactionsPPUHistogramCalled != nil {
+		return ars.BuildTransactionsPPUHistogramCalled()
 	}
 
 	return nil, nil

--- a/facade/nodeFacade.go
+++ b/facade/nodeFacade.go
@@ -334,6 +334,11 @@ func (nf *nodeFacade) GetTransactionsPoolNonceGapsForSender(sender string) (*com
 	return nf.apiResolver.GetTransactionsPoolNonceGapsForSender(sender, accountResponse.Nonce)
 }
 
+// BuildTransactionsPPUHistogram will build and return the transactions PPU histogram
+func (nf *nodeFacade) BuildTransactionsPPUHistogram() (*common.TransactionsPPUHistogram, error) {
+	return nf.apiResolver.BuildTransactionsPPUHistogram()
+}
+
 // ComputeTransactionGasLimit will estimate how many gas a transaction will consume
 func (nf *nodeFacade) ComputeTransactionGasLimit(tx *transaction.Transaction) (*transaction.CostResponse, error) {
 	return nf.apiResolver.ComputeTransactionGasLimit(tx)

--- a/integrationTests/interface.go
+++ b/integrationTests/interface.go
@@ -110,6 +110,7 @@ type Facade interface {
 	GetTransactionsPoolForSender(sender, fields string) (*common.TransactionsPoolForSenderApiResponse, error)
 	GetLastPoolNonceForSender(sender string) (uint64, error)
 	GetTransactionsPoolNonceGapsForSender(sender string) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error)
+	BuildTransactionsPPUHistogram() (*common.TransactionsPPUHistogram, error)
 	GetAlteredAccountsForBlock(options dataApi.GetAlteredAccountsForBlockOptions) ([]*alteredAccount.AlteredAccount, error)
 	IsDataTrieMigrated(address string, options api.AccountQueryOptions) (bool, error)
 	GetManagedKeysCount() int

--- a/node/external/interface.go
+++ b/node/external/interface.go
@@ -66,6 +66,7 @@ type APITransactionHandler interface {
 	GetTransactionsPoolForSender(sender, fields string) (*common.TransactionsPoolForSenderApiResponse, error)
 	GetLastPoolNonceForSender(sender string) (uint64, error)
 	GetTransactionsPoolNonceGapsForSender(sender string, senderAccountNonce uint64) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error)
+	BuildTransactionsPPUHistogram() (*common.TransactionsPPUHistogram, error)
 	UnmarshalTransaction(txBytes []byte, txType transaction.TxType) (*transaction.ApiTransactionResult, error)
 	PopulateComputedFields(tx *transaction.ApiTransactionResult)
 	UnmarshalReceipt(receiptBytes []byte) (*transaction.ApiReceipt, error)

--- a/node/external/nodeApiResolver.go
+++ b/node/external/nodeApiResolver.go
@@ -214,6 +214,11 @@ func (nar *nodeApiResolver) GetTransactionsPoolNonceGapsForSender(sender string,
 	return nar.apiTransactionHandler.GetTransactionsPoolNonceGapsForSender(sender, senderAccountNonce)
 }
 
+// BuildTransactionsPPUHistogram will build and return the transactions PPU histogram
+func (nar *nodeApiResolver) BuildTransactionsPPUHistogram() (*common.TransactionsPPUHistogram, error) {
+	return nar.apiTransactionHandler.BuildTransactionsPPUHistogram()
+}
+
 // GetBlockByHash will return the block with the given hash and optionally with transactions
 func (nar *nodeApiResolver) GetBlockByHash(hash string, options api.BlockQueryOptions) (*api.Block, error) {
 	decodedHash, err := hex.DecodeString(hash)

--- a/node/external/transactionAPI/apiTransactionProcessor.go
+++ b/node/external/transactionAPI/apiTransactionProcessor.go
@@ -492,6 +492,22 @@ func (atp *apiTransactionProcessor) appendGapFromAccountNonceIfNeeded(
 	}
 }
 
+// BuildTransactionsPPUHistogram builds and returns the transactions PPU histogram
+func (atp *apiTransactionProcessor) BuildTransactionsPPUHistogram() (*common.TransactionsPPUHistogram, error) {
+	selfShard := atp.shardCoordinator.SelfId()
+
+	// We are only interested into the "source is me" cache.
+	// Below, calling "ShardCacherIdentifier(selfShard, selfShard)" actually means "source is me" (workaround).
+	cacheId := process.ShardCacherIdentifier(selfShard, selfShard)
+	cache := atp.dataPool.Transactions().ShardDataStore(cacheId)
+	txCache, ok := cache.(*txcache.TxCache)
+	if !ok {
+		return nil, fmt.Errorf("%w, cache has unexpected type: %T", ErrCannotRetrieveTransactions, cache)
+	}
+
+	return txCache.BuildTransactionsPPUHistogram()
+}
+
 func (atp *apiTransactionProcessor) optionallyGetTransactionFromPool(hash []byte) *transaction.ApiTransactionResult {
 	txObj, txType, found := atp.getTxObjFromDataPool(hash)
 	if !found {

--- a/node/external/transactionAPI/errors.go
+++ b/node/external/transactionAPI/errors.go
@@ -29,6 +29,9 @@ var ErrNilDataFieldParser = errors.New("nil data field parser")
 // ErrCannotRetrieveTransactions signals that transactions cannot be retrieved
 var ErrCannotRetrieveTransactions = errors.New("transactions cannot be retrieved")
 
+// ErrCannotBuildTransactionsPPUHistogram signals that the transactions PPU histogram cannot be built
+var ErrCannotBuildTransactionsPPUHistogram = errors.New("transactions PPU histogram cannot be built")
+
 // ErrInvalidAddress signals that the address is invalid
 var ErrInvalidAddress = errors.New("invalid address")
 

--- a/node/mock/apiTransactionHandlerStub.go
+++ b/node/mock/apiTransactionHandlerStub.go
@@ -12,6 +12,7 @@ type TransactionAPIHandlerStub struct {
 	GetTransactionsPoolForSenderCalled          func(sender, fields string) (*common.TransactionsPoolForSenderApiResponse, error)
 	GetLastPoolNonceForSenderCalled             func(sender string) (uint64, error)
 	GetTransactionsPoolNonceGapsForSenderCalled func(sender string, senderAccountNonce uint64) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error)
+	BuildTransactionsPPUHistogramCalled         func() (*common.TransactionsPPUHistogram, error)
 	UnmarshalTransactionCalled                  func(txBytes []byte, txType transaction.TxType) (*transaction.ApiTransactionResult, error)
 	UnmarshalReceiptCalled                      func(receiptBytes []byte) (*transaction.ApiReceipt, error)
 	PopulateComputedFieldsCalled                func(tx *transaction.ApiTransactionResult)
@@ -67,6 +68,15 @@ func (tas *TransactionAPIHandlerStub) GetLastPoolNonceForSender(sender string) (
 func (tas *TransactionAPIHandlerStub) GetTransactionsPoolNonceGapsForSender(sender string, senderAccountNonce uint64) (*common.TransactionsPoolNonceGapsForSenderApiResponse, error) {
 	if tas.GetTransactionsPoolNonceGapsForSenderCalled != nil {
 		return tas.GetTransactionsPoolNonceGapsForSenderCalled(sender, senderAccountNonce)
+	}
+
+	return nil, nil
+}
+
+// BuildTransactionsPPUHistogram -
+func (tas *TransactionAPIHandlerStub) BuildTransactionsPPUHistogram() (*common.TransactionsPPUHistogram, error) {
+	if tas.BuildTransactionsPPUHistogramCalled != nil {
+		return tas.BuildTransactionsPPUHistogramCalled()
 	}
 
 	return nil, nil

--- a/txcache/README.md
+++ b/txcache/README.md
@@ -1,17 +1,17 @@
-## Mempool
+# Mempool
 
-### Glossary
+## Glossary
 
 1. **selection session:** an ephemeral session during which the mempool selects transactions for a proposer. A session starts when a proposer asks the mempool for transactions and ends when the mempool returns the transactions. The most important part of a session is the _selection loop_.
 2. **transaction PPU:** the price per unit of computation, for a transaction. It's computed as `initiallyPaidFee / gasLimit`.
 3. **initially paid transaction fee:** the fee for processing a transaction, as known before its actual processing. That is, without knowing the _refund_ component.
 
-### Configuration
+## Configuration
 
 1. **SelectTransactions::gasRequested:** `10_000_000_000`, the maximum total gas limit of the transactions to be returned to a proposer (one _selection session_). This value is provided by the Protocol.
 2. **SelectTransactions::maxNum:** `30_000`, the maximum number of transactions to be returned to a proposer (one _selection session_). This value is provided by the Protocol.
 
-### Transactions selection
+## Transactions selection
 
 ### Paragraph 1
 
@@ -208,3 +208,14 @@ Transactions from the same sender are organized based on specific rules to ensur
 2. **Gas price descending (same nonce)**: if multiple transactions share the same nonce, they are sorted by their gas prices in descending order - transactions offering higher gas prices are prioritized. This mechanism allows one to easily override a pending transaction with a higher gas price.
 
 3. **Hash ascending (same nonce and gas price)**: for transactions that have identical nonce and gas price, the tie is broken by sorting them based on their transaction hash in ascending order. This provides a consistent and deterministic ordering when other factors are equal. While this ordering isn't a critical aspect of the mempool's operation, it ensures logical consistency.
+
+## PPU histogram
+
+The mempool is able to provide a histogram of the PPU values of the transactions it holds. This histogram is useful for downstream network components, such as the gas price recommender (gas price station).
+
+One can access the histogram through the Node API, as follows:
+
+```
+POST http://localhost:8080/transaction/pool/ppu-histogram HTTP/1.1
+Content-Type: application/json
+```

--- a/txcache/README.md
+++ b/txcache/README.md
@@ -224,14 +224,15 @@ Response example:
 
 ```
 {
-    "data": {
-        "histogram": {
-            "bins": [
-              { "from": ..., "to": ..., "gas": ... }   
-            ]
-        }
-    },
-    "error": "",
-    "code": "successful"
+  "data": {
+    "histogram": {
+      "bins": [
+        { "from": ..., "to": ..., "gas": ... },
+        ...
+      ]
+    }
+  },
+  "error": "",
+  "code": "successful"
 }
 ```

--- a/txcache/README.md
+++ b/txcache/README.md
@@ -219,3 +219,19 @@ One can access the histogram through the Node API, as follows:
 POST http://localhost:8080/transaction/pool/ppu-histogram HTTP/1.1
 Content-Type: application/json
 ```
+
+Response example:
+
+```
+{
+    "data": {
+        "histogram": {
+            "bins": [
+              { "from": ..., "to": ..., "gas": ... }   
+            ]
+        }
+    },
+    "error": "",
+    "code": "successful"
+}
+```

--- a/txcache/ppuHistogram.go
+++ b/txcache/ppuHistogram.go
@@ -1,0 +1,8 @@
+package txcache
+
+import "github.com/multiversx/mx-chain-go/common"
+
+// BuildTransactionsPPUHistogram builds and returns the transactions PPU histogram
+func (cache *TxCache) BuildTransactionsPPUHistogram() (*common.TransactionsPPUHistogram, error) {
+	return &common.TransactionsPPUHistogram{}, nil
+}


### PR DESCRIPTION
## Reasoning behind the pull request

Sketch Node API endpoint for PPU histogram, useful for the gas price recommender (gas price station).
  
## Proposed changes
- Define endpoint (POST).
- Propagate the request to the mempool.
- Actual implementation will follow later.

## Testing procedure

One can access the histogram through the Node API, as follows:

```
POST http://localhost:8080/transaction/pool/ppu-histogram HTTP/1.1
Content-Type: application/json
```

Response example:

```
{
    "data": {
        "histogram": {
            "bins": [
              { "from": ..., "to": ..., "gas": ... },
              ...
            ]
        }
    },
    "error": "",
    "code": "successful"
}
```

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
