### PR TITLE
remove hash from trie nodes and use hash from parent nodes

### DIFF
--- a/trie/baseIterator.go
+++ b/trie/baseIterator.go
@@ -7,8 +7,8 @@ import (
 )
 
 type baseIterator struct {
-	currentNode node
-	nextNodes   []node
+	currentNode nodeWithHash
+	nextNodes   []nodeWithHash
 	db          common.TrieStorageInteractor
 }
 
@@ -36,9 +36,12 @@ func newBaseIterator(trie common.Trie, rootHash []byte) (*baseIterator, error) {
 	}
 
 	return &baseIterator{
-		currentNode: rootNode,
-		nextNodes:   nextNodes,
-		db:          trieStorage,
+		currentNode: nodeWithHash{
+			node: rootNode,
+			hash: rootHash,
+		},
+		nextNodes: nextNodes,
+		db:        trieStorage,
 	}, nil
 }
 
@@ -48,24 +51,28 @@ func (it *baseIterator) HasNext() bool {
 }
 
 // next moves the iterator to the next node
-func (it *baseIterator) next() ([]node, error) {
+func (it *baseIterator) next() ([]nodeWithHash, error) {
 	n := it.nextNodes[0]
 
-	err := n.isEmptyOrNil()
+	if n.node == nil {
+		return nil, ErrNilNode
+	}
+
+	err := n.node.isEmptyOrNil()
 	if err != nil {
 		return nil, ErrNilNode
 	}
 
 	it.currentNode = n
-	return it.currentNode.getChildren(it.db)
+	return it.currentNode.node.getChildren(it.db)
 }
 
 // MarshalizedNode marshalizes the current node, and then returns the serialized node
 func (it *baseIterator) MarshalizedNode() ([]byte, error) {
-	return it.currentNode.getEncodedNode()
+	return it.currentNode.node.getEncodedNode()
 }
 
 // GetHash returns the current node hash
 func (it *baseIterator) GetHash() []byte {
-	return it.currentNode.getHash()
+	return it.currentNode.hash
 }

--- a/trie/baseIterator.go
+++ b/trie/baseIterator.go
@@ -54,12 +54,7 @@ func (it *baseIterator) HasNext() bool {
 func (it *baseIterator) next() ([]nodeWithHash, error) {
 	n := it.nextNodes[0]
 
-	if n.node == nil {
-		return nil, ErrNilNode
-	}
-
-	err := n.node.isEmptyOrNil()
-	if err != nil {
+	if check.IfNil(n.node) {
 		return nil, ErrNilNode
 	}
 

--- a/trie/baseNode.go
+++ b/trie/baseNode.go
@@ -9,24 +9,9 @@ import (
 
 type baseNode struct {
 	mutex  sync.RWMutex
-	hash   []byte
 	dirty  bool
 	marsh  marshal.Marshalizer
 	hasher hashing.Hasher
-}
-
-func (bn *baseNode) getHash() []byte {
-	bn.mutex.RLock()
-	defer bn.mutex.RUnlock()
-
-	return bn.hash
-}
-
-func (bn *baseNode) setGivenHash(hash []byte) {
-	bn.mutex.Lock()
-	defer bn.mutex.Unlock()
-
-	bn.hash = hash
 }
 
 func (bn *baseNode) isDirty() bool {

--- a/trie/branchNode_test.go
+++ b/trie/branchNode_test.go
@@ -63,6 +63,7 @@ func getBnAndCollapsedBn(marshalizer marshal.Marshalizer, hasher hashing.Hasher)
 	ChildrenHashes[13], _ = encodeNodeAndGetHash(children[13])
 	collapsedBn, _ := newBranchNode(marshalizer, hasher)
 	collapsedBn.ChildrenHashes = ChildrenHashes
+	bn.ChildrenHashes = ChildrenHashes
 
 	return bn, collapsedBn
 }
@@ -139,13 +140,6 @@ func getEncodedTrieNodesAndHashes(tr common.Trie) ([][]byte, [][]byte) {
 	return nodes, hashes
 }
 
-func TestBranchNode_getHash(t *testing.T) {
-	t.Parallel()
-
-	bn := &branchNode{baseNode: &baseNode{hash: []byte("test hash")}}
-	assert.Equal(t, bn.hash, bn.getHash())
-}
-
 func TestBranchNode_isDirty(t *testing.T) {
 	t.Parallel()
 
@@ -156,40 +150,6 @@ func TestBranchNode_isDirty(t *testing.T) {
 	assert.Equal(t, false, bn.isDirty())
 }
 
-func TestBranchNode_setHash(t *testing.T) {
-	t.Parallel()
-
-	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	hash, _ := encodeNodeAndGetHash(collapsedBn)
-	manager := getTestGoroutinesManager()
-
-	bn.setHash(manager)
-	assert.Nil(t, manager.GetError())
-	assert.Equal(t, hash, bn.hash)
-}
-
-func TestBranchNode_setHashCollapsedNode(t *testing.T) {
-	t.Parallel()
-
-	_, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	hash, _ := encodeNodeAndGetHash(collapsedBn)
-	manager := getTestGoroutinesManager()
-
-	collapsedBn.setHash(manager)
-	assert.Nil(t, manager.GetError())
-	assert.Equal(t, hash, collapsedBn.hash)
-}
-
-func TestBranchNode_setGivenHash(t *testing.T) {
-	t.Parallel()
-
-	bn := &branchNode{baseNode: &baseNode{}}
-	expectedHash := []byte("node hash")
-
-	bn.setGivenHash(expectedHash)
-	assert.Equal(t, expectedHash, bn.hash)
-}
-
 func TestBranchNode_commit(t *testing.T) {
 	t.Parallel()
 
@@ -198,7 +158,6 @@ func TestBranchNode_commit(t *testing.T) {
 	bn, collapsedBn := getBnAndCollapsedBn(marsh, hasher)
 
 	hash, _ := encodeNodeAndGetHash(collapsedBn)
-	bn.setHash(getTestGoroutinesManager())
 
 	manager := getTestGoroutinesManager()
 	bn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), db, db)
@@ -247,30 +206,56 @@ func TestBranchNode_getEncodedNodeNil(t *testing.T) {
 func TestBranchNode_resolveIfCollapsed(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	childPos := byte(2)
+	t.Run("child pos out of range", func(t *testing.T) {
+		t.Parallel()
 
-	bn.setHash(getTestGoroutinesManager())
-	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
-	resolved, _ := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"), bn.marsh, bn.hasher)
-	resolved.dirty = false
-	resolved.hash = bn.ChildrenHashes[childPos]
+		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
 
-	childNode, err := collapsedBn.resolveIfCollapsed(childPos, db)
-	assert.Nil(t, err)
-	assert.Equal(t, resolved, collapsedBn.children[childPos])
-	assert.Equal(t, resolved, childNode)
-}
+		childNode, childHash, err := bn.resolveIfCollapsed(17, nil)
+		assert.Equal(t, ErrChildPosOutOfRange, err)
+		assert.Nil(t, childNode)
+		assert.Nil(t, childHash)
+	})
+	t.Run("resolve collapsed node", func(t *testing.T) {
+		t.Parallel()
 
-func TestBranchNode_resolveCollapsedPosOutOfRange(t *testing.T) {
-	t.Parallel()
+		db := testscommon.NewMemDbMock()
+		bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		childPos := byte(2)
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+		resolved, _ := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"), bn.marsh, bn.hasher)
+		resolved.dirty = false
+		resolvedHash, _ := encodeNodeAndGetHash(resolved)
 
-	childNode, err := bn.resolveIfCollapsed(17, nil)
-	assert.Equal(t, ErrChildPosOutOfRange, err)
-	assert.Nil(t, childNode)
+		childNode, childHash, err := collapsedBn.resolveIfCollapsed(childPos, db)
+		assert.Nil(t, err)
+		assert.Equal(t, resolved, collapsedBn.children[childPos])
+		assert.Equal(t, resolved, childNode)
+		assert.Equal(t, childHash, resolvedHash)
+	})
+	t.Run("invalid node state", func(t *testing.T) {
+		t.Parallel()
+
+		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn.ChildrenHashes = make([][]byte, nrOfChildren)
+
+		childNode, childHash, err := bn.resolveIfCollapsed(2, nil)
+		assert.Equal(t, ErrInvalidNodeState, err)
+		assert.Nil(t, childNode)
+		assert.Nil(t, childHash)
+	})
+	t.Run("node is not collapsed", func(t *testing.T) {
+		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+
+		resolved, _ := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"), bn.marsh, bn.hasher)
+		resolvedHash, _ := encodeNodeAndGetHash(resolved)
+
+		childNode, childHash, err := bn.resolveIfCollapsed(2, nil)
+		assert.Nil(t, err)
+		assert.Equal(t, resolved, childNode)
+		assert.Equal(t, childHash, resolvedHash)
+	})
 }
 
 func TestBranchNode_tryGet(t *testing.T) {
@@ -328,7 +313,6 @@ func TestBranchNode_tryGetCollapsedNode(t *testing.T) {
 	db := testscommon.NewMemDbMock()
 	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
 
-	bn.setHash(getTestGoroutinesManager())
 	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
 
 	childPos := byte(2)
@@ -436,7 +420,6 @@ func TestBranchNode_insertCollapsedNode(t *testing.T) {
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	bn.setHash(getTestGoroutinesManager())
 	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
 
 	goRoutinesManager := getTestGoroutinesManager()
@@ -455,15 +438,11 @@ func TestBranchNode_insertInStoredBnOnExistingPos(t *testing.T) {
 
 	db := testscommon.NewMemDbMock()
 	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	bn.setHash(getTestGoroutinesManager())
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
 	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
-	bnHash := bn.getHash()
-	nd, _ := bn.getNext(key, db)
-	lnHash := nd.currentNode.getHash()
-	expectedHashes := [][]byte{lnHash, bnHash}
+	expectedHashes := [][]byte{bn.ChildrenHashes[2]}
 
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
@@ -502,13 +481,11 @@ func TestBranchNode_insertInStoredBnOnNilPos(t *testing.T) {
 
 	db := testscommon.NewMemDbMock()
 	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	bn.setHash(getTestGoroutinesManager())
 	nilChildPos := byte(11)
 	key := append([]byte{nilChildPos}, []byte("dog")...)
 
 	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
-	bnHash := bn.getHash()
-	expectedHashes := [][]byte{bnHash}
+	var expectedHashes [][]byte
 
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
@@ -558,11 +535,10 @@ func TestBranchNode_delete(t *testing.T) {
 	t.Parallel()
 
 	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	var children [nrOfChildren]node
-	children[6], _ = newLeafNode(getTrieDataWithDefaultVersion("doe", "doe"), bn.marsh, bn.hasher)
-	children[13], _ = newLeafNode(getTrieDataWithDefaultVersion("doge", "doge"), bn.marsh, bn.hasher)
-	expectedBn, _ := newBranchNode(bn.marsh, bn.hasher)
-	expectedBn.children = children
+
+	expectedBn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	expectedBn.children[2] = nil
+	expectedBn.ChildrenHashes[2] = nil
 
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
@@ -573,9 +549,9 @@ func TestBranchNode_delete(t *testing.T) {
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 
-	expectedBn.setHash(getTestGoroutinesManager())
-	newBn.setHash(getTestGoroutinesManager())
-	assert.Equal(t, expectedBn.getHash(), newBn.getHash())
+	expectedBnHash, _ := encodeNodeAndGetHash(expectedBn)
+	newBnHash, _ := encodeNodeAndGetHash(newBn)
+	assert.Equal(t, expectedBnHash, newBnHash)
 }
 
 func TestBranchNode_deleteFromStoredBn(t *testing.T) {
@@ -583,15 +559,12 @@ func TestBranchNode_deleteFromStoredBn(t *testing.T) {
 
 	db := testscommon.NewMemDbMock()
 	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	bn.setHash(getTestGoroutinesManager())
 	childPos := byte(2)
 	lnKey := append([]byte{childPos}, []byte("dog")...)
 
 	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
-	bnHash := bn.getHash()
-	nd, _ := bn.getNext(lnKey, db)
-	lnHash := nd.currentNode.getHash()
-	expectedHashes := [][]byte{lnHash, bnHash}
+	lnHash := bn.ChildrenHashes[2]
+	expectedHashes := [][]byte{lnHash}
 
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{{Key: lnKey}}
@@ -652,7 +625,6 @@ func TestBranchNode_deleteCollapsedNode(t *testing.T) {
 
 	db := testscommon.NewMemDbMock()
 	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	bn.setHash(getTestGoroutinesManager())
 	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
 
 	childPos := byte(2)
@@ -672,7 +644,8 @@ func TestBranchNode_deleteCollapsedNode(t *testing.T) {
 func TestBranchNode_deleteAndReduceBn(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := newBranchNode(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn.ChildrenHashes[13] = nil
 	var children [nrOfChildren]node
 	firstChildPos := byte(2)
 	secondChildPos := byte(6)
@@ -687,7 +660,6 @@ func TestBranchNode_deleteAndReduceBn(t *testing.T) {
 	data := []core.TrieData{{Key: key}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	ln.setHash(goRoutinesManager)
 	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
@@ -706,7 +678,7 @@ func TestBranchNode_reduceNode(t *testing.T) {
 	key := append([]byte{childPos}, []byte("dog")...)
 	ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string(key), "dog"), bn.marsh, bn.hasher)
 
-	n, newChildHash, err := bn.children[childPos].reduceNode(int(childPos), nil)
+	n, newChildHash, err := bn.children[childPos].reduceNode(int(childPos), bn.ChildrenHashes[childPos], nil)
 	assert.Equal(t, ln, n)
 	assert.Nil(t, err)
 	assert.True(t, newChildHash)
@@ -823,7 +795,6 @@ func TestBranchNode_getChildrenCollapsedBn(t *testing.T) {
 
 	db := testscommon.NewMemDbMock()
 	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	bn.setHash(getTestGoroutinesManager())
 	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
 
 	children, err := collapsedBn.getChildren(db)
@@ -846,7 +817,6 @@ func TestBranchNode_loadChildren(t *testing.T) {
 	marsh, hasher := getTestMarshalizerAndHasher()
 	tr := initTrie()
 	rootNode := tr.GetRootNode()
-	rootNode.setHash(getTestGoroutinesManager())
 	nodes, _ := getEncodedTrieNodesAndHashes(tr)
 	nodesCacher, _ := cache.NewLRUCache(100)
 	for i := range nodes {
@@ -957,39 +927,10 @@ func TestBranchNode_getMarshalizer(t *testing.T) {
 	assert.Equal(t, expectedMarsh, marsh)
 }
 
-func TestBranchNode_setRootHashCollapsedChildren(t *testing.T) {
-	t.Parallel()
-
-	marsh, hasher := getTestMarshalizerAndHasher()
-	bn := &branchNode{
-		CollapsedBn: CollapsedBn{
-			ChildrenHashes: make([][]byte, nrOfChildren),
-		},
-		baseNode: &baseNode{
-			marsh:  marsh,
-			hasher: hasher,
-		},
-	}
-
-	_, collapsedBn := getBnAndCollapsedBn(marsh, hasher)
-	_, collapsedEn := getEnAndCollapsedEn()
-	collapsedLn := getLn(marsh, hasher)
-
-	bn.children[0] = collapsedBn
-	bn.children[1] = collapsedEn
-	bn.children[2] = collapsedLn
-
-	manager := getTestGoroutinesManager()
-	bn.setHash(manager)
-	assert.Nil(t, manager.GetError())
-}
-
 func TestBranchNode_commitCollapsesTrieIfMaxTrieLevelInMemoryIsReached(t *testing.T) {
 	t.Parallel()
 
 	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	bn.setHash(getTestGoroutinesManager())
-	collapsedBn.setHash(getTestGoroutinesManager())
 
 	manager := getTestGoroutinesManager()
 	bn.commitDirty(0, 1, manager, hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
@@ -997,7 +938,6 @@ func TestBranchNode_commitCollapsesTrieIfMaxTrieLevelInMemoryIsReached(t *testin
 
 	assert.Equal(t, collapsedBn.ChildrenHashes, bn.ChildrenHashes)
 	assert.Equal(t, collapsedBn.children, bn.children)
-	assert.Equal(t, collapsedBn.hash, bn.hash)
 }
 
 func TestBranchNode_reduceNodeBnChild(t *testing.T) {
@@ -1007,8 +947,9 @@ func TestBranchNode_reduceNodeBnChild(t *testing.T) {
 	en, _ := getEnAndCollapsedEn()
 	pos := 5
 	expectedNode, _ := newExtensionNode([]byte{byte(pos)}, en.child, marsh, hasher)
+	expectedNode.ChildHash = en.ChildHash
 
-	newNode, newChildHash, err := en.child.reduceNode(pos, nil)
+	newNode, newChildHash, err := en.child.reduceNode(pos, en.ChildHash, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedNode, newNode)
 	assert.False(t, newChildHash)
@@ -1022,8 +963,6 @@ func TestBranchNode_printShouldNotPanicEvenIfNodeIsCollapsed(t *testing.T) {
 
 	db := testscommon.NewMemDbMock()
 	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	bn.setHash(getTestGoroutinesManager())
-	collapsedBn.setHash(getTestGoroutinesManager())
 	collapsedBn.setDirty(false)
 	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
 
@@ -1074,20 +1013,18 @@ func TestBranchNode_SizeInBytes(t *testing.T) {
 
 	collapsed1 := []byte("collapsed1")
 	collapsed2 := []byte("collapsed2")
-	hash := []byte("hash")
 	bn = &branchNode{
 		CollapsedBn: CollapsedBn{
 			ChildrenHashes: [][]byte{collapsed1, collapsed2},
 		},
 		children: [17]node{},
 		baseNode: &baseNode{
-			hash:   hash,
 			dirty:  false,
 			marsh:  nil,
 			hasher: nil,
 		},
 	}
-	assert.Equal(t, len(collapsed1)+len(collapsed2)+len(hash)+1+19*pointerSizeInBytes, bn.sizeInBytes())
+	assert.Equal(t, len(collapsed1)+len(collapsed2)+1+19*pointerSizeInBytes, bn.sizeInBytes())
 }
 
 func TestBranchNode_commitSnapshotContextDone(t *testing.T) {
@@ -1127,7 +1064,6 @@ func TestBranchNode_commitSnapshotChildIsMissingErr(t *testing.T) {
 	}
 
 	_, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	collapsedBn.setHash(getTestGoroutinesManager())
 	missingNodesChan := make(chan []byte, 10)
 	nodeBytes, _ := collapsedBn.getEncodedNode()
 	err := collapsedBn.commitSnapshot(db, nil, missingNodesChan, context.Background(), statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, nodeBytes, 0)
@@ -1490,13 +1426,10 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 
 		db := testscommon.NewMemDbMock()
 		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-		bn.setHash(getTestGoroutinesManager())
 		manager := getTestGoroutinesManager()
 		bn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), db, db)
 		assert.Nil(t, manager.GetError())
 		assert.False(t, bn.dirty)
-		originalHash := bn.getHash()
-		assert.True(t, len(originalHash) > 0)
 		newData := []core.TrieData{
 			{
 				Key:     []byte{1, 2, 3},
@@ -1510,9 +1443,7 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 		bnModified := &atomic.Flag{}
 		bn.insertOnNilChild(newData, childPos, goRoutinesManager, modifiedHashes, bnModified, db)
 		assert.Nil(t, goRoutinesManager.GetError())
-		expectedNumTrieNodesChanged := 1
-		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
-		assert.Equal(t, originalHash, modifiedHashes.Get()[0])
+		assert.Equal(t, 0, len(modifiedHashes.Get()))
 		assert.True(t, bn.dirty)
 		assert.NotNil(t, bn.children[childPos])
 		assert.Equal(t, byte(core.AutoBalanceEnabled), bn.ChildrenVersion[childPos])
@@ -1592,7 +1523,8 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 		children[6], _ = newLeafNode(getTrieDataWithDefaultVersion("doe", "doe"), marshaller, hasher)
 		bn, _ := newBranchNode(marshaller, hasher)
 		bn.children = children
-		bn.setHash(getTestGoroutinesManager())
+		bn.ChildrenHashes[2], _ = encodeNodeAndGetHash(bn.children[2])
+		bn.ChildrenHashes[6], _ = encodeNodeAndGetHash(bn.children[6])
 		newData := []core.TrieData{
 			{
 				Key:     []byte{1, 2, 3},
@@ -1609,9 +1541,9 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 		bn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), db, db)
 		assert.Nil(t, manager.GetError())
 		assert.False(t, bn.dirty)
-		originalHash := bn.getHash()
+		originalHash, _ := encodeNodeAndGetHash(bn)
 		assert.True(t, len(originalHash) > 0)
-		originalChildHash := bn.children[childPos].getHash()
+		originalChildHash := bn.ChildrenHashes[childPos]
 		assert.True(t, len(originalChildHash) > 0)
 
 		goRoutinesManager := getTestGoroutinesManager()
@@ -1621,21 +1553,16 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.True(t, bnModified.IsSet())
 		assert.True(t, bn.dirty)
-		expectedNumTrieNodesChanged := 2
+		expectedNumTrieNodesChanged := 1
 		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 
 		originalChildHashPresent := false
-		originalHashPresent := false
 		for _, hash := range modifiedHashes.Get() {
 			if bytes.Equal(hash, originalChildHash) {
 				originalChildHashPresent = true
 			}
-			if bytes.Equal(hash, originalHash) {
-				originalHashPresent = true
-			}
 		}
 		assert.True(t, originalChildHashPresent)
-		assert.True(t, originalHashPresent)
 
 		_, ok := bn.children[childPos].(*extensionNode)
 		assert.True(t, ok)
@@ -1653,7 +1580,8 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 		children[6], _ = newLeafNode(getTrieDataWithDefaultVersion("doe", "doe"), marshaller, hasher)
 		bn, _ := newBranchNode(marshaller, hasher)
 		bn.children = children
-		bn.setHash(getTestGoroutinesManager())
+		bn.ChildrenHashes[2], _ = encodeNodeAndGetHash(bn.children[2])
+		bn.ChildrenHashes[6], _ = encodeNodeAndGetHash(bn.children[6])
 		newData := []core.TrieData{
 			{
 				Key:     key,
@@ -1690,7 +1618,10 @@ func TestBranchNode_insertBatch(t *testing.T) {
 	children[6], _ = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{7, 8, 9}), "doe"), marshaller, hasher)
 	bn, _ := newBranchNode(marshaller, hasher)
 	bn.children = children
-	bn.setHash(getTestGoroutinesManager())
+	childHash1, _ := encodeNodeAndGetHash(children[2])
+	childHash2, _ := encodeNodeAndGetHash(children[6])
+	bn.ChildrenHashes[2] = childHash1
+	bn.ChildrenHashes[6] = childHash2
 
 	newData := []core.TrieData{
 		{
@@ -1719,7 +1650,7 @@ func TestBranchNode_insertBatch(t *testing.T) {
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 	newNode := bn.insert(newData, goRoutinesManager, modifiedHashes, db)
 	assert.Nil(t, goRoutinesManager.GetError())
-	expectedNumTrieNodesChanged := 2
+	expectedNumTrieNodesChanged := 1
 	assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 	assert.True(t, newNode.isDirty())
 
@@ -1742,14 +1673,18 @@ func getNewBn() *branchNode {
 	childBn, _ := newBranchNode(marsh, hasher)
 	childBn.children[1], _ = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{3, 4, 5}), "dog"), marsh, hasher)
 	childBn.children[3], _ = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{7, 8, 9}), "doe"), marsh, hasher)
+	childBn.ChildrenHashes[1], _ = encodeNodeAndGetHash(childBn.children[1])
+	childBn.ChildrenHashes[3], _ = encodeNodeAndGetHash(childBn.children[3])
 
 	children[4], _ = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{3, 4, 5}), "dog"), marsh, hasher)
 	children[7], _ = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{7, 8, 9}), "doe"), marsh, hasher)
 	children[9] = childBn
-
 	bn, _ := newBranchNode(marsh, hasher)
 	bn.children = children
-	bn.setHash(getTestGoroutinesManager())
+	bn.ChildrenHashes[4], _ = encodeNodeAndGetHash(bn.children[4])
+	bn.ChildrenHashes[7], _ = encodeNodeAndGetHash(bn.children[7])
+	bn.ChildrenHashes[9], _ = encodeNodeAndGetHash(childBn)
+
 	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
 	return bn
 }
@@ -1778,7 +1713,7 @@ func TestBranchNode_deleteBatch(t *testing.T) {
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.True(t, dirty)
 		assert.True(t, newNode.isDirty())
-		expectedNumTrieNodesChanged := 5
+		expectedNumTrieNodesChanged := 4
 		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		bn, ok := newNode.(*branchNode)
 		assert.True(t, ok)
@@ -1813,7 +1748,7 @@ func TestBranchNode_deleteBatch(t *testing.T) {
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.True(t, dirty)
 		assert.True(t, newNode.isDirty())
-		expectedNumTrieNodesChanged := 6
+		expectedNumTrieNodesChanged := 5
 		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 		ln, ok := newNode.(*leafNode)
 		assert.True(t, ok)
@@ -1846,7 +1781,7 @@ func TestBranchNode_deleteBatch(t *testing.T) {
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.True(t, dirty)
 		assert.Nil(t, newNode)
-		expectedNumTrieNodesChanged := 6
+		expectedNumTrieNodesChanged := 5
 		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
 	})
 }

--- a/trie/branchNode_test.go
+++ b/trie/branchNode_test.go
@@ -246,6 +246,8 @@ func TestBranchNode_resolveIfCollapsed(t *testing.T) {
 		assert.Nil(t, childHash)
 	})
 	t.Run("node is not collapsed", func(t *testing.T) {
+		t.Parallel()
+		
 		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
 
 		resolved, _ := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"), bn.marsh, bn.hasher)

--- a/trie/depthFirstSync.go
+++ b/trie/depthFirstSync.go
@@ -258,16 +258,16 @@ func (d *depthFirstTrieSyncer) storeTrieNode(element node) error {
 	return nil
 }
 
-func (d *depthFirstTrieSyncer) storeLeaves(children []node) ([]node, error) {
-	childrenNotLeaves := make([]node, 0, len(children))
+func (d *depthFirstTrieSyncer) storeLeaves(children []nodeWithHash) ([]nodeWithHash, error) {
+	childrenNotLeaves := make([]nodeWithHash, 0, len(children))
 	for _, element := range children {
-		_, isLeaf := element.(*leafNode)
+		_, isLeaf := element.node.(*leafNode)
 		if !isLeaf {
 			childrenNotLeaves = append(childrenNotLeaves, element)
 			continue
 		}
 
-		err := d.storeTrieNode(element)
+		err := d.storeTrieNode(element.node)
 		if err != nil {
 			return nil, err
 		}

--- a/trie/doubleListSync.go
+++ b/trie/doubleListSync.go
@@ -198,7 +198,7 @@ func (d *doubleListTrieSyncer) processMissingHashes() {
 		delete(d.missingHashes, hash)
 		delete(d.requestedHashes, hash)
 
-		d.existingNodes[string(n.getHash())] = n
+		d.existingNodes[hash] = n
 	}
 }
 
@@ -213,7 +213,7 @@ func (d *doubleListTrieSyncer) processExistingNodes() error {
 
 		d.timeoutHandler.ResetWatchdog()
 
-		var children []node
+		var children []nodeWithHash
 		var missingChildrenHashes [][]byte
 		missingChildrenHashes, children, err = element.loadChildren(d.getNode)
 		if err != nil {
@@ -230,7 +230,7 @@ func (d *doubleListTrieSyncer) processExistingNodes() error {
 		delete(d.existingNodes, hash)
 
 		for _, child := range children {
-			d.existingNodes[string(child.getHash())] = child
+			d.existingNodes[string(child.hash)] = child.node
 		}
 
 		for _, missingHash := range missingChildrenHashes {

--- a/trie/errors.go
+++ b/trie/errors.go
@@ -146,4 +146,4 @@ var ErrInvalidTypeConversion = errors.New("invalid type conversion")
 var ErrNodeHashIsNotSet = errors.New("node hash is not set")
 
 // ErrInvalidNodeState indicates an erroneous condition where a node's child pointer is set but the child hash is empty.
-var ErrInvalidNodeState = errors.New("invalid node state, child pointer is set but the child hash is empty ")
+var ErrInvalidNodeState = errors.New("invalid node state, child pointer is set but the child hash is empty")

--- a/trie/errors.go
+++ b/trie/errors.go
@@ -144,3 +144,6 @@ var ErrInvalidTypeConversion = errors.New("invalid type conversion")
 
 // ErrNodeHashIsNotSet signals that the node hash is not set
 var ErrNodeHashIsNotSet = errors.New("node hash is not set")
+
+// ErrInvalidNodeState indicates an erroneous condition where a node's child pointer is set but the child hash is empty.
+var ErrInvalidNodeState = errors.New("invalid node state, child pointer is set but the child hash is empty ")

--- a/trie/export_test.go
+++ b/trie/export_test.go
@@ -96,3 +96,8 @@ func SetGoRoutinesManager(tr common.Trie, gm common.TrieGoroutinesManager) {
 	pmt, _ := tr.(*patriciaMerkleTrie)
 	pmt.goRoutinesManager = gm
 }
+
+// GetModifiedHashes -
+func GetModifiedHashes(tr common.Trie) [][]byte {
+	return tr.(*patriciaMerkleTrie).GetOldHashes()
+}

--- a/trie/interface.go
+++ b/trie/interface.go
@@ -18,9 +18,12 @@ type nodeData struct {
 	hexKey      []byte
 }
 
+type nodeWithHash struct {
+	node node
+	hash []byte
+}
+
 type baseTrieNode interface {
-	getHash() []byte
-	setGivenHash([]byte)
 	setDirty(bool)
 	isDirty() bool
 	getMarshalizer() marshal.Marshalizer
@@ -31,18 +34,17 @@ type baseTrieNode interface {
 
 type node interface {
 	baseTrieNode
-	setHash(goRoutinesManager common.TrieGoroutinesManager)
 	getEncodedNode() ([]byte, error)
 	tryGet(key []byte, depth uint32, db common.TrieStorageInteractor) ([]byte, uint32, error)
 	getNext(key []byte, db common.TrieStorageInteractor) (*nodeData, error)
 	insert(newData []core.TrieData, goRoutinesManager common.TrieGoroutinesManager, modifiedHashes common.AtomicBytesSlice, db common.TrieStorageInteractor) node
 	delete(data []core.TrieData, goRoutinesManager common.TrieGoroutinesManager, modifiedHashes common.AtomicBytesSlice, db common.TrieStorageInteractor) (bool, node)
-	reduceNode(pos int, db common.TrieStorageInteractor) (node, bool, error)
+	reduceNode(pos int, hash []byte, db common.TrieStorageInteractor) (node, bool, error)
 	isEmptyOrNil() error
 	print(writer io.Writer, index int, db common.TrieStorageInteractor)
-	getChildren(db common.TrieStorageInteractor) ([]node, error)
+	getChildren(db common.TrieStorageInteractor) ([]nodeWithHash, error)
 	getNodeData(common.KeyBuilder) ([]common.TrieNodeData, error)
-	loadChildren(func([]byte) (node, error)) ([][]byte, []node, error)
+	loadChildren(func([]byte) (node, error)) ([][]byte, []nodeWithHash, error)
 	getAllLeavesOnChannel(chan core.KeyValueHolder, common.KeyBuilder, common.TrieLeafParser, common.TrieStorageInteractor, marshal.Marshalizer, chan struct{}, context.Context) error
 	getNextHashAndKey([]byte) (bool, []byte, []byte)
 	getValue() []byte
@@ -113,8 +115,8 @@ type IdleNodeProvider interface {
 // RootManager is used to manage the root node and hashes related to it
 type RootManager interface {
 	GetRootNode() node
-	SetNewRootNode(newRoot node)
-	SetDataForRootChange(newRoot node, oldRootHash []byte, oldHashes [][]byte)
+	GetRootHash() []byte
+	SetDataForRootChange(rootData RootData)
 	ResetCollectedHashes()
 	GetOldHashes() [][]byte
 	GetOldRootHash() []byte

--- a/trie/interface.go
+++ b/trie/interface.go
@@ -12,12 +12,15 @@ import (
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
+// nodeData is used when computing merkle proofs. It is used as a DTO to avoid multiple storage accesses / serializations
 type nodeData struct {
 	currentNode node
 	encodedNode []byte
 	hexKey      []byte
 }
 
+// nodeWithHash is used as a DTO to avoid multiple hashing / serialization operations.
+// It is used to store the hash of a node along with the node itself
 type nodeWithHash struct {
 	node node
 	hash []byte

--- a/trie/node.go
+++ b/trie/node.go
@@ -55,15 +55,11 @@ func encodeNodeAndGetHash(n node) ([]byte, error) {
 
 // encodeNodeAndCommitToDB will encode and save provided node. It returns the node's value in bytes
 func encodeNodeAndCommitToDB(n node, db common.BaseStorer) (int, error) {
-	key := n.getHash()
-	if len(key) == 0 {
-		return 0, ErrNodeHashIsNotSet
-	}
-
 	val, err := n.getEncodedNode()
 	if err != nil {
 		return 0, err
 	}
+	key := n.getHasher().Compute(string(val))
 
 	// test point encodeNodeAndCommitToDB
 
@@ -85,7 +81,6 @@ func getNodeFromDBAndDecode(n []byte, db common.TrieStorageInteractor, marshaliz
 		return nil, nil, err
 	}
 
-	decodedNode.setGivenHash(n)
 	return decodedNode, encodedNode, nil
 }
 
@@ -109,11 +104,6 @@ func concat(s1 []byte, s2 ...byte) []byte {
 	copy(r[len(s1):], s2)
 
 	return r
-}
-
-func hasValidHash(n node) bool {
-	childHash := n.getHash()
-	return len(childHash) != 0
 }
 
 func decodeNode(encNode []byte, marshalizer marshal.Marshalizer, hasher hashing.Hasher) (node, error) {
@@ -242,7 +232,6 @@ func saveDirtyNodeToStorage(
 		return false
 	}
 	hash := hasher.Compute(string(encNode))
-	n.setGivenHash(hash)
 	hashesCollector.AddDirtyHash(hash)
 
 	// test point encodeNodeAndCommitToDB

--- a/trie/patriciaMerkleTrie.go
+++ b/trie/patriciaMerkleTrie.go
@@ -454,7 +454,7 @@ func (tr *patriciaMerkleTrie) recreate(root []byte, identifier string, tsm commo
 	return newTr, nil
 }
 
-// ToString outputs a graphical view of the trie. Mainly used in tests/kdebugging
+// ToString outputs a graphical view of the trie. Mainly used in tests/debugging
 func (tr *patriciaMerkleTrie) ToString() string {
 	tr.trieOperationInProgress.SetValue(true)
 	defer tr.trieOperationInProgress.Reset()

--- a/trie/patriciaMerkleTrie_test.go
+++ b/trie/patriciaMerkleTrie_test.go
@@ -552,6 +552,7 @@ func TestPatriciaMerkleTrie_String(t *testing.T) {
 	tr := initTrie()
 	str := tr.(trieWithToString).ToString()
 	assert.NotEqual(t, 0, len(str))
+	fmt.Println(str)
 
 	tr = emptyTrie()
 	str = tr.(trieWithToString).ToString()
@@ -2084,6 +2085,29 @@ func TestGetNodeDataFromHash(t *testing.T) {
 	assert.Equal(t, uint64(hashSize+keySize), thirdChildData.Size())
 	assert.False(t, thirdChildData.IsLeaf())
 
+}
+
+func TestPatriciaMerkleTrie_CollectModifiedHashse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("collect hashes on insert", func(t *testing.T) {
+		t.Parallel()
+
+		tr := initTrie()
+		assert.Equal(t, 0, len(trie.GetModifiedHashes(tr)))
+		tr.Update([]byte("ddog"), []byte("pup"))
+		trie.ExecuteUpdatesFromBatch(tr)
+		assert.Equal(t, 4, len(trie.GetModifiedHashes(tr)))
+	})
+	t.Run("collect hashes on delete", func(t *testing.T) {
+		t.Parallel()
+
+		tr := initTrie()
+		assert.Equal(t, 0, len(trie.GetModifiedHashes(tr)))
+		tr.Delete([]byte("ddog"))
+		trie.ExecuteUpdatesFromBatch(tr)
+		assert.Equal(t, 5, len(trie.GetModifiedHashes(tr)))
+	})
 }
 
 func BenchmarkPatriciaMerkleTree_Insert(b *testing.B) {

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -212,9 +212,8 @@ func TestTrieSync_FoundInStorageShouldNotRequest(t *testing.T) {
 	testMarshalizer, testHasher := getTestMarshalizerAndHasher()
 	bn, _ := getBnAndCollapsedBn(testMarshalizer, testHasher)
 	manager := getTestGoroutinesManager()
-	bn.setHash(manager)
 	require.Nil(t, manager.GetError())
-	rootHash := bn.getHash()
+	rootHash, _ := encodeNodeAndGetHash(bn)
 
 	_, trieStorage := newEmptyTrie()
 	db := testscommon.NewMemDbMock()

--- a/trie/trieNodesHandler.go
+++ b/trie/trieNodesHandler.go
@@ -42,14 +42,14 @@ func (handler *trieNodesHandler) getExistingNode(hash string) (node, bool) {
 	return element, exists
 }
 
-func (handler *trieNodesHandler) replaceParentWithChildren(index int, parentHash string, children []node, missingChildrenHashes [][]byte) {
+func (handler *trieNodesHandler) replaceParentWithChildren(index int, parentHash string, children []nodeWithHash, missingChildrenHashes [][]byte) {
 	delete(handler.existingNodes, parentHash)
 
 	allChildrenHashes := make([]string, 0, len(children)+len(missingChildrenHashes))
 	for _, c := range children {
-		hash := string(c.getHash())
+		hash := string(c.hash)
 		allChildrenHashes = append(allChildrenHashes, hash)
-		handler.existingNodes[hash] = c
+		handler.existingNodes[hash] = c.node
 	}
 	for _, m := range missingChildrenHashes {
 		hash := string(m)

--- a/trie/trieNodesHandler_test.go
+++ b/trie/trieNodesHandler_test.go
@@ -59,7 +59,7 @@ func TestTrieNodesHandler_jobDone(t *testing.T) {
 	handler.processMissingHashWasFound(&leafNode{}, roothash)
 	assert.False(t, handler.jobDone())
 
-	handler.replaceParentWithChildren(0, roothash, make([]node, 0), make([][]byte, 0))
+	handler.replaceParentWithChildren(0, roothash, make([]nodeWithHash, 0), make([][]byte, 0))
 	assert.True(t, handler.jobDone())
 }
 
@@ -85,13 +85,11 @@ func TestTrieNodesHandler_replaceParentWithChildren(t *testing.T) {
 	node1 := &leafNode{
 		baseNode: &baseNode{},
 	}
-	node1.setGivenHash([]byte(hash1))
 
 	hash2 := "hash2"
 	node2 := &leafNode{
 		baseNode: &baseNode{},
 	}
-	node2.setGivenHash([]byte(hash2))
 
 	hash3 := "hash3"
 
@@ -101,7 +99,11 @@ func TestTrieNodesHandler_replaceParentWithChildren(t *testing.T) {
 	handler.addInitialRootHash(roothash)
 	handler.processMissingHashWasFound(&leafNode{}, roothash)
 
-	handler.replaceParentWithChildren(0, roothash, []node{node1, node2}, [][]byte{[]byte(hash3)})
+	nodes := []nodeWithHash{
+		{node1, []byte(hash1)},
+		{node2, []byte(hash2)},
+	}
+	handler.replaceParentWithChildren(0, roothash, nodes, [][]byte{[]byte(hash3)})
 
 	t.Run("test the initial roothash is deleted", func(t *testing.T) {
 		assert.False(t, handler.hashIsMissing(roothash))

--- a/trie/trieStorageManager.go
+++ b/trie/trieStorageManager.go
@@ -383,6 +383,16 @@ func (tsm *trieStorageManager) takeSnapshot(snapshotEntry *snapshotsQueueEntry, 
 		return
 	}
 
+	err = stsm.Put(snapshotEntry.rootHash, rootBytes)
+	if err != nil {
+		snapshotEntry.iteratorChannels.ErrChan.WriteInChanNonBlocking(err)
+		treatSnapshotError(err,
+			"trie storage manager: put takeSnapshot",
+			snapshotEntry.rootHash,
+			snapshotEntry.mainTrieRootHash,
+		)
+	}
+
 	stats := statistics.NewTrieStatistics()
 	err = newRoot.commitSnapshot(stsm, snapshotEntry.iteratorChannels.LeavesChan, snapshotEntry.missingNodesChan, ctx, stats, tsm.idleProvider, rootBytes, rootDepthLevel)
 	if err != nil {


### PR DESCRIPTION
## Reasoning behind the pull request
- Each trie node saves it's own hash. But intermediary nodes also save the hash for each child. This means that some hashes are duplicated in memory. 
  
## Proposed changes
- Remove the `hash` field from each trie node. When that hash is needed, it can be accessed from the parent node. 
- The trie insert/delete now happens in batches. Because of this we can compute the hash for each trie node when a batch is commited to the trie, thus removing the need to traverse the trie and compute the rootHash when it is needed.

## Testing procedure
- Normal testing procedure

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
