### PR TITLE
save keys as bytes instead of hex

### DIFF
--- a/trie/export_test.go
+++ b/trie/export_test.go
@@ -86,11 +86,6 @@ func ExecuteUpdatesFromBatch(tr common.Trie) {
 	_ = pmt.updateTrie()
 }
 
-// KeyBytesToHex -
-func KeyBytesToHex(str []byte) []byte {
-	return keyBytesToHex(str)
-}
-
 // GetBatchManager -
 func GetBatchManager(tr common.Trie) common.TrieBatchManager {
 	return tr.(*patriciaMerkleTrie).batchManager

--- a/trie/keyBuilder/keyBuilder.go
+++ b/trie/keyBuilder/keyBuilder.go
@@ -8,7 +8,11 @@ const (
 	// NibbleSize marks the size of a byte nibble
 	NibbleSize = 4
 
-	keyLength = 32
+	// HexTerminator is the terminator for a trie hex key
+	HexTerminator = 16
+
+	keyLength  = 32
+	nibbleMask = 0x0f
 )
 
 type keyBuilder struct {
@@ -58,6 +62,24 @@ func hexToTrieKeyBytes(hex []byte) ([]byte, error) {
 	}
 
 	return key, nil
+}
+
+// KeyBytesToHex transforms key bytes into hex nibbles. The key nibbles are reversed, meaning that the
+// last key nibble will be the first in the hex key. A hex terminator is added at the end of the hex key.
+func KeyBytesToHex(str []byte) []byte {
+	hexLength := len(str)*2 + 1
+	nibbles := make([]byte, hexLength)
+
+	hexSliceIndex := 0
+	nibbles[hexLength-1] = HexTerminator
+
+	for i := hexLength - 2; i > 0; i -= 2 {
+		nibbles[i] = str[hexSliceIndex] >> NibbleSize
+		nibbles[i-1] = str[hexSliceIndex] & nibbleMask
+		hexSliceIndex++
+	}
+
+	return nibbles
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/trie/keyBuilder/keyBuilder_test.go
+++ b/trie/keyBuilder/keyBuilder_test.go
@@ -49,3 +49,20 @@ func TestHexToTrieKeyBytesInvalidLength(t *testing.T) {
 	assert.Nil(t, key)
 	assert.Equal(t, ErrInvalidLength, err)
 }
+
+func TestKeyBytesToHex(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty string", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, []byte{16}, KeyBytesToHex(nil))
+	})
+	t.Run("convert to hex and reverse", func(t *testing.T) {
+		t.Parallel()
+
+		key := "dog"
+		expected := []byte{7, 6, 15, 6, 4, 6, 16}
+		assert.Equal(t, expected, KeyBytesToHex([]byte(key)))
+	})
+}

--- a/trie/leafNode.go
+++ b/trie/leafNode.go
@@ -14,6 +14,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/trie/keyBuilder"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
@@ -231,7 +232,7 @@ func (ln *leafNode) insertInNewBn(
 	}
 
 	var newKeyForOldLn []byte
-	posForOldLn := byte(hexTerminator)
+	posForOldLn := byte(keyBuilder.HexTerminator)
 	if len(ln.Key) > keyMatchLen {
 		newKeyForOldLn = ln.Key[keyMatchLen+1:]
 		posForOldLn = ln.Key[keyMatchLen]

--- a/trie/node.go
+++ b/trie/node.go
@@ -11,7 +11,6 @@ import (
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
-	"github.com/multiversx/mx-chain-go/trie/keyBuilder"
 	logger "github.com/multiversx/mx-chain-logger-go"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
@@ -19,8 +18,6 @@ import (
 const (
 	nrOfChildren         = 17
 	firstByte            = 0
-	hexTerminator        = 16
-	nibbleMask           = 0x0f
 	pointerSizeInBytes   = 8
 	numNodeInnerPointers = 2 // each trie node contains a marshalizer and a hasher
 	pollingIdleNode      = time.Millisecond
@@ -158,24 +155,6 @@ func getEmptyNodeOfType(t byte) (node, error) {
 
 func childPosOutOfRange(pos byte) bool {
 	return pos >= nrOfChildren
-}
-
-// keyBytesToHex transforms key bytes into hex nibbles. The key nibbles are reversed, meaning that the
-// last key nibble will be the first in the hex key. A hex terminator is added at the end of the hex key.
-func keyBytesToHex(str []byte) []byte {
-	hexLength := len(str)*2 + 1
-	nibbles := make([]byte, hexLength)
-
-	hexSliceIndex := 0
-	nibbles[hexLength-1] = hexTerminator
-
-	for i := hexLength - 2; i > 0; i -= 2 {
-		nibbles[i] = str[hexSliceIndex] >> keyBuilder.NibbleSize
-		nibbles[i-1] = str[hexSliceIndex] & nibbleMask
-		hexSliceIndex++
-	}
-
-	return nibbles
 }
 
 // prefixLen returns the length of the common prefix of a and b.

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -340,7 +340,7 @@ func TestKeyBytesToHex(t *testing.T) {
 	}
 
 	for i := range test {
-		assert.Equal(t, test[i].hex, keyBytesToHex(test[i].key))
+		assert.Equal(t, test[i].hex, keyBuilder.KeyBytesToHex(test[i].key))
 	}
 }
 

--- a/trie/patriciaMerkleTrie_test.go
+++ b/trie/patriciaMerkleTrie_test.go
@@ -1606,7 +1606,7 @@ func TestPatriciaMerkleTrie_AddBatchedDataToTrie(t *testing.T) {
 
 		bm := trie.GetBatchManager(tr)
 		for i := 0; i < numOperations; i++ {
-			key := trie.KeyBytesToHex([]byte("dog" + strconv.Itoa(i)))
+			key := []byte("dog" + strconv.Itoa(i))
 			val, present := bm.Get(key)
 			assert.True(t, present)
 			if i%2 == 0 {
@@ -1669,7 +1669,7 @@ func TestPatriciaMerkleTrie_AddBatchedDataToTrie(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, []byte("reindeer"), val)
 
-			val, found := bm.Get(trie.KeyBytesToHex([]byte("dog" + strconv.Itoa(i))))
+			val, found := bm.Get([]byte("dog" + strconv.Itoa(i)))
 			assert.False(t, found)
 			assert.Nil(t, val)
 		}
@@ -1679,7 +1679,7 @@ func TestPatriciaMerkleTrie_AddBatchedDataToTrie(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, []byte("reindeer"), val)
 
-			val, found := bm.Get(trie.KeyBytesToHex([]byte("dog" + strconv.Itoa(i))))
+			val, found := bm.Get([]byte("dog" + strconv.Itoa(i)))
 			assert.True(t, found)
 			assert.Equal(t, []byte("reindeer"), val)
 		}
@@ -1743,7 +1743,7 @@ func TestPatriciaMerkleTrie_AddBatchedDataToTrie(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, []byte("reindeer"), val)
 
-			val, found := bm.Get(trie.KeyBytesToHex([]byte("dog" + strconv.Itoa(i))))
+			val, found := bm.Get(keyBuilder.KeyBytesToHex([]byte("dog" + strconv.Itoa(i))))
 			assert.False(t, found)
 			assert.Nil(t, val)
 		}
@@ -1793,7 +1793,7 @@ func TestPatriciaMerkleTrie_Get(t *testing.T) {
 		// check some values are in the batch
 		bm := trie.GetBatchManager(tr)
 		for i := numTrieValues; i < numTrieValues+numBatchValues; i++ {
-			val, found := bm.Get(trie.KeyBytesToHex([]byte("dog" + strconv.Itoa(i))))
+			val, found := bm.Get([]byte("dog" + strconv.Itoa(i)))
 			assert.True(t, found)
 			assert.Equal(t, []byte("reindeer"+strconv.Itoa(i)), val)
 		}
@@ -1832,7 +1832,7 @@ func TestPatriciaMerkleTrie_Get(t *testing.T) {
 		// check some values are in the batch
 		bm := trie.GetBatchManager(tr)
 		for i := numTrieValues; i < numTrieValues+numBatchValues; i++ {
-			val, found := bm.Get(trie.KeyBytesToHex([]byte("dog" + strconv.Itoa(i))))
+			val, found := bm.Get([]byte("dog" + strconv.Itoa(i)))
 			assert.True(t, found)
 			assert.Equal(t, []byte("reindeer"+strconv.Itoa(i)), val)
 		}

--- a/trie/trieChangesBatch/trieChangesBatch.go
+++ b/trie/trieChangesBatch/trieChangesBatch.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-go/trie/keyBuilder"
 	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
@@ -107,8 +108,9 @@ func (t *trieChangesBatch) IsInterfaceNil() bool {
 
 func getSortedData(dataMap map[string]core.TrieData) []core.TrieData {
 	data := make([]core.TrieData, 0, len(dataMap))
-	for k := range dataMap {
-		data = append(data, dataMap[k])
+	for _, trieData := range dataMap {
+		trieData.Key = keyBuilder.KeyBytesToHex(trieData.Key)
+		data = append(data, trieData)
 	}
 
 	sort.Slice(data, func(i, j int) bool {

--- a/trie/trieChangesBatch/trieChangesBatch_test.go
+++ b/trie/trieChangesBatch/trieChangesBatch_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-go/trie/keyBuilder"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -107,9 +108,9 @@ func TestTrieChangesBatch_GetSortedDataForInsertion(t *testing.T) {
 
 	data := tcb.GetSortedDataForInsertion()
 	assert.Equal(t, 3, len(data))
-	assert.Equal(t, "key1", string(data[0].Key))
-	assert.Equal(t, "key2", string(data[1].Key))
-	assert.Equal(t, "key3", string(data[2].Key))
+	assert.Equal(t, keyBuilder.KeyBytesToHex([]byte("key1")), data[0].Key)
+	assert.Equal(t, keyBuilder.KeyBytesToHex([]byte("key2")), data[1].Key)
+	assert.Equal(t, keyBuilder.KeyBytesToHex([]byte("key3")), data[2].Key)
 }
 
 func TestTrieChangesBatch_GetSortedDataForRemoval(t *testing.T) {
@@ -127,7 +128,7 @@ func TestTrieChangesBatch_GetSortedDataForRemoval(t *testing.T) {
 
 	data := tcb.GetSortedDataForRemoval()
 	assert.Equal(t, 3, len(data))
-	assert.Equal(t, key1, string(data[0].Key))
-	assert.Equal(t, key2, string(data[1].Key))
-	assert.Equal(t, key3, string(data[2].Key))
+	assert.Equal(t, keyBuilder.KeyBytesToHex([]byte(key1)), data[0].Key)
+	assert.Equal(t, keyBuilder.KeyBytesToHex([]byte(key2)), data[1].Key)
+	assert.Equal(t, keyBuilder.KeyBytesToHex([]byte(key3)), data[2].Key)
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- The keys that are saved in the batch are saved as `hex`. This means that the keys occupy two times as much space
  
## Proposed changes
- Save keys as bytes instead of hex inside the batcher, and convert to hex only when inserting in the trie

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
