### PR TITLE
Fixed non-deterministic unit test

### DIFF
--- a/testscommon/requestHandlerStub.go
+++ b/testscommon/requestHandlerStub.go
@@ -1,8 +1,6 @@
 package testscommon
 
-import (
-	"time"
-)
+import "time"
 
 // RequestHandlerStub -
 type RequestHandlerStub struct {
@@ -66,7 +64,6 @@ func (rhs *RequestHandlerStub) RequestShardHeader(shardID uint32, hash []byte) {
 	if rhs.RequestShardHeaderCalled == nil {
 		return
 	}
-
 	rhs.RequestShardHeaderCalled(shardID, hash)
 }
 

--- a/testscommon/requestHandlerStub.go
+++ b/testscommon/requestHandlerStub.go
@@ -1,7 +1,6 @@
 package testscommon
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -65,10 +64,9 @@ func (rhs *RequestHandlerStub) SetEpoch(_ uint32) {
 // RequestShardHeader -
 func (rhs *RequestHandlerStub) RequestShardHeader(shardID uint32, hash []byte) {
 	if rhs.RequestShardHeaderCalled == nil {
-		fmt.Println("I DONT HAVE A HANDLER")
 		return
 	}
-	fmt.Println("I HAVE A HANDLER")
+
 	rhs.RequestShardHeaderCalled(shardID, hash)
 }
 

--- a/testscommon/requestHandlerStub.go
+++ b/testscommon/requestHandlerStub.go
@@ -1,6 +1,9 @@
 package testscommon
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // RequestHandlerStub -
 type RequestHandlerStub struct {
@@ -62,8 +65,10 @@ func (rhs *RequestHandlerStub) SetEpoch(_ uint32) {
 // RequestShardHeader -
 func (rhs *RequestHandlerStub) RequestShardHeader(shardID uint32, hash []byte) {
 	if rhs.RequestShardHeaderCalled == nil {
+		fmt.Println("I DONT HAVE A HANDLER")
 		return
 	}
+	fmt.Println("I HAVE A HANDLER")
 	rhs.RequestShardHeaderCalled(shardID, hash)
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request
- Unit test was based on waiting certain amount of time for a goroutine to finish execution which can cause non-deterministic results. 
  
## Proposed changes
- Fixed by properly populating the header pool when requesting it and using a wait group to deterministically determine when the header should have reached the pool 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
