### PR TITLE
Merge andromeda activation flags

### DIFF
--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -342,9 +342,6 @@
     # EquivalentMessagesEnableEpoch represents the epoch when the equivalent messages are enabled
     EquivalentMessagesEnableEpoch = 8 # the chain simulator tests for staking v4 fail if this is set earlier, as they test the transition in epochs 4-7
 
-    # FixedOrderInConsensusEnableEpoch represents the epoch when the fixed order in consensus is enabled
-    FixedOrderInConsensusEnableEpoch = 8 # the chain simulator tests for staking v4 fail if this is set earlier, as they test the transition in epochs 4-7
-
     # BLSMultiSignerEnableEpoch represents the activation epoch for different types of BLS multi-signers
     BLSMultiSignerEnableEpoch = [
         { EnableEpoch = 0, Type = "no-KOSK" },

--- a/common/enablers/enableEpochsHandler.go
+++ b/common/enablers/enableEpochsHandler.go
@@ -798,12 +798,6 @@ func (handler *enableEpochsHandler) createAllFlagsMap() {
 			},
 			activationEpoch: handler.enableEpochsConfig.EquivalentMessagesEnableEpoch,
 		},
-		common.FixedOrderInConsensusFlag: {
-			isActiveInEpoch: func(epoch uint32) bool {
-				return epoch >= handler.enableEpochsConfig.FixedOrderInConsensusEnableEpoch
-			},
-			activationEpoch: handler.enableEpochsConfig.FixedOrderInConsensusEnableEpoch,
-		},
 	}
 }
 

--- a/common/enablers/enableEpochsHandler_test.go
+++ b/common/enablers/enableEpochsHandler_test.go
@@ -126,7 +126,6 @@ func createEnableEpochsConfig() config.EnableEpochs {
 		RelayedTransactionsV3EnableEpoch:                         109,
 		RelayedTransactionsV3FixESDTTransferEnableEpoch:          110,
 		EquivalentMessagesEnableEpoch:                            111,
-		FixedOrderInConsensusEnableEpoch:                         112,
 	}
 }
 
@@ -330,7 +329,6 @@ func TestEnableEpochsHandler_IsFlagEnabled(t *testing.T) {
 	require.True(t, handler.IsFlagEnabled(common.FixRelayedBaseCostFlag))
 	require.True(t, handler.IsFlagEnabled(common.FixRelayedMoveBalanceToNonPayableSCFlag))
 	require.True(t, handler.IsFlagEnabled(common.EquivalentMessagesFlag))
-	require.True(t, handler.IsFlagEnabled(common.FixedOrderInConsensusFlag))
 }
 
 func TestEnableEpochsHandler_GetActivationEpoch(t *testing.T) {
@@ -457,7 +455,6 @@ func TestEnableEpochsHandler_GetActivationEpoch(t *testing.T) {
 	require.Equal(t, cfg.RelayedTransactionsV3EnableEpoch, handler.GetActivationEpoch(common.RelayedTransactionsV3Flag))
 	require.Equal(t, cfg.RelayedTransactionsV3FixESDTTransferEnableEpoch, handler.GetActivationEpoch(common.RelayedTransactionsV3FixESDTTransferFlag))
 	require.Equal(t, cfg.EquivalentMessagesEnableEpoch, handler.GetActivationEpoch(common.EquivalentMessagesFlag))
-	require.Equal(t, cfg.FixedOrderInConsensusEnableEpoch, handler.GetActivationEpoch(common.FixedOrderInConsensusFlag))
 }
 
 func TestEnableEpochsHandler_IsInterfaceNil(t *testing.T) {

--- a/config/epochConfig.go
+++ b/config/epochConfig.go
@@ -125,7 +125,6 @@ type EnableEpochs struct {
 	RelayedTransactionsV3EnableEpoch                         uint32
 	RelayedTransactionsV3FixESDTTransferEnableEpoch          uint32
 	EquivalentMessagesEnableEpoch                            uint32
-	FixedOrderInConsensusEnableEpoch                         uint32
 	BLSMultiSignerEnableEpoch                                []MultiSignerConfig
 }
 

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -911,9 +911,6 @@ func TestEnableEpochConfig(t *testing.T) {
 	# EquivalentMessagesEnableEpoch represents the epoch when the equivalent messages are enabled
 	EquivalentMessagesEnableEpoch = 105
 
-	# FixedOrderInConsensusEnableEpoch represents the epoch when the fixed order in consensus is enabled
-	FixedOrderInConsensusEnableEpoch = 106
-
     # MaxNodesChangeEnableEpoch holds configuration for changing the maximum number of nodes and the enabling epoch
     MaxNodesChangeEnableEpoch = [
         { EpochEnable = 44, MaxNumNodes = 2169, NodesToShufflePerShard = 80 },
@@ -1037,7 +1034,6 @@ func TestEnableEpochConfig(t *testing.T) {
 			RelayedTransactionsV3EnableEpoch:                         103,
 			RelayedTransactionsV3FixESDTTransferEnableEpoch:          104,
 			EquivalentMessagesEnableEpoch:                            105,
-			FixedOrderInConsensusEnableEpoch:                         106,
 			MaxNodesChangeEnableEpoch: []MaxNodesChangeConfig{
 				{
 					EpochEnable:            44,

--- a/integrationTests/chainSimulator/staking/jail/jail_test.go
+++ b/integrationTests/chainSimulator/staking/jail/jail_test.go
@@ -78,7 +78,6 @@ func testChainSimulatorJailAndUnJail(t *testing.T, targetEpoch int32, nodeStatus
 		MetaChainMinNodes:      4,
 		AlterConfigsFunction: func(cfg *config.Configs) {
 			configs.SetStakingV4ActivationEpochs(cfg, stakingV4JailUnJailStep1EnableEpoch)
-			cfg.EpochConfig.EnableEpochs.FixedOrderInConsensusEnableEpoch = 100
 			cfg.EpochConfig.EnableEpochs.EquivalentMessagesEnableEpoch = 100
 			newNumNodes := cfg.SystemSCConfig.StakingSystemSCConfig.MaxNumberOfNodesForStake + 8 // 8 nodes until new nodes will be placed on queue
 			configs.SetMaxNumberOfNodesInConfigs(cfg, uint32(newNumNodes), 0, numOfShards)

--- a/integrationTests/chainSimulator/staking/stakingProvider/delegation_test.go
+++ b/integrationTests/chainSimulator/staking/stakingProvider/delegation_test.go
@@ -96,7 +96,6 @@ func TestChainSimulator_MakeNewContractFromValidatorData(t *testing.T) {
 				cfg.EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch[2].EpochEnable = 102
 
 				cfg.EpochConfig.EnableEpochs.EquivalentMessagesEnableEpoch = 1
-				cfg.EpochConfig.EnableEpochs.FixedOrderInConsensusEnableEpoch = 1
 			},
 		})
 		require.Nil(t, err)
@@ -144,7 +143,6 @@ func TestChainSimulator_MakeNewContractFromValidatorData(t *testing.T) {
 				cfg.EpochConfig.EnableEpochs.MaxNodesChangeEnableEpoch[2].EpochEnable = 102
 
 				cfg.EpochConfig.EnableEpochs.EquivalentMessagesEnableEpoch = 1
-				cfg.EpochConfig.EnableEpochs.FixedOrderInConsensusEnableEpoch = 1
 			},
 		})
 		require.Nil(t, err)

--- a/integrationTests/consensus/consensusSigning_test.go
+++ b/integrationTests/consensus/consensusSigning_test.go
@@ -29,7 +29,6 @@ func initNodesWithTestSigner(
 
 	enableEpochsConfig := integrationTests.CreateEnableEpochsConfig()
 	enableEpochsConfig.EquivalentMessagesEnableEpoch = equivalentProofsActivationEpoch
-	enableEpochsConfig.FixedOrderInConsensusEnableEpoch = equivalentProofsActivationEpoch
 
 	nodes := integrationTests.CreateNodesWithTestFullNode(
 		int(numMetaNodes),

--- a/integrationTests/consensus/consensus_test.go
+++ b/integrationTests/consensus/consensus_test.go
@@ -97,7 +97,6 @@ func testConsensusBLSWithFullProcessing(t *testing.T, equivalentProofsActivation
 	enableEpochsConfig := integrationTests.CreateEnableEpochsConfig()
 
 	enableEpochsConfig.EquivalentMessagesEnableEpoch = equivalentProofsActivationEpoch
-	enableEpochsConfig.FixedOrderInConsensusEnableEpoch = equivalentProofsActivationEpoch
 
 	fmt.Println("Step 1. Setup nodes...")
 
@@ -410,7 +409,6 @@ func runFullConsensusTest(
 
 	equivalentProofsActivationEpoch := integrationTests.UnreachableEpoch
 	enableEpochsConfig.EquivalentMessagesEnableEpoch = equivalentProofsActivationEpoch
-	enableEpochsConfig.FixedOrderInConsensusEnableEpoch = equivalentProofsActivationEpoch
 
 	nodes := initNodesAndTest(
 		numMetaNodes,
@@ -470,7 +468,6 @@ func runConsensusWithNotEnoughValidators(t *testing.T, consensusType string) {
 	roundTime := uint64(1000)
 	enableEpochsConfig := integrationTests.CreateEnableEpochsConfig()
 	enableEpochsConfig.EquivalentMessagesEnableEpoch = integrationTests.UnreachableEpoch
-	enableEpochsConfig.FixedOrderInConsensusEnableEpoch = integrationTests.UnreachableEpoch
 	nodes := initNodesAndTest(numMetaNodes, numNodes, consensusSize, numInvalid, roundTime, consensusType, 1, enableEpochsConfig)
 
 	defer func() {

--- a/integrationTests/multiShard/endOfEpoch/epochStartChangeWithContinuousTransactionsInMultiShardedEnvironment/epochStartChangeWithContinuousTransactionsInMultiShardedEnvironment_test.go
+++ b/integrationTests/multiShard/endOfEpoch/epochStartChangeWithContinuousTransactionsInMultiShardedEnvironment/epochStartChangeWithContinuousTransactionsInMultiShardedEnvironment_test.go
@@ -27,7 +27,6 @@ func TestEpochStartChangeWithContinuousTransactionsInMultiShardedEnvironment(t *
 		StakingV4Step2EnableEpoch:            integrationTests.UnreachableEpoch,
 		StakingV4Step3EnableEpoch:            integrationTests.UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:        integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:     integrationTests.UnreachableEpoch,
 	}
 
 	nodes := integrationTests.CreateNodesWithEnableEpochs(

--- a/integrationTests/multiShard/endOfEpoch/epochStartChangeWithoutTransactionInMultiShardedEnvironment/epochStartChangeWithoutTransactionInMultiShardedEnvironment_test.go
+++ b/integrationTests/multiShard/endOfEpoch/epochStartChangeWithoutTransactionInMultiShardedEnvironment/epochStartChangeWithoutTransactionInMultiShardedEnvironment_test.go
@@ -26,7 +26,6 @@ func TestEpochStartChangeWithoutTransactionInMultiShardedEnvironment(t *testing.
 		StakingV4Step2EnableEpoch:            integrationTests.UnreachableEpoch,
 		StakingV4Step3EnableEpoch:            integrationTests.UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:        integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:     integrationTests.UnreachableEpoch,
 	}
 
 	nodes := integrationTests.CreateNodesWithEnableEpochs(

--- a/integrationTests/multiShard/endOfEpoch/startInEpoch/startInEpoch_test.go
+++ b/integrationTests/multiShard/endOfEpoch/startInEpoch/startInEpoch_test.go
@@ -78,7 +78,6 @@ func testNodeStartsInEpoch(t *testing.T, shardID uint32, expectedHighestRound ui
 		StakingV4Step2EnableEpoch:            integrationTests.UnreachableEpoch,
 		StakingV4Step3EnableEpoch:            integrationTests.UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:        integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:     integrationTests.UnreachableEpoch,
 	}
 
 	nodes := integrationTests.CreateNodesWithEnableEpochs(

--- a/integrationTests/multiShard/smartContract/polynetworkbridge/bridge_test.go
+++ b/integrationTests/multiShard/smartContract/polynetworkbridge/bridge_test.go
@@ -33,7 +33,6 @@ func TestBridgeSetupAndBurn(t *testing.T) {
 		SCProcessorV2EnableEpoch:            integrationTests.UnreachableEpoch,
 		FixAsyncCallBackArgsListEnableEpoch: integrationTests.UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:       integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:    integrationTests.UnreachableEpoch,
 	}
 	arwenVersion := config.WasmVMVersionByEpoch{Version: "v1.4"}
 	vmConfig := &config.VirtualMachineConfig{

--- a/integrationTests/multiShard/txScenarios/common.go
+++ b/integrationTests/multiShard/txScenarios/common.go
@@ -42,7 +42,6 @@ func createGeneralSetupForTxTest(initialBalance *big.Int) (
 		ScheduledMiniBlocksEnableEpoch:              integrationTests.UnreachableEpoch,
 		MiniBlockPartialExecutionEnableEpoch:        integrationTests.UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:               integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:            integrationTests.UnreachableEpoch,
 	}
 
 	nodes := integrationTests.CreateNodesWithEnableEpochs(

--- a/integrationTests/state/stateTrie/stateTrie_test.go
+++ b/integrationTests/state/stateTrie/stateTrie_test.go
@@ -2491,7 +2491,6 @@ func startNodesAndIssueToken(
 		StakingV4Step2EnableEpoch:                   integrationTests.UnreachableEpoch,
 		StakingV4Step3EnableEpoch:                   integrationTests.UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:               integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:            integrationTests.UnreachableEpoch,
 		AutoBalanceDataTriesEnableEpoch:             1,
 	}
 	nodes = integrationTests.CreateNodesWithEnableEpochs(

--- a/integrationTests/sync/basicSync/basicSync_test.go
+++ b/integrationTests/sync/basicSync/basicSync_test.go
@@ -210,7 +210,6 @@ func TestSyncWorksInShard_EmptyBlocksNoForks_With_EquivalentProofs(t *testing.T)
 
 	enableEpochs := integrationTests.CreateEnableEpochsConfig()
 	enableEpochs.EquivalentMessagesEnableEpoch = uint32(0)
-	enableEpochs.FixedOrderInConsensusEnableEpoch = uint32(0)
 
 	nodes := make([]*integrationTests.TestProcessorNode, numNodesPerShard+1)
 	connectableNodes := make([]integrationTests.Connectable, 0)
@@ -299,7 +298,6 @@ func TestSyncMetaAndShard_With_EquivalentProofs(t *testing.T) {
 
 	enableEpochs := integrationTests.CreateEnableEpochsConfig()
 	enableEpochs.EquivalentMessagesEnableEpoch = uint32(0)
-	enableEpochs.FixedOrderInConsensusEnableEpoch = uint32(0)
 
 	nodes := make([]*integrationTests.TestProcessorNode, 2*numNodesPerShard)
 	leaders := make([]*integrationTests.TestProcessorNode, 0)

--- a/integrationTests/testNetwork.go
+++ b/integrationTests/testNetwork.go
@@ -423,7 +423,6 @@ func (net *TestNetwork) createNodes() {
 		ScheduledMiniBlocksEnableEpoch:       UnreachableEpoch,
 		MiniBlockPartialExecutionEnableEpoch: UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:        UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:     UnreachableEpoch,
 	}
 
 	net.Nodes = CreateNodesWithEnableEpochs(

--- a/integrationTests/testProcessorNode.go
+++ b/integrationTests/testProcessorNode.go
@@ -3375,7 +3375,6 @@ func CreateEnableEpochsConfig() config.EnableEpochs {
 		FixRelayedBaseCostEnableEpoch:                     UnreachableEpoch,
 		FixRelayedMoveBalanceToNonPayableSCEnableEpoch:    UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:                     UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:                  UnreachableEpoch,
 	}
 }
 
@@ -3688,7 +3687,6 @@ func GetDefaultEnableEpochsConfig() *config.EnableEpochs {
 		StakingV4Step2EnableEpoch:                       UnreachableEpoch,
 		StakingV4Step3EnableEpoch:                       UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:                   UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:                UnreachableEpoch,
 	}
 }
 

--- a/integrationTests/testProcessorNodeWithMultisigner.go
+++ b/integrationTests/testProcessorNodeWithMultisigner.go
@@ -185,7 +185,6 @@ func CreateNodeWithBLSAndTxKeys(
 		MiniBlockPartialExecutionEnableEpoch: UnreachableEpoch,
 		RefactorPeersMiniBlocksEnableEpoch:   UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:        UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:     UnreachableEpoch,
 	}
 
 	return CreateNode(
@@ -248,7 +247,6 @@ func CreateNodesWithNodesCoordinatorFactory(
 		StakingV4Step2EnableEpoch:                       UnreachableEpoch,
 		StakingV4Step3EnableEpoch:                       UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:                   UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:                UnreachableEpoch,
 	}
 
 	nodesMap := make(map[uint32][]*TestProcessorNode)
@@ -502,7 +500,6 @@ func CreateNodesWithNodesCoordinatorAndHeaderSigVerifier(
 					ScheduledMiniBlocksEnableEpoch:       UnreachableEpoch,
 					MiniBlockPartialExecutionEnableEpoch: UnreachableEpoch,
 					EquivalentMessagesEnableEpoch:        UnreachableEpoch,
-					FixedOrderInConsensusEnableEpoch:     UnreachableEpoch,
 				},
 				NodeKeys:                cp.NodesKeys[shardId][i],
 				NodesSetup:              nodesSetup,
@@ -644,7 +641,6 @@ func CreateNodesWithNodesCoordinatorKeygenAndSingleSigner(
 					ScheduledMiniBlocksEnableEpoch:       UnreachableEpoch,
 					MiniBlockPartialExecutionEnableEpoch: UnreachableEpoch,
 					EquivalentMessagesEnableEpoch:        UnreachableEpoch,
-					FixedOrderInConsensusEnableEpoch:     UnreachableEpoch,
 				},
 				NodeKeys:                cp.NodesKeys[shardId][i],
 				NodesSetup:              nodesSetup,

--- a/integrationTests/vm/esdt/common.go
+++ b/integrationTests/vm/esdt/common.go
@@ -172,7 +172,6 @@ func CreateNodesAndPrepareBalances(numOfShards int) ([]*integrationTests.TestPro
 		ScheduledMiniBlocksEnableEpoch:              integrationTests.UnreachableEpoch,
 		MiniBlockPartialExecutionEnableEpoch:        integrationTests.UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:               integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:            integrationTests.UnreachableEpoch,
 	}
 	roundsConfig := testscommon.GetDefaultRoundsConfig()
 	return CreateNodesAndPrepareBalancesWithEpochsAndRoundsConfig(

--- a/integrationTests/vm/esdt/process/esdtProcess_test.go
+++ b/integrationTests/vm/esdt/process/esdtProcess_test.go
@@ -45,7 +45,6 @@ func TestESDTIssueAndTransactionsOnMultiShardEnvironment(t *testing.T) {
 		ScheduledMiniBlocksEnableEpoch:              integrationTests.UnreachableEpoch,
 		MiniBlockPartialExecutionEnableEpoch:        integrationTests.UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:               integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:            integrationTests.UnreachableEpoch,
 	}
 	nodes := integrationTests.CreateNodesWithEnableEpochs(
 		numOfShards,
@@ -179,7 +178,6 @@ func TestESDTCallBurnOnANonBurnableToken(t *testing.T) {
 		MiniBlockPartialExecutionEnableEpoch:        integrationTests.UnreachableEpoch,
 		MultiClaimOnDelegationEnableEpoch:           integrationTests.UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:               integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:            integrationTests.UnreachableEpoch,
 	}
 
 	nodes := integrationTests.CreateNodesWithEnableEpochs(
@@ -1291,7 +1289,6 @@ func TestExecOnDestWithTokenTransferFromScAtoScBWithIntermediaryExecOnDest_NotEn
 		SCProcessorV2EnableEpoch:                integrationTests.UnreachableEpoch,
 		FailExecutionOnEveryAPIErrorEnableEpoch: integrationTests.UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:           integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:        integrationTests.UnreachableEpoch,
 	}
 	arwenVersion := config.WasmVMVersionByEpoch{Version: "v1.4"}
 	vmConfig := &config.VirtualMachineConfig{
@@ -1990,7 +1987,6 @@ func TestIssueAndBurnESDT_MaxGasPerBlockExceeded(t *testing.T) {
 		GlobalMintBurnDisableEpoch:           integrationTests.UnreachableEpoch,
 		MaxBlockchainHookCountersEnableEpoch: integrationTests.UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:        integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:     integrationTests.UnreachableEpoch,
 	}
 	nodes := integrationTests.CreateNodesWithEnableEpochs(
 		numOfShards,
@@ -2376,7 +2372,6 @@ func TestESDTIssueUnderProtectedKeyWillReturnTokensBack(t *testing.T) {
 		ScheduledMiniBlocksEnableEpoch:              integrationTests.UnreachableEpoch,
 		MiniBlockPartialExecutionEnableEpoch:        integrationTests.UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:               integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:            integrationTests.UnreachableEpoch,
 	}
 
 	nodes := integrationTests.CreateNodesWithEnableEpochs(

--- a/integrationTests/vm/esdt/roles/esdtRoles_test.go
+++ b/integrationTests/vm/esdt/roles/esdtRoles_test.go
@@ -388,9 +388,8 @@ func TestESDTLocalBurnFromAnyoneOfThisToken(t *testing.T) {
 	numMetachainNodes := 2
 
 	enableEpochs := config.EnableEpochs{
-		ScheduledMiniBlocksEnableEpoch:   integrationTests.UnreachableEpoch,
-		EquivalentMessagesEnableEpoch:    integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch: integrationTests.UnreachableEpoch,
+		ScheduledMiniBlocksEnableEpoch: integrationTests.UnreachableEpoch,
+		EquivalentMessagesEnableEpoch:  integrationTests.UnreachableEpoch,
 	}
 	nodes := integrationTests.CreateNodesWithEnableEpochs(
 		numOfShards,
@@ -481,9 +480,8 @@ func TestESDTWithTransferRoleCrossShardShouldWork(t *testing.T) {
 	numMetachainNodes := 2
 
 	enableEpochs := config.EnableEpochs{
-		ScheduledMiniBlocksEnableEpoch:   integrationTests.UnreachableEpoch,
-		EquivalentMessagesEnableEpoch:    integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch: integrationTests.UnreachableEpoch,
+		ScheduledMiniBlocksEnableEpoch: integrationTests.UnreachableEpoch,
+		EquivalentMessagesEnableEpoch:  integrationTests.UnreachableEpoch,
 	}
 	nodes := integrationTests.CreateNodesWithEnableEpochs(
 		numOfShards,

--- a/integrationTests/vm/staking/componentsHolderCreator.go
+++ b/integrationTests/vm/staking/componentsHolderCreator.go
@@ -71,7 +71,6 @@ func createCoreComponents() factory.CoreComponentsHolder {
 		GovernanceEnableEpoch:              integrationTests.UnreachableEpoch,
 		RefactorPeersMiniBlocksEnableEpoch: integrationTests.UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:      integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:   integrationTests.UnreachableEpoch,
 	}
 
 	enableEpochsHandler, _ := enablers.NewEnableEpochsHandler(configEnableEpochs, epochNotifier)

--- a/integrationTests/vm/systemVM/stakingSC_test.go
+++ b/integrationTests/vm/systemVM/stakingSC_test.go
@@ -39,7 +39,6 @@ func TestStakingUnstakingAndUnbondingOnMultiShardEnvironment(t *testing.T) {
 		StakingV4Step2EnableEpoch:            integrationTests.UnreachableEpoch,
 		StakingV4Step3EnableEpoch:            integrationTests.UnreachableEpoch,
 		EquivalentMessagesEnableEpoch:        integrationTests.UnreachableEpoch,
-		FixedOrderInConsensusEnableEpoch:     integrationTests.UnreachableEpoch,
 	}
 
 	nodes := integrationTests.CreateNodesWithEnableEpochs(


### PR DESCRIPTION
## Reasoning behind the pull request
- remove `FixedOrderInConsensusFlag`

## Testing procedure
- To be tested with patch2

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
