### PR TITLE
Invalid signers cache

### DIFF
--- a/consensus/spos/bls/proxy/subroundsHandler_test.go
+++ b/consensus/spos/bls/proxy/subroundsHandler_test.go
@@ -81,6 +81,7 @@ func getDefaultArgumentsSubroundHandler() (*SubroundsHandlerArgs, *spos.Consensu
 	consensusCore.SetEnableEpochsHandler(epochsEnable)
 	consensusCore.SetEquivalentProofsPool(&dataRetriever.ProofsPoolMock{})
 	consensusCore.SetEpochNotifier(epochNotifier)
+	consensusCore.SetInvalidSignersCache(&consensus.InvalidSignersCacheMock{})
 	handlerArgs.ConsensusCoreHandler = consensusCore
 
 	return handlerArgs, consensusCore

--- a/consensus/spos/bls/v2/export_test.go
+++ b/consensus/spos/bls/v2/export_test.go
@@ -302,7 +302,7 @@ func (sr *subroundEndRound) ReceivedInvalidSignersInfo(cnsDta *consensus.Message
 }
 
 // VerifyInvalidSigners calls the unexported verifyInvalidSigners function
-func (sr *subroundEndRound) VerifyInvalidSigners(invalidSigners []byte) error {
+func (sr *subroundEndRound) VerifyInvalidSigners(invalidSigners []byte) ([]string, error) {
 	return sr.verifyInvalidSigners(invalidSigners)
 }
 
@@ -313,7 +313,7 @@ func (sr *subroundEndRound) GetMinConsensusGroupIndexOfManagedKeys() int {
 
 // CreateAndBroadcastInvalidSigners calls the unexported createAndBroadcastInvalidSigners function
 func (sr *subroundEndRound) CreateAndBroadcastInvalidSigners(invalidSigners []byte) {
-	sr.createAndBroadcastInvalidSigners(invalidSigners)
+	sr.createAndBroadcastInvalidSigners(invalidSigners, nil)
 }
 
 // GetFullMessagesForInvalidSigners calls the unexported getFullMessagesForInvalidSigners function

--- a/consensus/spos/bls/v2/subroundEndRound.go
+++ b/consensus/spos/bls/v2/subroundEndRound.go
@@ -151,7 +151,7 @@ func (sr *subroundEndRound) receivedInvalidSignersInfo(_ context.Context, cnsDta
 	}
 
 	invalidSignersCache := sr.InvalidSignersCache()
-	if invalidSignersCache.HasInvalidSigners(cnsDta.BlockHeaderHash, cnsDta.InvalidSigners) {
+	if invalidSignersCache.CheckKnownInvalidSigners(cnsDta.BlockHeaderHash, cnsDta.InvalidSigners) {
 		return false
 	}
 

--- a/consensus/spos/bls/v2/subroundEndRound_test.go
+++ b/consensus/spos/bls/v2/subroundEndRound_test.go
@@ -1507,7 +1507,7 @@ func TestSubroundEndRound_ReceivedInvalidSignersInfo(t *testing.T) {
 
 		container := consensusMocks.InitConsensusCore()
 		invalidSignersCache := &consensusMocks.InvalidSignersCacheMock{
-			HasInvalidSignersCalled: func(headerHash []byte, invalidSigners []byte) bool {
+			CheckKnownInvalidSignersCalled: func(headerHash []byte, invalidSigners []byte) bool {
 				return true
 			},
 		}

--- a/consensus/spos/bls/v2/subroundEndRound_test.go
+++ b/consensus/spos/bls/v2/subroundEndRound_test.go
@@ -1507,7 +1507,7 @@ func TestSubroundEndRound_ReceivedInvalidSignersInfo(t *testing.T) {
 
 		container := consensusMocks.InitConsensusCore()
 		invalidSignersCache := &consensusMocks.InvalidSignersCacheMock{
-			HasInvalidSignersCalled: func(hash string) bool {
+			HasInvalidSignersCalled: func(headerHash []byte, invalidSigners []byte) bool {
 				return true
 			},
 		}
@@ -1551,7 +1551,7 @@ func TestSubroundEndRound_ReceivedInvalidSignersInfo(t *testing.T) {
 		container := consensusMocks.InitConsensusCore()
 		wasAddInvalidSignersCalled := false
 		invalidSignersCache := &consensusMocks.InvalidSignersCacheMock{
-			AddInvalidSignersCalled: func(hash string) {
+			AddInvalidSignersCalled: func(headerHash []byte, invalidSigners []byte, invalidPublicKeys []string) {
 				wasAddInvalidSignersCalled = true
 			},
 		}
@@ -1581,7 +1581,6 @@ func TestVerifyInvalidSigners(t *testing.T) {
 
 		container := consensusMocks.InitConsensusCore()
 
-		expectedErr := errors.New("expected err")
 		messageSigningHandler := &mock.MessageSigningHandlerStub{
 			DeserializeCalled: func(messagesBytes []byte) ([]p2p.MessageP2P, error) {
 				return nil, expectedErr
@@ -1592,7 +1591,7 @@ func TestVerifyInvalidSigners(t *testing.T) {
 
 		sr := initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
 
-		err := sr.VerifyInvalidSigners([]byte{})
+		_, err := sr.VerifyInvalidSigners([]byte{})
 		require.Equal(t, expectedErr, err)
 	})
 
@@ -1606,7 +1605,6 @@ func TestVerifyInvalidSigners(t *testing.T) {
 		}}
 		invalidSignersBytes, _ := container.Marshalizer().Marshal(invalidSigners)
 
-		expectedErr := errors.New("expected err")
 		messageSigningHandler := &mock.MessageSigningHandlerStub{
 			DeserializeCalled: func(messagesBytes []byte) ([]p2p.MessageP2P, error) {
 				require.Equal(t, invalidSignersBytes, messagesBytes)
@@ -1621,7 +1619,7 @@ func TestVerifyInvalidSigners(t *testing.T) {
 
 		sr := initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
 
-		err := sr.VerifyInvalidSigners(invalidSignersBytes)
+		_, err := sr.VerifyInvalidSigners(invalidSignersBytes)
 		require.Equal(t, expectedErr, err)
 	})
 
@@ -1663,7 +1661,7 @@ func TestVerifyInvalidSigners(t *testing.T) {
 
 		sr := initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
 
-		err := sr.VerifyInvalidSigners(invalidSignersBytes)
+		_, err := sr.VerifyInvalidSigners(invalidSignersBytes)
 		require.Nil(t, err)
 		require.True(t, wasCalled)
 	})
@@ -1691,7 +1689,7 @@ func TestVerifyInvalidSigners(t *testing.T) {
 
 		sr := initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
 
-		err := sr.VerifyInvalidSigners(invalidSignersBytes)
+		_, err := sr.VerifyInvalidSigners(invalidSignersBytes)
 		require.Nil(t, err)
 	})
 }
@@ -1747,7 +1745,7 @@ func TestSubroundEndRound_CreateAndBroadcastInvalidSigners(t *testing.T) {
 
 		wasAddInvalidSignersCalled := false
 		invalidSignersCache := &consensusMocks.InvalidSignersCacheMock{
-			AddInvalidSignersCalled: func(hash string) {
+			AddInvalidSignersCalled: func(headerHash []byte, invalidSigners []byte, invalidPublicKeys []string) {
 				wasAddInvalidSignersCalled = true
 			},
 		}

--- a/consensus/spos/bls/v2/subroundStartRound.go
+++ b/consensus/spos/bls/v2/subroundStartRound.go
@@ -101,6 +101,7 @@ func (sr *subroundStartRound) doStartRoundJob(_ context.Context) bool {
 	topic := spos.GetConsensusTopicID(sr.ShardCoordinator())
 	sr.GetAntiFloodHandler().ResetForTopic(topic)
 	sr.worker.ResetConsensusMessages()
+	sr.worker.ResetInvalidSignersCache()
 
 	return true
 }

--- a/consensus/spos/consensusCore.go
+++ b/consensus/spos/consensusCore.go
@@ -43,6 +43,7 @@ type ConsensusCore struct {
 	enableEpochsHandler           common.EnableEpochsHandler
 	equivalentProofsPool          consensus.EquivalentProofsPool
 	epochNotifier                 process.EpochNotifier
+	invalidSignersCache           InvalidSignersCache
 }
 
 // ConsensusCoreArgs store all arguments that are needed to create a ConsensusCore object
@@ -72,6 +73,7 @@ type ConsensusCoreArgs struct {
 	EnableEpochsHandler           common.EnableEpochsHandler
 	EquivalentProofsPool          consensus.EquivalentProofsPool
 	EpochNotifier                 process.EpochNotifier
+	InvalidSignersCache           InvalidSignersCache
 }
 
 // NewConsensusCore creates a new ConsensusCore instance
@@ -104,6 +106,7 @@ func NewConsensusCore(
 		enableEpochsHandler:           args.EnableEpochsHandler,
 		equivalentProofsPool:          args.EquivalentProofsPool,
 		epochNotifier:                 args.EpochNotifier,
+		invalidSignersCache:           args.InvalidSignersCache,
 	}
 
 	err := ValidateConsensusCore(consensusCore)
@@ -239,6 +242,11 @@ func (cc *ConsensusCore) EquivalentProofsPool() consensus.EquivalentProofsPool {
 	return cc.equivalentProofsPool
 }
 
+// InvalidSignersCache returns the invalid signers cache component
+func (cc *ConsensusCore) InvalidSignersCache() InvalidSignersCache {
+	return cc.invalidSignersCache
+}
+
 // SetBlockchain sets blockchain handler
 func (cc *ConsensusCore) SetBlockchain(blockChain data.ChainHandler) {
 	cc.blockChain = blockChain
@@ -362,6 +370,11 @@ func (cc *ConsensusCore) SetEquivalentProofsPool(proofPool consensus.EquivalentP
 // SetEpochNotifier sets epoch notifier
 func (cc *ConsensusCore) SetEpochNotifier(epochNotifier process.EpochNotifier) {
 	cc.epochNotifier = epochNotifier
+}
+
+// SetInvalidSignersCache sets the invalid signers cache
+func (cc *ConsensusCore) SetInvalidSignersCache(cache InvalidSignersCache) {
+	cc.invalidSignersCache = cache
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/consensus/spos/consensusCoreValidator.go
+++ b/consensus/spos/consensusCoreValidator.go
@@ -88,6 +88,9 @@ func ValidateConsensusCore(container ConsensusCoreHandler) error {
 	if check.IfNil(container.EpochStartRegistrationHandler()) {
 		return ErrNilEpochStartNotifier
 	}
+	if check.IfNil(container.InvalidSignersCache()) {
+		return ErrNilInvalidSignersCache
+	}
 
 	return nil
 }

--- a/consensus/spos/consensusCoreValidator_test.go
+++ b/consensus/spos/consensusCoreValidator_test.go
@@ -46,6 +46,7 @@ func initConsensusDataContainer() *spos.ConsensusCore {
 	enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{}
 	proofsPool := &dataRetriever.ProofsPoolMock{}
 	epochNotifier := &epochNotifierMock.EpochNotifierStub{}
+	invalidSignersCache := &consensusMocks.InvalidSignersCacheMock{}
 
 	consensusCore, _ := spos.NewConsensusCore(&spos.ConsensusCoreArgs{
 		BlockChain:                    blockChain,
@@ -73,6 +74,7 @@ func initConsensusDataContainer() *spos.ConsensusCore {
 		EnableEpochsHandler:           enableEpochsHandler,
 		EquivalentProofsPool:          proofsPool,
 		EpochNotifier:                 epochNotifier,
+		InvalidSignersCache:           invalidSignersCache,
 	})
 
 	return consensusCore
@@ -370,6 +372,17 @@ func TestConsensusContainerValidator_ValidateNilEpochStartRegistrationHandlerSho
 	err := spos.ValidateConsensusCore(container)
 
 	assert.Equal(t, spos.ErrNilEpochStartNotifier, err)
+}
+
+func TestConsensusContainerValidator_ValidateNilInvalidSignersCacheShouldFail(t *testing.T) {
+	t.Parallel()
+
+	container := initConsensusDataContainer()
+	container.SetInvalidSignersCache(nil)
+
+	err := spos.ValidateConsensusCore(container)
+
+	assert.Equal(t, spos.ErrNilInvalidSignersCache, err)
 }
 
 func TestConsensusContainerValidator_ShouldWork(t *testing.T) {

--- a/consensus/spos/consensusCore_test.go
+++ b/consensus/spos/consensusCore_test.go
@@ -41,6 +41,7 @@ func createDefaultConsensusCoreArgs() *spos.ConsensusCoreArgs {
 		EnableEpochsHandler:           consensusCoreMock.EnableEpochsHandler(),
 		EquivalentProofsPool:          consensusCoreMock.EquivalentProofsPool(),
 		EpochNotifier:                 consensusCoreMock.EpochNotifier(),
+		InvalidSignersCache:           &consensus.InvalidSignersCacheMock{},
 	}
 	return args
 }

--- a/consensus/spos/errors.go
+++ b/consensus/spos/errors.go
@@ -276,3 +276,9 @@ var ErrNilEpochNotifier = errors.New("nil epoch notifier")
 
 // ErrNilEpochStartNotifier signals that nil epoch start notifier has been provided
 var ErrNilEpochStartNotifier = errors.New("nil epoch start notifier")
+
+// ErrInvalidSignersAlreadyReceived signals that an invalid signers message has been already received
+var ErrInvalidSignersAlreadyReceived = errors.New("invalid signers already received")
+
+// ErrNilInvalidSignersCache signals that nil invalid signers has been provided
+var ErrNilInvalidSignersCache = errors.New("nil invalid signers cache")

--- a/consensus/spos/interface.go
+++ b/consensus/spos/interface.go
@@ -272,7 +272,7 @@ type RoundThresholdHandler interface {
 // InvalidSignersCache encapsulates the methods needed for a invalid signers cache
 type InvalidSignersCache interface {
 	AddInvalidSigners(headerHash []byte, invalidSigners []byte, invalidPublicKeys []string)
-	HasInvalidSigners(headerHash []byte, invalidSigners []byte) bool
+	CheckKnownInvalidSigners(headerHash []byte, invalidSigners []byte) bool
 	Reset()
 	IsInterfaceNil() bool
 }

--- a/consensus/spos/interface.go
+++ b/consensus/spos/interface.go
@@ -271,8 +271,8 @@ type RoundThresholdHandler interface {
 
 // InvalidSignersCache encapsulates the methods needed for a invalid signers cache
 type InvalidSignersCache interface {
-	AddInvalidSigners(hash string)
-	HasInvalidSigners(hash string) bool
+	AddInvalidSigners(headerHash []byte, invalidSigners []byte, invalidPublicKeys []string)
+	HasInvalidSigners(headerHash []byte, invalidSigners []byte) bool
 	Reset()
 	IsInterfaceNil() bool
 }

--- a/consensus/spos/interface.go
+++ b/consensus/spos/interface.go
@@ -48,6 +48,7 @@ type ConsensusCoreHandler interface {
 	EnableEpochsHandler() common.EnableEpochsHandler
 	EquivalentProofsPool() consensus.EquivalentProofsPool
 	EpochNotifier() process.EpochNotifier
+	InvalidSignersCache() InvalidSignersCache
 	IsInterfaceNil() bool
 }
 
@@ -127,6 +128,8 @@ type WorkerHandler interface {
 	ResetConsensusMessages()
 	// ResetConsensusRoundState resets the consensus round state when transitioning to a different consensus version
 	ResetConsensusRoundState()
+	// ResetInvalidSignersCache resets the invalid signers cache
+	ResetInvalidSignersCache()
 	// IsInterfaceNil returns true if there is no value under the interface
 	IsInterfaceNil() bool
 }
@@ -264,4 +267,12 @@ type RoundThresholdHandler interface {
 	SetThreshold(subroundId int, threshold int)
 	FallbackThreshold(subroundId int) int
 	SetFallbackThreshold(subroundId int, threshold int)
+}
+
+// InvalidSignersCache encapsulates the methods needed for a invalid signers cache
+type InvalidSignersCache interface {
+	AddInvalidSigners(hash string)
+	HasInvalidSigners(hash string) bool
+	Reset()
+	IsInterfaceNil() bool
 }

--- a/consensus/spos/invalidSignersCache.go
+++ b/consensus/spos/invalidSignersCache.go
@@ -78,8 +78,8 @@ func (cache *invalidSignersCache) AddInvalidSigners(headerHash []byte, invalidSi
 	}
 }
 
-// HasInvalidSigners check whether the provided hash exists in the internal map or not
-func (cache *invalidSignersCache) HasInvalidSigners(headerHash []byte, serializedInvalidSigners []byte) bool {
+// CheckKnownInvalidSigners checks whether all the provided invalid signers are known for the header hash
+func (cache *invalidSignersCache) CheckKnownInvalidSigners(headerHash []byte, serializedInvalidSigners []byte) bool {
 	cache.RLock()
 	defer cache.RUnlock()
 

--- a/consensus/spos/invalidSignersCache.go
+++ b/consensus/spos/invalidSignersCache.go
@@ -1,0 +1,49 @@
+package spos
+
+import "sync"
+
+type invalidSignersCache struct {
+	sync.RWMutex
+	invalidSignersMap map[string]struct{}
+}
+
+// NewInvalidSignersCache returns a new instance of invalidSignersCache
+func NewInvalidSignersCache() *invalidSignersCache {
+	return &invalidSignersCache{
+		invalidSignersMap: make(map[string]struct{}),
+	}
+}
+
+// AddInvalidSigners adds the provided hash into the internal map if it does not exist
+func (cache *invalidSignersCache) AddInvalidSigners(hash string) {
+	if len(hash) == 0 {
+		return
+	}
+
+	cache.Lock()
+	defer cache.Unlock()
+
+	cache.invalidSignersMap[hash] = struct{}{}
+}
+
+// HasInvalidSigners check whether the provided hash exists in int internal map or not
+func (cache *invalidSignersCache) HasInvalidSigners(hash string) bool {
+	cache.RLock()
+	defer cache.RUnlock()
+
+	_, has := cache.invalidSignersMap[hash]
+	return has
+}
+
+// Reset clears the internal map
+func (cache *invalidSignersCache) Reset() {
+	cache.Lock()
+	defer cache.Unlock()
+
+	cache.invalidSignersMap = make(map[string]struct{})
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (cache *invalidSignersCache) IsInterfaceNil() bool {
+	return cache == nil
+}

--- a/consensus/spos/invalidSignersCache.go
+++ b/consensus/spos/invalidSignersCache.go
@@ -3,14 +3,13 @@ package spos
 import "sync"
 
 type invalidSignersCache struct {
-	sync.RWMutex
-	invalidSignersMap map[string]struct{}
+	invalidSignersMap *sync.Map
 }
 
 // NewInvalidSignersCache returns a new instance of invalidSignersCache
 func NewInvalidSignersCache() *invalidSignersCache {
 	return &invalidSignersCache{
-		invalidSignersMap: make(map[string]struct{}),
+		invalidSignersMap: &sync.Map{},
 	}
 }
 
@@ -20,27 +19,18 @@ func (cache *invalidSignersCache) AddInvalidSigners(hash string) {
 		return
 	}
 
-	cache.Lock()
-	defer cache.Unlock()
-
-	cache.invalidSignersMap[hash] = struct{}{}
+	cache.invalidSignersMap.Store(hash, struct{}{})
 }
 
-// HasInvalidSigners check whether the provided hash exists in int internal map or not
+// HasInvalidSigners check whether the provided hash exists in the internal map or not
 func (cache *invalidSignersCache) HasInvalidSigners(hash string) bool {
-	cache.RLock()
-	defer cache.RUnlock()
-
-	_, has := cache.invalidSignersMap[hash]
+	_, has := cache.invalidSignersMap.Load(hash)
 	return has
 }
 
 // Reset clears the internal map
 func (cache *invalidSignersCache) Reset() {
-	cache.Lock()
-	defer cache.Unlock()
-
-	cache.invalidSignersMap = make(map[string]struct{})
+	cache.invalidSignersMap = &sync.Map{}
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/consensus/spos/invalidSignersCache.go
+++ b/consensus/spos/invalidSignersCache.go
@@ -2,39 +2,118 @@ package spos
 
 import (
 	"sync"
+
+	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/hashing"
+	"github.com/multiversx/mx-chain-core-go/marshal"
+	"github.com/multiversx/mx-chain-go/consensus"
+	"github.com/multiversx/mx-chain-go/p2p"
 )
+
+// ArgInvalidSignersCache defines the DTO used to create a new instance of invalidSignersCache
+type ArgInvalidSignersCache struct {
+	Hasher         hashing.Hasher
+	SigningHandler p2p.P2PSigningHandler
+	Marshaller     marshal.Marshalizer
+}
 
 type invalidSignersCache struct {
 	sync.RWMutex
-	invalidSignersHashesMap map[string]struct{}
+	invalidSignersHashesMap    map[string]struct{}
+	invalidSignersForHeaderMap map[string]map[string]struct{}
+	hasher                     hashing.Hasher
+	signingHandler             p2p.P2PSigningHandler
+	marshaller                 marshal.Marshalizer
 }
 
 // NewInvalidSignersCache returns a new instance of invalidSignersCache
-func NewInvalidSignersCache() *invalidSignersCache {
-	return &invalidSignersCache{
-		invalidSignersHashesMap: make(map[string]struct{}),
+func NewInvalidSignersCache(args ArgInvalidSignersCache) (*invalidSignersCache, error) {
+	err := checkArgs(args)
+	if err != nil {
+		return nil, err
 	}
+
+	return &invalidSignersCache{
+		invalidSignersHashesMap:    make(map[string]struct{}),
+		invalidSignersForHeaderMap: make(map[string]map[string]struct{}),
+		hasher:                     args.Hasher,
+		signingHandler:             args.SigningHandler,
+		marshaller:                 args.Marshaller,
+	}, nil
+}
+
+func checkArgs(args ArgInvalidSignersCache) error {
+	if check.IfNil(args.Hasher) {
+		return ErrNilHasher
+	}
+	if check.IfNil(args.SigningHandler) {
+		return ErrNilSigningHandler
+	}
+	if check.IfNil(args.Marshaller) {
+		return ErrNilMarshalizer
+	}
+
+	return nil
 }
 
 // AddInvalidSigners adds the provided hash into the internal map if it does not exist
-func (cache *invalidSignersCache) AddInvalidSigners(hash string) {
-	if len(hash) == 0 {
+func (cache *invalidSignersCache) AddInvalidSigners(headerHash []byte, invalidSigners []byte, invalidPublicKeys []string) {
+	if len(invalidPublicKeys) == 0 || len(invalidSigners) == 0 {
 		return
 	}
 
 	cache.Lock()
 	defer cache.Unlock()
 
-	cache.invalidSignersHashesMap[hash] = struct{}{}
+	invalidSignersHash := cache.hasher.Compute(string(invalidSigners))
+	cache.invalidSignersHashesMap[string(invalidSignersHash)] = struct{}{}
+
+	_, ok := cache.invalidSignersForHeaderMap[string(headerHash)]
+	if !ok {
+		cache.invalidSignersForHeaderMap[string(headerHash)] = make(map[string]struct{})
+	}
+
+	for _, pk := range invalidPublicKeys {
+		cache.invalidSignersForHeaderMap[string(headerHash)][pk] = struct{}{}
+	}
 }
 
 // HasInvalidSigners check whether the provided hash exists in the internal map or not
-func (cache *invalidSignersCache) HasInvalidSigners(hash string) bool {
+func (cache *invalidSignersCache) HasInvalidSigners(headerHash []byte, invalidSigners []byte) bool {
 	cache.RLock()
 	defer cache.RUnlock()
 
-	_, has := cache.invalidSignersHashesMap[hash]
-	return has
+	invalidSignersHash := cache.hasher.Compute(string(invalidSigners))
+	_, hasSameInvalidSigners := cache.invalidSignersHashesMap[string(invalidSignersHash)]
+	if hasSameInvalidSigners {
+		return true
+	}
+
+	_, isHeaderKnown := cache.invalidSignersForHeaderMap[string(headerHash)]
+	if !isHeaderKnown {
+		return false
+	}
+
+	messages, err := cache.signingHandler.Deserialize(invalidSigners)
+	if err != nil {
+		return false
+	}
+
+	knownInvalidSigners := 0
+	for _, msg := range messages {
+		cnsMsg := &consensus.Message{}
+		err = cache.marshaller.Unmarshal(cnsMsg, msg.Data())
+		if err != nil {
+			return false
+		}
+
+		_, isKnownInvalidSigner := cache.invalidSignersForHeaderMap[string(headerHash)][string(cnsMsg.PubKey)]
+		if isKnownInvalidSigner {
+			knownInvalidSigners++
+		}
+	}
+
+	return knownInvalidSigners == len(messages)
 }
 
 // Reset clears the internal map
@@ -43,6 +122,7 @@ func (cache *invalidSignersCache) Reset() {
 	defer cache.Unlock()
 
 	cache.invalidSignersHashesMap = make(map[string]struct{})
+	cache.invalidSignersForHeaderMap = make(map[string]map[string]struct{})
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/consensus/spos/invalidSignersCache_test.go
+++ b/consensus/spos/invalidSignersCache_test.go
@@ -1,0 +1,77 @@
+package spos
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalidSignersCache_IsInterfaceNil(t *testing.T) {
+	t.Parallel()
+
+	var cache *invalidSignersCache
+	require.True(t, cache.IsInterfaceNil())
+
+	cache = NewInvalidSignersCache()
+	require.False(t, cache.IsInterfaceNil())
+}
+
+func TestInvalidSignersCache(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all ops should work", func(t *testing.T) {
+		t.Parallel()
+
+		cache := NewInvalidSignersCache()
+		require.NotNil(t, cache)
+
+		cache.AddInvalidSigners("") // early return, for coverage only
+
+		hash := "hash"
+		require.False(t, cache.HasInvalidSigners(hash))
+
+		cache.AddInvalidSigners(hash)
+		require.True(t, cache.HasInvalidSigners(hash))
+
+		cache.Reset()
+		require.False(t, cache.HasInvalidSigners(hash))
+	})
+	t.Run("concurrent ops should work", func(t *testing.T) {
+		t.Parallel()
+
+		defer func() {
+			r := recover()
+			if r != nil {
+				require.Fail(t, "should have not panicked")
+			}
+		}()
+
+		cache := NewInvalidSignersCache()
+		require.NotNil(t, cache)
+
+		numCalls := 1000
+		wg := sync.WaitGroup{}
+		wg.Add(numCalls)
+
+		for i := 0; i < numCalls; i++ {
+			go func(idx int) {
+				switch idx % 3 {
+				case 0:
+					cache.AddInvalidSigners(fmt.Sprintf("hash_%d", idx))
+				case 1:
+					cache.HasInvalidSigners(fmt.Sprintf("hash_%d", idx))
+				case 2:
+					cache.Reset()
+				default:
+					require.Fail(t, "should not happen")
+				}
+
+				wg.Done()
+			}(i)
+		}
+
+		wg.Wait()
+	})
+}

--- a/consensus/spos/invalidSignersCache_test.go
+++ b/consensus/spos/invalidSignersCache_test.go
@@ -126,15 +126,15 @@ func TestInvalidSignersCache(t *testing.T) {
 
 		cache.AddInvalidSigners(nil, nil, nil) // early return, for coverage only
 
-		require.False(t, cache.HasInvalidSigners(headerHash1, invalidSigners1))
+		require.False(t, cache.CheckKnownInvalidSigners(headerHash1, invalidSigners1))
 
 		cache.AddInvalidSigners(headerHash1, invalidSigners1, pubKeys1)
-		require.True(t, cache.HasInvalidSigners(headerHash1, invalidSigners1)) // should find in signers by hashes map
+		require.True(t, cache.CheckKnownInvalidSigners(headerHash1, invalidSigners1)) // should find in signers by hashes map
 
-		require.True(t, cache.HasInvalidSigners(headerHash1, invalidSigners2)) // should have different hash but the known signers
+		require.True(t, cache.CheckKnownInvalidSigners(headerHash1, invalidSigners2)) // should have different hash but the known signers
 
 		cache.Reset()
-		require.False(t, cache.HasInvalidSigners(headerHash1, invalidSigners1))
+		require.False(t, cache.CheckKnownInvalidSigners(headerHash1, invalidSigners1))
 	})
 	t.Run("concurrent ops should work", func(t *testing.T) {
 		t.Parallel()
@@ -160,7 +160,7 @@ func TestInvalidSignersCache(t *testing.T) {
 				case 0:
 					cache.AddInvalidSigners([]byte("hash"), []byte("invalidSigners"), []string{"pk0", "pk1"})
 				case 1:
-					cache.HasInvalidSigners([]byte("hash"), []byte("invalidSigners"))
+					cache.CheckKnownInvalidSigners([]byte("hash"), []byte("invalidSigners"))
 				case 2:
 					cache.Reset()
 				default:

--- a/consensus/spos/invalidSignersCache_test.go
+++ b/consensus/spos/invalidSignersCache_test.go
@@ -1,12 +1,34 @@
 package spos
 
 import (
+	"crypto/rand"
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiversx/mx-chain-communication-go/p2p/data"
+	"github.com/multiversx/mx-chain-communication-go/p2p/libp2p"
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-go/consensus"
+	consensusMock "github.com/multiversx/mx-chain-go/consensus/mock"
+	"github.com/multiversx/mx-chain-go/p2p"
+	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
 	"github.com/stretchr/testify/require"
 )
+
+func createMockArgs() ArgInvalidSignersCache {
+	return ArgInvalidSignersCache{
+		Hasher:         &testscommon.HasherStub{},
+		SigningHandler: &consensusMock.MessageSigningHandlerStub{},
+		Marshaller:     &marshallerMock.MarshalizerStub{},
+	}
+}
 
 func TestInvalidSignersCache_IsInterfaceNil(t *testing.T) {
 	t.Parallel()
@@ -14,8 +36,50 @@ func TestInvalidSignersCache_IsInterfaceNil(t *testing.T) {
 	var cache *invalidSignersCache
 	require.True(t, cache.IsInterfaceNil())
 
-	cache = NewInvalidSignersCache()
+	cache, _ = NewInvalidSignersCache(createMockArgs())
 	require.False(t, cache.IsInterfaceNil())
+}
+
+func TestNewInvalidSignersCache(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil Hasher should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgs()
+		args.Hasher = nil
+
+		cache, err := NewInvalidSignersCache(args)
+		require.Equal(t, ErrNilHasher, err)
+		require.Nil(t, cache)
+	})
+	t.Run("nil SigningHandler should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgs()
+		args.SigningHandler = nil
+
+		cache, err := NewInvalidSignersCache(args)
+		require.Equal(t, ErrNilSigningHandler, err)
+		require.Nil(t, cache)
+	})
+	t.Run("nil Marshaller should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockArgs()
+		args.Marshaller = nil
+
+		cache, err := NewInvalidSignersCache(args)
+		require.Equal(t, ErrNilMarshalizer, err)
+		require.Nil(t, cache)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		cache, err := NewInvalidSignersCache(createMockArgs())
+		require.NoError(t, err)
+		require.NotNil(t, cache)
+	})
 }
 
 func TestInvalidSignersCache(t *testing.T) {
@@ -24,19 +88,53 @@ func TestInvalidSignersCache(t *testing.T) {
 	t.Run("all ops should work", func(t *testing.T) {
 		t.Parallel()
 
-		cache := NewInvalidSignersCache()
+		headerHash1 := []byte("headerHash11")
+		invalidSigners1 := []byte("invalidSigners1")
+		pubKeys1 := []string{"pk0", "pk1"}
+		invalidSigners2 := []byte("invalidSigners2")
+
+		args := createMockArgs()
+		args.Hasher = &testscommon.HasherStub{
+			ComputeCalled: func(s string) []byte {
+				return []byte(s)
+			},
+		}
+		args.SigningHandler = &consensusMock.MessageSigningHandlerStub{
+			DeserializeCalled: func(messagesBytes []byte) ([]p2p.MessageP2P, error) {
+				if string(messagesBytes) == string(invalidSigners1) {
+					m1, _ := libp2p.NewMessage(createDummyP2PMessage(), &testscommon.ProtoMarshalizerMock{}, "")
+					m2, _ := libp2p.NewMessage(createDummyP2PMessage(), &testscommon.ProtoMarshalizerMock{}, "")
+					return []p2p.MessageP2P{m1, m2}, nil
+				}
+
+				m1, _ := libp2p.NewMessage(createDummyP2PMessage(), &testscommon.ProtoMarshalizerMock{}, "")
+				return []p2p.MessageP2P{m1}, nil
+			},
+		}
+		cnt := 0
+		args.Marshaller = &marshallerMock.MarshalizerStub{
+			UnmarshalCalled: func(obj interface{}, buff []byte) error {
+				message := obj.(*consensus.Message)
+				message.PubKey = []byte(fmt.Sprintf("pk%d", cnt))
+				cnt++
+
+				return nil
+			},
+		}
+		cache, _ := NewInvalidSignersCache(args)
 		require.NotNil(t, cache)
 
-		cache.AddInvalidSigners("") // early return, for coverage only
+		cache.AddInvalidSigners(nil, nil, nil) // early return, for coverage only
 
-		hash := "hash"
-		require.False(t, cache.HasInvalidSigners(hash))
+		require.False(t, cache.HasInvalidSigners(headerHash1, invalidSigners1))
 
-		cache.AddInvalidSigners(hash)
-		require.True(t, cache.HasInvalidSigners(hash))
+		cache.AddInvalidSigners(headerHash1, invalidSigners1, pubKeys1)
+		require.True(t, cache.HasInvalidSigners(headerHash1, invalidSigners1)) // should find in signers by hashes map
+
+		require.True(t, cache.HasInvalidSigners(headerHash1, invalidSigners2)) // should have different hash but the known signers
 
 		cache.Reset()
-		require.False(t, cache.HasInvalidSigners(hash))
+		require.False(t, cache.HasInvalidSigners(headerHash1, invalidSigners1))
 	})
 	t.Run("concurrent ops should work", func(t *testing.T) {
 		t.Parallel()
@@ -48,7 +146,8 @@ func TestInvalidSignersCache(t *testing.T) {
 			}
 		}()
 
-		cache := NewInvalidSignersCache()
+		args := createMockArgs()
+		cache, _ := NewInvalidSignersCache(args)
 		require.NotNil(t, cache)
 
 		numCalls := 1000
@@ -59,9 +158,9 @@ func TestInvalidSignersCache(t *testing.T) {
 			go func(idx int) {
 				switch idx % 3 {
 				case 0:
-					cache.AddInvalidSigners(fmt.Sprintf("hash_%d", idx))
+					cache.AddInvalidSigners([]byte("hash"), []byte("invalidSigners"), []string{"pk0", "pk1"})
 				case 1:
-					cache.HasInvalidSigners(fmt.Sprintf("hash_%d", idx))
+					cache.HasInvalidSigners([]byte("hash"), []byte("invalidSigners"))
 				case 2:
 					cache.Reset()
 				default:
@@ -74,4 +173,29 @@ func TestInvalidSignersCache(t *testing.T) {
 
 		wg.Wait()
 	})
+}
+
+func createDummyP2PMessage() *pubsub.Message {
+	marshaller := &testscommon.ProtoMarshalizerMock{}
+	topicMessage := &data.TopicMessage{
+		Timestamp: time.Now().Unix(),
+		Payload:   []byte("data"),
+		Version:   1,
+	}
+	buff, _ := marshaller.Marshal(topicMessage)
+	topic := "topic"
+	mes := &pb.Message{
+		From:  getRandomID().Bytes(),
+		Data:  buff,
+		Topic: &topic,
+	}
+
+	return &pubsub.Message{Message: mes}
+}
+
+func getRandomID() core.PeerID {
+	prvKey, _, _ := crypto.GenerateSecp256k1Key(rand.Reader)
+	id, _ := peer.IDFromPublicKey(prvKey.GetPublic())
+
+	return core.PeerID(id)
 }

--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -577,7 +577,7 @@ func (wrk *Worker) doJobOnMessageWithHeader(cnsMsg *consensus.Message) error {
 
 func (wrk *Worker) verifyMessageWithInvalidSigners(cnsMsg *consensus.Message) error {
 	// No need to guard this method by verification of common.EquivalentMessagesFlag as invalidSignersCache will have entries only for consensus v2
-	if wrk.invalidSignersCache.HasInvalidSigners(cnsMsg.BlockHeaderHash, cnsMsg.InvalidSigners) {
+	if wrk.invalidSignersCache.CheckKnownInvalidSigners(cnsMsg.BlockHeaderHash, cnsMsg.InvalidSigners) {
 		// return error here to avoid further broadcast of this message
 		return ErrInvalidSignersAlreadyReceived
 	}

--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -18,7 +18,6 @@ import (
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
-
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/consensus"
 	errorsErd "github.com/multiversx/mx-chain-go/errors"
@@ -84,6 +83,8 @@ type Worker struct {
 	nodeRedundancyHandler     consensus.NodeRedundancyHandler
 	peerBlacklistHandler      consensus.PeerBlacklistHandler
 	closer                    core.SafeCloser
+
+	invalidSignersCache InvalidSignersCache
 }
 
 // WorkerArgs holds the consensus worker arguments
@@ -114,6 +115,7 @@ type WorkerArgs struct {
 	NodeRedundancyHandler    consensus.NodeRedundancyHandler
 	PeerBlacklistHandler     consensus.PeerBlacklistHandler
 	EnableEpochsHandler      common.EnableEpochsHandler
+	InvalidSignersCache      InvalidSignersCache
 }
 
 // NewWorker creates a new Worker object
@@ -166,6 +168,7 @@ func NewWorker(args *WorkerArgs) (*Worker, error) {
 		peerBlacklistHandler:     args.PeerBlacklistHandler,
 		closer:                   closing.NewSafeChanCloser(),
 		enableEpochsHandler:      args.EnableEpochsHandler,
+		invalidSignersCache:      args.InvalidSignersCache,
 	}
 
 	wrk.consensusMessageValidator = consensusMessageValidatorObj
@@ -268,6 +271,9 @@ func checkNewWorkerParams(args *WorkerArgs) error {
 	}
 	if check.IfNil(args.EnableEpochsHandler) {
 		return ErrNilEnableEpochsHandler
+	}
+	if check.IfNil(args.InvalidSignersCache) {
+		return ErrNilInvalidSignersCache
 	}
 
 	return nil
@@ -447,6 +453,7 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 	isMessageWithBlockBody := wrk.consensusService.IsMessageWithBlockBody(msgType)
 	isMessageWithBlockHeader := wrk.consensusService.IsMessageWithBlockHeader(msgType)
 	isMessageWithBlockBodyAndHeader := wrk.consensusService.IsMessageWithBlockBodyAndHeader(msgType)
+	isMessageWithInvalidSigners := wrk.consensusService.IsMessageWithInvalidSigners(msgType)
 
 	if isMessageWithBlockBody || isMessageWithBlockBodyAndHeader {
 		wrk.doJobOnMessageWithBlockBody(cnsMsg)
@@ -461,6 +468,13 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 
 	if wrk.consensusService.IsMessageWithSignature(msgType) {
 		wrk.doJobOnMessageWithSignature(cnsMsg, message)
+	}
+
+	if isMessageWithInvalidSigners {
+		err = wrk.verifyMessageWithInvalidSigners(cnsMsg)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	errNotCritical := wrk.checkSelfState(cnsMsg)
@@ -485,7 +499,8 @@ func (wrk *Worker) shouldBlacklistPeer(err error) bool {
 		errors.Is(err, errorsErd.ErrSignatureMismatch) ||
 		errors.Is(err, nodesCoordinator.ErrEpochNodesConfigDoesNotExist) ||
 		errors.Is(err, ErrMessageTypeLimitReached) ||
-		errors.Is(err, ErrEquivalentMessageAlreadyReceived) {
+		errors.Is(err, ErrEquivalentMessageAlreadyReceived) ||
+		errors.Is(err, ErrInvalidSignersAlreadyReceived) {
 		return false
 	}
 
@@ -555,6 +570,17 @@ func (wrk *Worker) doJobOnMessageWithHeader(cnsMsg *consensus.Message) error {
 			"error", errNotCritical.Error())
 		// we should not return error here because the other peers connected to self might need this message
 		// to advance the consensus
+	}
+
+	return nil
+}
+
+func (wrk *Worker) verifyMessageWithInvalidSigners(cnsMsg *consensus.Message) error {
+	// No need to guard this method by verification of common.EquivalentMessagesFlag as invalidSignersCache will have entries only for consensus v2
+	invalidSignersHash := wrk.hasher.Compute(string(cnsMsg.InvalidSigners))
+	if wrk.invalidSignersCache.HasInvalidSigners(string(invalidSignersHash)) {
+		// return error here to avoid further broadcast of this message
+		return ErrInvalidSignersAlreadyReceived
 	}
 
 	return nil
@@ -803,6 +829,11 @@ func (wrk *Worker) ResetConsensusMessages() {
 // ResetConsensusRoundState resets the consensus round state
 func (wrk *Worker) ResetConsensusRoundState() {
 	wrk.consensusState.ResetConsensusRoundState()
+}
+
+// ResetInvalidSignersCache resets the invalid signers cache
+func (wrk *Worker) ResetInvalidSignersCache() {
+	wrk.invalidSignersCache.Reset()
 }
 
 func (wrk *Worker) checkValidityAndProcessFinalInfo(cnsMsg *consensus.Message, p2pMessage p2p.MessageP2P) error {

--- a/consensus/spos/worker_test.go
+++ b/consensus/spos/worker_test.go
@@ -2017,7 +2017,7 @@ func TestWorker_ProcessReceivedMessageWithInvalidSigners(t *testing.T) {
 	workerArgs := createDefaultWorkerArgs(&statusHandlerMock.AppStatusHandlerStub{})
 	cntHasInvalidSignersCalled := 0
 	workerArgs.InvalidSignersCache = &consensusMocks.InvalidSignersCacheMock{
-		HasInvalidSignersCalled: func(hash string) bool {
+		HasInvalidSignersCalled: func(headerHash []byte, invalidSigners []byte) bool {
 			cntHasInvalidSignersCalled++
 			return cntHasInvalidSignersCalled > 1
 		},

--- a/consensus/spos/worker_test.go
+++ b/consensus/spos/worker_test.go
@@ -2015,11 +2015,11 @@ func TestWorker_ProcessReceivedMessageWithInvalidSigners(t *testing.T) {
 	t.Parallel()
 
 	workerArgs := createDefaultWorkerArgs(&statusHandlerMock.AppStatusHandlerStub{})
-	cntHasInvalidSignersCalled := 0
+	cntCheckKnownInvalidSignersCalled := 0
 	workerArgs.InvalidSignersCache = &consensusMocks.InvalidSignersCacheMock{
-		HasInvalidSignersCalled: func(headerHash []byte, invalidSigners []byte) bool {
-			cntHasInvalidSignersCalled++
-			return cntHasInvalidSignersCalled > 1
+		CheckKnownInvalidSignersCalled: func(headerHash []byte, invalidSigners []byte) bool {
+			cntCheckKnownInvalidSignersCalled++
+			return cntCheckKnownInvalidSignersCalled > 1
 		},
 	}
 	workerArgs.AntifloodHandler = &mock.P2PAntifloodHandlerStub{

--- a/consensus/spos/worker_test.go
+++ b/consensus/spos/worker_test.go
@@ -123,6 +123,7 @@ func createDefaultWorkerArgs(appStatusHandler core.AppStatusHandler) *spos.Worke
 		NodeRedundancyHandler:    &mock.NodeRedundancyHandlerStub{},
 		PeerBlacklistHandler:     &mock.PeerBlacklistHandlerStub{},
 		EnableEpochsHandler:      &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
+		InvalidSignersCache:      &consensusMocks.InvalidSignersCacheMock{},
 	}
 
 	return workerArgs
@@ -388,6 +389,17 @@ func TestWorker_NewWorkerPoolEnableEpochsHandlerNilShouldFail(t *testing.T) {
 
 	assert.Nil(t, wrk)
 	assert.Equal(t, spos.ErrNilEnableEpochsHandler, err)
+}
+
+func TestWorker_NewWorkerPoolInvalidSignersCacheNilShouldFail(t *testing.T) {
+	t.Parallel()
+
+	workerArgs := createDefaultWorkerArgs(&statusHandlerMock.AppStatusHandlerStub{})
+	workerArgs.InvalidSignersCache = nil
+	wrk, err := spos.NewWorker(workerArgs)
+
+	assert.Nil(t, wrk)
+	assert.Equal(t, spos.ErrNilInvalidSignersCache, err)
 }
 
 func TestWorker_NewWorkerShouldWork(t *testing.T) {
@@ -1997,6 +2009,78 @@ func TestWorker_ProcessReceivedMessageWithSignature(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, msg, p2pMsgWithSignature)
 	})
+}
+
+func TestWorker_ProcessReceivedMessageWithInvalidSigners(t *testing.T) {
+	t.Parallel()
+
+	workerArgs := createDefaultWorkerArgs(&statusHandlerMock.AppStatusHandlerStub{})
+	cntHasInvalidSignersCalled := 0
+	workerArgs.InvalidSignersCache = &consensusMocks.InvalidSignersCacheMock{
+		HasInvalidSignersCalled: func(hash string) bool {
+			cntHasInvalidSignersCalled++
+			return cntHasInvalidSignersCalled > 1
+		},
+	}
+	workerArgs.AntifloodHandler = &mock.P2PAntifloodHandlerStub{
+		CanProcessMessageCalled: func(message p2p.MessageP2P, fromConnectedPeer core.PeerID) error {
+			return nil
+		},
+		CanProcessMessagesOnTopicCalled: func(peer core.PeerID, topic string, numMessages uint32, totalSize uint64, sequence []byte) error {
+			return nil
+		},
+		BlacklistPeerCalled: func(peer core.PeerID, reason string, duration time.Duration) {
+			require.Fail(t, "should have not been called")
+		},
+	}
+	wrk, _ := spos.NewWorker(workerArgs)
+	wrk.ConsensusState().SetHeader(&block.HeaderV2{})
+
+	hdr := &block.Header{}
+	hdr.Nonce = 1
+	hdr.TimeStamp = uint64(wrk.RoundHandler().TimeStamp().Unix())
+	hdrStr, _ := mock.MarshalizerMock{}.Marshal(hdr)
+	hdrHash := (&hashingMocks.HasherMock{}).Compute(string(hdrStr))
+	pubKey := []byte(wrk.ConsensusState().ConsensusGroup()[0])
+
+	invalidSigners := []byte("invalid signers")
+	cnsMsg := consensus.NewConsensusMessage(
+		hdrHash,
+		nil,
+		nil,
+		nil,
+		pubKey,
+		bytes.Repeat([]byte("a"), SignatureSize),
+		int(bls.MtInvalidSigners),
+		0,
+		chainID,
+		nil,
+		nil,
+		nil,
+		currentPid,
+		invalidSigners,
+	)
+	buff, err := wrk.Marshalizer().Marshal(cnsMsg)
+	require.Nil(t, err)
+
+	msg := &p2pmocks.P2PMessageMock{
+		DataField:      buff,
+		PeerField:      currentPid,
+		SignatureField: []byte("signature"),
+	}
+
+	// first call should be ok
+	msgID, err := wrk.ProcessReceivedMessage(msg, "", &p2pmocks.MessengerStub{})
+	require.Nil(t, err)
+	require.Nil(t, msgID)
+
+	// reset the received messages to allow a second one of the same type
+	wrk.ResetConsensusMessages()
+
+	// second call should see this message as already received and return error
+	msgID, err = wrk.ProcessReceivedMessage(msg, "", &p2pmocks.MessengerStub{})
+	require.Equal(t, spos.ErrInvalidSignersAlreadyReceived, err)
+	require.Nil(t, msgID)
 }
 
 func TestWorker_ReceivedHeader(t *testing.T) {

--- a/consensus/spos/worker_test.go
+++ b/consensus/spos/worker_test.go
@@ -2033,6 +2033,11 @@ func TestWorker_ProcessReceivedMessageWithInvalidSigners(t *testing.T) {
 			require.Fail(t, "should have not been called")
 		},
 	}
+	workerArgs.EnableEpochsHandler = &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+		IsFlagEnabledCalled: func(flag core.EnableEpochFlag) bool {
+			return true
+		},
+	}
 	wrk, _ := spos.NewWorker(workerArgs)
 	wrk.ConsensusState().SetHeader(&block.HeaderV2{})
 

--- a/factory/consensus/consensusComponents.go
+++ b/factory/consensus/consensusComponents.go
@@ -180,6 +180,8 @@ func (ccf *consensusComponentsFactory) Create() (*consensusComponents, error) {
 		return nil, err
 	}
 
+	invalidSignersCache := spos.NewInvalidSignersCache()
+
 	workerArgs := &spos.WorkerArgs{
 		ConsensusService:         consensusService,
 		BlockChain:               ccf.dataComponents.Blockchain(),
@@ -207,6 +209,7 @@ func (ccf *consensusComponentsFactory) Create() (*consensusComponents, error) {
 		NodeRedundancyHandler:    ccf.processComponents.NodeRedundancyHandler(),
 		PeerBlacklistHandler:     cc.peerBlacklistHandler,
 		EnableEpochsHandler:      ccf.coreComponents.EnableEpochsHandler(),
+		InvalidSignersCache:      invalidSignersCache,
 	}
 
 	cc.worker, err = spos.NewWorker(workerArgs)
@@ -257,6 +260,7 @@ func (ccf *consensusComponentsFactory) Create() (*consensusComponents, error) {
 		EnableEpochsHandler:           ccf.coreComponents.EnableEpochsHandler(),
 		EquivalentProofsPool:          ccf.dataComponents.Datapool().Proofs(),
 		EpochNotifier:                 ccf.coreComponents.EpochNotifier(),
+		InvalidSignersCache:           invalidSignersCache,
 	}
 
 	consensusDataContainer, err := spos.NewConsensusCore(

--- a/factory/consensus/consensusComponents.go
+++ b/factory/consensus/consensusComponents.go
@@ -180,7 +180,20 @@ func (ccf *consensusComponentsFactory) Create() (*consensusComponents, error) {
 		return nil, err
 	}
 
-	invalidSignersCache := spos.NewInvalidSignersCache()
+	p2pSigningHandler, err := ccf.createP2pSigningHandler()
+	if err != nil {
+		return nil, err
+	}
+
+	argsInvalidSignersCacher := spos.ArgInvalidSignersCache{
+		Hasher:         ccf.coreComponents.Hasher(),
+		SigningHandler: p2pSigningHandler,
+		Marshaller:     ccf.coreComponents.InternalMarshalizer(),
+	}
+	invalidSignersCache, err := spos.NewInvalidSignersCache(argsInvalidSignersCacher)
+	if err != nil {
+		return nil, err
+	}
 
 	workerArgs := &spos.WorkerArgs{
 		ConsensusService:         consensusService,
@@ -225,11 +238,6 @@ func (ccf *consensusComponentsFactory) Create() (*consensusComponents, error) {
 		ccf.processComponents.ShardCoordinator().SelfId(),
 	)
 	err = ccf.createConsensusTopic(cc)
-	if err != nil {
-		return nil, err
-	}
-
-	p2pSigningHandler, err := ccf.createP2pSigningHandler()
 	if err != nil {
 		return nil, err
 	}

--- a/factory/consensus/consensusComponents_test.go
+++ b/factory/consensus/consensusComponents_test.go
@@ -770,7 +770,7 @@ func TestConsensusComponentsFactory_Create(t *testing.T) {
 		cnt := 0
 		netwCompStub.MessengerCalled = func() p2p.Messenger {
 			cnt++
-			if cnt > 3 {
+			if cnt > 4 {
 				return nil
 			}
 			return &p2pmocks.MessengerStub{}

--- a/factory/interface.go
+++ b/factory/interface.go
@@ -406,6 +406,8 @@ type ConsensusWorker interface {
 	ResetConsensusMessages()
 	// ResetConsensusRoundState resets the state of the consensus round
 	ResetConsensusRoundState()
+	// ResetInvalidSignersCache resets the invalid signers cache
+	ResetInvalidSignersCache()
 	// ReceivedHeader method is a wired method through which worker will receive headers from network
 	ReceivedHeader(headerHandler data.HeaderHandler, headerHash []byte)
 	// ReceivedProof will handle a received proof in consensus worker

--- a/testscommon/consensus/invalidSignersCacheMock.go
+++ b/testscommon/consensus/invalidSignersCacheMock.go
@@ -2,9 +2,9 @@ package consensus
 
 // InvalidSignersCacheMock -
 type InvalidSignersCacheMock struct {
-	AddInvalidSignersCalled func(headerHash []byte, invalidSigners []byte, invalidPublicKeys []string)
-	HasInvalidSignersCalled func(headerHash []byte, invalidSigners []byte) bool
-	ResetCalled             func()
+	AddInvalidSignersCalled        func(headerHash []byte, invalidSigners []byte, invalidPublicKeys []string)
+	CheckKnownInvalidSignersCalled func(headerHash []byte, invalidSigners []byte) bool
+	ResetCalled                    func()
 }
 
 // AddInvalidSigners -
@@ -14,10 +14,10 @@ func (mock *InvalidSignersCacheMock) AddInvalidSigners(headerHash []byte, invali
 	}
 }
 
-// HasInvalidSigners -
-func (mock *InvalidSignersCacheMock) HasInvalidSigners(headerHash []byte, invalidSigners []byte) bool {
-	if mock.HasInvalidSignersCalled != nil {
-		return mock.HasInvalidSignersCalled(headerHash, invalidSigners)
+// CheckKnownInvalidSigners -
+func (mock *InvalidSignersCacheMock) CheckKnownInvalidSigners(headerHash []byte, invalidSigners []byte) bool {
+	if mock.CheckKnownInvalidSignersCalled != nil {
+		return mock.CheckKnownInvalidSignersCalled(headerHash, invalidSigners)
 	}
 	return false
 }

--- a/testscommon/consensus/invalidSignersCacheMock.go
+++ b/testscommon/consensus/invalidSignersCacheMock.go
@@ -2,22 +2,22 @@ package consensus
 
 // InvalidSignersCacheMock -
 type InvalidSignersCacheMock struct {
-	AddInvalidSignersCalled func(hash string)
-	HasInvalidSignersCalled func(hash string) bool
+	AddInvalidSignersCalled func(headerHash []byte, invalidSigners []byte, invalidPublicKeys []string)
+	HasInvalidSignersCalled func(headerHash []byte, invalidSigners []byte) bool
 	ResetCalled             func()
 }
 
 // AddInvalidSigners -
-func (mock *InvalidSignersCacheMock) AddInvalidSigners(hash string) {
+func (mock *InvalidSignersCacheMock) AddInvalidSigners(headerHash []byte, invalidSigners []byte, invalidPublicKeys []string) {
 	if mock.AddInvalidSignersCalled != nil {
-		mock.AddInvalidSignersCalled(hash)
+		mock.AddInvalidSignersCalled(headerHash, invalidSigners, invalidPublicKeys)
 	}
 }
 
 // HasInvalidSigners -
-func (mock *InvalidSignersCacheMock) HasInvalidSigners(hash string) bool {
+func (mock *InvalidSignersCacheMock) HasInvalidSigners(headerHash []byte, invalidSigners []byte) bool {
 	if mock.HasInvalidSignersCalled != nil {
-		return mock.HasInvalidSignersCalled(hash)
+		return mock.HasInvalidSignersCalled(headerHash, invalidSigners)
 	}
 	return false
 }

--- a/testscommon/consensus/invalidSignersCacheMock.go
+++ b/testscommon/consensus/invalidSignersCacheMock.go
@@ -1,0 +1,35 @@
+package consensus
+
+// InvalidSignersCacheMock -
+type InvalidSignersCacheMock struct {
+	AddInvalidSignersCalled func(hash string)
+	HasInvalidSignersCalled func(hash string) bool
+	ResetCalled             func()
+}
+
+// AddInvalidSigners -
+func (mock *InvalidSignersCacheMock) AddInvalidSigners(hash string) {
+	if mock.AddInvalidSignersCalled != nil {
+		mock.AddInvalidSignersCalled(hash)
+	}
+}
+
+// HasInvalidSigners -
+func (mock *InvalidSignersCacheMock) HasInvalidSigners(hash string) bool {
+	if mock.HasInvalidSignersCalled != nil {
+		return mock.HasInvalidSignersCalled(hash)
+	}
+	return false
+}
+
+// Reset -
+func (mock *InvalidSignersCacheMock) Reset() {
+	if mock.ResetCalled != nil {
+		mock.ResetCalled()
+	}
+}
+
+// IsInterfaceNil -
+func (mock *InvalidSignersCacheMock) IsInterfaceNil() bool {
+	return mock == nil
+}

--- a/testscommon/consensus/mockTestInitializer.go
+++ b/testscommon/consensus/mockTestInitializer.go
@@ -245,6 +245,7 @@ func InitConsensusCoreWithMultiSigner(multiSigner crypto.MultiSigner) *spos.Cons
 		EnableEpochsHandler:           enableEpochsHandler,
 		EquivalentProofsPool:          equivalentProofsPool,
 		EpochNotifier:                 epochNotifier,
+		InvalidSignersCache:           &InvalidSignersCacheMock{},
 	})
 
 	return container

--- a/testscommon/consensus/sposWorkerMock.go
+++ b/testscommon/consensus/sposWorkerMock.go
@@ -34,6 +34,7 @@ type SposWorkerMock struct {
 	ResetConsensusStateCalled              func()
 	ReceivedProofCalled                    func(proofHandler consensus.ProofHandler)
 	ResetConsensusRoundStateCalled         func()
+	ResetInvalidSignersCacheCalled         func()
 }
 
 // ResetConsensusRoundState -
@@ -172,4 +173,11 @@ func (sposWorkerMock *SposWorkerMock) ReceivedProof(proofHandler consensus.Proof
 // IsInterfaceNil returns true if there is no value under the interface
 func (sposWorkerMock *SposWorkerMock) IsInterfaceNil() bool {
 	return sposWorkerMock == nil
+}
+
+// ResetInvalidSignersCache -
+func (sposWorkerMock *SposWorkerMock) ResetInvalidSignersCache() {
+	if sposWorkerMock.ResetInvalidSignersCacheCalled != nil {
+		sposWorkerMock.ResetInvalidSignersCacheCalled()
+	}
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- as now all participants can aggregate signatures and send final info, the network might get flooded with the invalid signers messages
  
## Proposed changes
- added a mechanism similar to equivalent proofs to avoid further broadcast in case of known invalid signers message

## Testing procedure
- with rc branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
