### PR TITLE
Remove prev proof api block

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -192,6 +192,19 @@
         MaxBatchSize = 100
         MaxOpenFiles = 10
 
+[ProofsStorage]
+    [ProofsStorage.Cache]
+        Name = "ProofsStorage"
+        Capacity = 1000
+        Type = "SizeLRU"
+        SizeInBytes = 20971520 #20MB
+    [ProofsStorage.DB]
+        FilePath = "Proofs"
+        Type = "LvlDBSerial"
+        BatchDelaySeconds = 2
+        MaxBatchSize = 100
+        MaxOpenFiles = 10
+
 [TxStorage]
     [TxStorage.Cache]
         Name = "TxStorage"

--- a/config/config.go
+++ b/config/config.go
@@ -166,6 +166,7 @@ type Config struct {
 
 	BootstrapStorage StorageConfig
 	MetaBlockStorage StorageConfig
+	ProofStorage     StorageConfig
 
 	AccountsTrieStorage      StorageConfig
 	PeerAccountsTrieStorage  StorageConfig

--- a/dataRetriever/unitType.go
+++ b/dataRetriever/unitType.go
@@ -49,6 +49,8 @@ const (
 	PeerAccountsUnit UnitType = 21
 	// ScheduledSCRsUnit is the scheduled SCRs storage unit identifier
 	ScheduledSCRsUnit UnitType = 22
+	// ProofsUnit is the header proofs unit identifier
+	ProofsUnit UnitType = 23
 
 	// ShardHdrNonceHashDataUnit is the header nonce-hash pair data unit identifier
 	//TODO: Add only unit types lower than 100

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.9.3
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiversx/mx-chain-communication-go v1.2.0
-	github.com/multiversx/mx-chain-core-go v1.3.0
+	github.com/multiversx/mx-chain-core-go v1.3.1-0.20250403071012-623c95e1298c
 	github.com/multiversx/mx-chain-crypto-go v1.2.12
 	github.com/multiversx/mx-chain-es-indexer-go v1.8.0
 	github.com/multiversx/mx-chain-logger-go v1.0.15

--- a/go.sum
+++ b/go.sum
@@ -391,8 +391,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.2.0 h1:0wOoLldiRbvaOPxwICbnRCqCpLqPewg8M/FMbC/0OXY=
 github.com/multiversx/mx-chain-communication-go v1.2.0/go.mod h1:wS3aAwkmHbC9mlzQdvL6p7l8Rqw3vmzhj7WZW1dTveA=
-github.com/multiversx/mx-chain-core-go v1.3.0 h1:GhDlvwHAhG5AabgCoGxwdtTEzVCa0KPkGAKB+BtIgQ0=
-github.com/multiversx/mx-chain-core-go v1.3.0/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
+github.com/multiversx/mx-chain-core-go v1.3.1-0.20250403071012-623c95e1298c h1:dHfBvYn7akZ42EnyNAX5IRXR+FpWwWtgGu7MX+P7dJ8=
+github.com/multiversx/mx-chain-core-go v1.3.1-0.20250403071012-623c95e1298c/go.mod h1:B5zU4MFyJezmEzCsAHE9YNULmGCm2zbPHvl9hazNxmE=
 github.com/multiversx/mx-chain-crypto-go v1.2.12 h1:zWip7rpUS4CGthJxfKn5MZfMfYPjVjIiCID6uX5BSOk=
 github.com/multiversx/mx-chain-crypto-go v1.2.12/go.mod h1:HzcPpCm1zanNct/6h2rIh+MFrlXbjA5C8+uMyXj3LI4=
 github.com/multiversx/mx-chain-es-indexer-go v1.8.0 h1:VLN9V3yNxchyGub25yOIUoa3KOuxqxGfRuXIH5f24s8=

--- a/node/external/blockAPI/metaBlock.go
+++ b/node/external/blockAPI/metaBlock.go
@@ -253,7 +253,7 @@ func (mbp *metaAPIBlockProcessor) convertMetaBlockBytesToAPIBlock(hash []byte, b
 	addScheduledInfoInBlock(blockHeader, apiMetaBlock)
 	addStartOfEpochInfoInBlock(blockHeader, apiMetaBlock)
 
-	err = mbp.addProofs(hash, blockHeader, apiMetaBlock, mbp.getHeaderHandler)
+	err = mbp.addProofs(hash, blockHeader, apiMetaBlock)
 	if err != nil {
 		return nil, err
 	}

--- a/node/external/blockAPI/shardBlock.go
+++ b/node/external/blockAPI/shardBlock.go
@@ -242,7 +242,7 @@ func (sbp *shardAPIBlockProcessor) convertShardBlockBytesToAPIBlock(hash []byte,
 	}
 
 	addScheduledInfoInBlock(blockHeader, apiBlock)
-	err = sbp.addProofs(hash, blockHeader, apiBlock, sbp.getHeaderHandler)
+	err = sbp.addProofs(hash, blockHeader, apiBlock)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/factory/storageServiceFactory.go
+++ b/storage/factory/storageServiceFactory.go
@@ -235,6 +235,16 @@ func (psf *StorageServiceFactory) createAndAddBaseStorageUnits(
 	}
 	store.AddStorer(dataRetriever.MetaBlockUnit, metaBlockUnit)
 
+	proofsUnitArgs, err := psf.createPruningStorerArgs(psf.generalConfig.ProofStorage, disabledCustomDatabaseRemover)
+	if err != nil {
+		return err
+	}
+	proofsUnit, err := psf.createPruningPersister(proofsUnitArgs)
+	if err != nil {
+		return fmt.Errorf("%w for ProofsStorage", err)
+	}
+	store.AddStorer(dataRetriever.ProofsUnit, proofsUnit)
+
 	metaHdrHashNonceUnit, err := psf.createStaticStorageUnit(psf.generalConfig.MetaHdrNonceHashStorage, shardID, emptyDBPathSuffix)
 	if err != nil {
 		return fmt.Errorf("%w for MetaHdrNonceHashStorage", err)


### PR DESCRIPTION
## Reasoning behind the pull request
- Removed previous header proof from API block structure
- Added storer for `proofs`
- Changed the version of mx-chain-core-go: https://github.com/multiversx/mx-chain-core-go/pull/363
- Changed the version of mx-chain-indexer-go: https://github.com/multiversx/mx-chain-es-indexer-go/pull/337
 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
