### PR TITLE
fixed backups not proposing block in multikey mode

### DIFF
--- a/consensus/spos/bls/v2/export_test.go
+++ b/consensus/spos/bls/v2/export_test.go
@@ -268,7 +268,7 @@ func (sr *subroundEndRound) DoEndRoundJobByNode() bool {
 
 // CreateAndBroadcastProof calls the unexported createAndBroadcastHeaderFinalInfo function
 func (sr *subroundEndRound) CreateAndBroadcastProof(signature []byte, bitmap []byte) {
-	_ = sr.createAndBroadcastProof(signature, bitmap)
+	_ = sr.createAndBroadcastProof(signature, bitmap, "sender")
 }
 
 // ReceivedProof calls the unexported receivedProof function
@@ -308,7 +308,7 @@ func (sr *subroundEndRound) GetMinConsensusGroupIndexOfManagedKeys() int {
 
 // CreateAndBroadcastInvalidSigners calls the unexported createAndBroadcastInvalidSigners function
 func (sr *subroundEndRound) CreateAndBroadcastInvalidSigners(invalidSigners []byte) {
-	sr.createAndBroadcastInvalidSigners(invalidSigners, nil)
+	sr.createAndBroadcastInvalidSigners(invalidSigners, nil, "sender")
 }
 
 // GetFullMessagesForInvalidSigners calls the unexported getFullMessagesForInvalidSigners function

--- a/consensus/spos/bls/v2/subroundBlock.go
+++ b/consensus/spos/bls/v2/subroundBlock.go
@@ -74,8 +74,7 @@ func checkNewSubroundBlockParams(
 
 // doBlockJob method does the job of the subround Block
 func (sr *subroundBlock) doBlockJob(ctx context.Context) bool {
-	isSelfLeader := sr.IsSelfLeader() && sr.ShouldConsiderSelfKeyInConsensus()
-	if !isSelfLeader { // is NOT self leader in this round?
+	if !sr.IsSelfLeader() { // is NOT self leader in this round?
 		return false
 	}
 

--- a/consensus/spos/bls/v2/subroundEndRound.go
+++ b/consensus/spos/bls/v2/subroundEndRound.go
@@ -355,8 +355,10 @@ func (sr *subroundEndRound) sendProof() (bool, error) {
 		return false, err
 	}
 
+	currentSender := sr.getEquivalentProofSender()
+
 	// Aggregate signatures, handle invalid signers and send final info if needed
-	bitmap, sig, err := sr.aggregateSigsAndHandleInvalidSigners(bitmap)
+	bitmap, sig, err := sr.aggregateSigsAndHandleInvalidSigners(bitmap, currentSender)
 	if err != nil {
 		log.Debug("sendProof.aggregateSigsAndHandleInvalidSigners", "error", err.Error())
 		return false, err
@@ -371,7 +373,7 @@ func (sr *subroundEndRound) sendProof() (bool, error) {
 	}
 
 	// broadcast header proof
-	err = sr.createAndBroadcastProof(sig, bitmap)
+	err = sr.createAndBroadcastProof(sig, bitmap, currentSender)
 	if err != nil {
 		log.Warn("sendProof.createAndBroadcastProof", "error", err.Error())
 	}
@@ -389,12 +391,12 @@ func (sr *subroundEndRound) shouldSendProof() bool {
 	return sr.IsSelfInConsensusGroup()
 }
 
-func (sr *subroundEndRound) aggregateSigsAndHandleInvalidSigners(bitmap []byte) ([]byte, []byte, error) {
+func (sr *subroundEndRound) aggregateSigsAndHandleInvalidSigners(bitmap []byte, sender string) ([]byte, []byte, error) {
 	sig, err := sr.SigningHandler().AggregateSigs(bitmap, sr.GetHeader().GetEpoch())
 	if err != nil {
 		log.Debug("doEndRoundJobByNode.AggregateSigs", "error", err.Error())
 
-		return sr.handleInvalidSignersOnAggSigFail()
+		return sr.handleInvalidSignersOnAggSigFail(sender)
 	}
 
 	err = sr.SigningHandler().SetAggregatedSig(sig)
@@ -408,7 +410,7 @@ func (sr *subroundEndRound) aggregateSigsAndHandleInvalidSigners(bitmap []byte) 
 	if err != nil {
 		log.Debug("doEndRoundJobByNode.Verify", "error", err.Error())
 
-		return sr.handleInvalidSignersOnAggSigFail()
+		return sr.handleInvalidSignersOnAggSigFail(sender)
 	}
 
 	return bitmap, sig, nil
@@ -524,7 +526,7 @@ func (sr *subroundEndRound) getFullMessagesForInvalidSigners(invalidPubKeys []st
 	return invalidSigners, nil
 }
 
-func (sr *subroundEndRound) handleInvalidSignersOnAggSigFail() ([]byte, []byte, error) {
+func (sr *subroundEndRound) handleInvalidSignersOnAggSigFail(sender string) ([]byte, []byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), sr.RoundHandler().TimeDuration())
 	invalidPubKeys, err := sr.verifyNodesOnAggSigFail(ctx)
 	cancel()
@@ -540,7 +542,7 @@ func (sr *subroundEndRound) handleInvalidSignersOnAggSigFail() ([]byte, []byte, 
 	}
 
 	if len(invalidSigners) > 0 {
-		sr.createAndBroadcastInvalidSigners(invalidSigners, invalidPubKeys)
+		sr.createAndBroadcastInvalidSigners(invalidSigners, invalidPubKeys, sender)
 	}
 
 	bitmap, sig, err := sr.computeAggSigOnValidNodes()
@@ -590,7 +592,11 @@ func (sr *subroundEndRound) computeAggSigOnValidNodes() ([]byte, []byte, error) 
 	return bitmap, sig, nil
 }
 
-func (sr *subroundEndRound) createAndBroadcastProof(signature []byte, bitmap []byte) error {
+func (sr *subroundEndRound) createAndBroadcastProof(
+	signature []byte,
+	bitmap []byte,
+	sender string,
+) error {
 	headerProof := &block.HeaderProof{
 		PubKeysBitmap:       bitmap,
 		AggregatedSignature: signature,
@@ -602,7 +608,6 @@ func (sr *subroundEndRound) createAndBroadcastProof(signature []byte, bitmap []b
 		IsStartOfEpoch:      sr.GetHeader().IsStartOfEpochBlock(),
 	}
 
-	sender := sr.getEquivalentProofSender()
 	err := sr.BroadcastMessenger().BroadcastEquivalentProof(headerProof, []byte(sender))
 	if err != nil {
 		return err
@@ -645,14 +650,12 @@ func (sr *subroundEndRound) getRandomManagedKeyProofSender() string {
 	return randManagedKey
 }
 
-func (sr *subroundEndRound) createAndBroadcastInvalidSigners(invalidSigners []byte, invalidSignersPubKeys []string) {
-	if !sr.ShouldConsiderSelfKeyInConsensus() {
-		return
-	}
-
-	sender, err := sr.GetLeader()
-	if err != nil {
-		log.Debug("createAndBroadcastInvalidSigners.getSender", "error", err)
+func (sr *subroundEndRound) createAndBroadcastInvalidSigners(
+	invalidSigners []byte,
+	invalidSignersPubKeys []string,
+	sender string,
+) {
+	if !sr.ShouldConsiderSelfKeyInConsensus() && !sr.IsMultiKeyInConsensusGroup() {
 		return
 	}
 
@@ -675,13 +678,13 @@ func (sr *subroundEndRound) createAndBroadcastInvalidSigners(invalidSigners []by
 
 	sr.InvalidSignersCache().AddInvalidSigners(sr.GetData(), invalidSigners, invalidSignersPubKeys)
 
-	err = sr.BroadcastMessenger().BroadcastConsensusMessage(cnsMsg)
+	err := sr.BroadcastMessenger().BroadcastConsensusMessage(cnsMsg)
 	if err != nil {
 		log.Debug("doEndRoundJob.BroadcastConsensusMessage", "error", err.Error())
 		return
 	}
 
-	log.Debug("step 3: invalid signers info has been sent")
+	log.Debug("step 3: invalid signers info has been sent", "sender", hex.EncodeToString([]byte(sender)))
 }
 
 func (sr *subroundEndRound) updateMetricsForLeader() {


### PR DESCRIPTION
## Reasoning behind the pull request
- multikey backups do not propose blocks when they should
  
## Proposed changes
- fixed early exit in subroundBlock in order to allow backups to propose block
- small fix also on invalid signatures propagation to use the proper sender for multikey as well

## Testing procedure
- with rc

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
