### PR TITLE
Recursive call to doEndRoundJobByNode in order to wait more signatures

### DIFF
--- a/consensus/spos/bls/v2/errors.go
+++ b/consensus/spos/bls/v2/errors.go
@@ -4,5 +4,3 @@ import "errors"
 
 // ErrNilSentSignatureTracker defines the error for setting a nil SentSignatureTracker
 var ErrNilSentSignatureTracker = errors.New("nil sent signature tracker")
-
-var errShouldNotSendProof = errors.New("should not send proof")

--- a/consensus/spos/bls/v2/errors.go
+++ b/consensus/spos/bls/v2/errors.go
@@ -4,3 +4,5 @@ import "errors"
 
 // ErrNilSentSignatureTracker defines the error for setting a nil SentSignatureTracker
 var ErrNilSentSignatureTracker = errors.New("nil sent signature tracker")
+
+var errShouldNotSendProof = errors.New("should not send proof")

--- a/consensus/spos/bls/v2/export_test.go
+++ b/consensus/spos/bls/v2/export_test.go
@@ -363,5 +363,5 @@ func (sr *subroundEndRound) GetEquivalentProofSender() string {
 
 // SendProof -
 func (sr *subroundEndRound) SendProof() {
-	_ = sr.sendProof()
+	_, _ = sr.sendProof()
 }

--- a/consensus/spos/bls/v2/export_test.go
+++ b/consensus/spos/bls/v2/export_test.go
@@ -363,5 +363,5 @@ func (sr *subroundEndRound) GetEquivalentProofSender() string {
 
 // SendProof -
 func (sr *subroundEndRound) SendProof() {
-	sr.sendProof()
+	_ = sr.sendProof()
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- if a node has too many invalid signatures to fall beyond threshold, it will simply wait for a proof
  
## Proposed changes
- wait for proof or more signatures

## Testing procedure
- with rc and invalid signers

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
