### PR TITLE
fix shard header finalized state

### DIFF
--- a/process/block/interceptedBlocks/common.go
+++ b/process/block/interceptedBlocks/common.go
@@ -143,7 +143,7 @@ func checkMetaShardInfo(
 			continue
 		}
 
-		log.Warn("proof in pool not equal to provided prev proof, will check prev proof",
+		log.Debug("proof in pool not equal to provided prev proof, will check prev proof",
 			"headerHash", sd.GetPreviousProof().GetHeaderHash(),
 		)
 

--- a/process/block/interceptedBlocks/common.go
+++ b/process/block/interceptedBlocks/common.go
@@ -143,7 +143,7 @@ func checkMetaShardInfo(
 			continue
 		}
 
-		log.Trace("proof in pool not equal to provided prev proof, will check prev proof",
+		log.Warn("proof in pool not equal to provided prev proof, will check prev proof",
 			"headerHash", sd.GetPreviousProof().GetHeaderHash(),
 		)
 

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -1100,7 +1100,12 @@ func (sp *shardProcessor) CommitBlock(
 		sp.lastRestartNonce = header.GetNonce()
 	}
 
-	sp.updateState(selfNotarizedHeaders, header, currentHeaderHash)
+	finalHeaderHash := headerHash
+	if !common.ShouldBlockHavePrevProof(header, sp.enableEpochsHandler, common.EquivalentMessagesFlag) {
+		finalHeaderHash = currentHeaderHash
+	}
+
+	sp.updateState(selfNotarizedHeaders, header, finalHeaderHash)
 
 	highestFinalBlockNonce := sp.forkDetector.GetHighestFinalBlockNonce()
 	log.Debug("highest final shard block",


### PR DESCRIPTION
## Reasoning behind the pull request
- Use current commited shard header in finalized state for outport driver

## Testing procedure
- With feat branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
