### PR TITLE
remove hasher and marshaller pointers from the trie nodes

### DIFF
--- a/common/interface.go
+++ b/common/interface.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"context"
+	"github.com/multiversx/mx-chain-core-go/hashing"
+	"github.com/multiversx/mx-chain-core-go/marshal"
 	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core"
@@ -441,5 +443,16 @@ type TrieHashesCollector interface {
 	AddObsoleteHashes(oldRootHash []byte, oldHashes [][]byte)
 	GetCollectedData() ([]byte, ModifiedHashes, ModifiedHashes)
 	Clean()
+	IsInterfaceNil() bool
+}
+
+// TrieContext aggregates functionality for marshaling, hashing, and managing trie storage operations.
+type TrieContext interface {
+	marshal.Marshalizer
+	hashing.Hasher
+	StorageManager
+	GetStorage() StorageManager
+	GetMarshaller() marshal.Marshalizer
+	GetHasher() hashing.Hasher
 	IsInterfaceNil() bool
 }

--- a/common/interface.go
+++ b/common/interface.go
@@ -2,13 +2,13 @@ package common
 
 import (
 	"context"
-	"github.com/multiversx/mx-chain-core-go/hashing"
-	"github.com/multiversx/mx-chain-core-go/marshal"
 	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/hashing"
+	"github.com/multiversx/mx-chain-core-go/marshal"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
 )
 

--- a/trie/baseIterator.go
+++ b/trie/baseIterator.go
@@ -9,7 +9,7 @@ import (
 type baseIterator struct {
 	currentNode nodeWithHash
 	nextNodes   []nodeWithHash
-	db          common.TrieStorageInteractor
+	trieContext common.TrieContext
 }
 
 // newBaseIterator creates a new instance of trie iterator
@@ -28,9 +28,8 @@ func newBaseIterator(trie common.Trie, rootHash []byte) (*baseIterator, error) {
 		return nil, ErrWrongTypeAssertion
 	}
 
-	trieStorage := trie.GetStorageManager()
 	rootNode := pmt.GetRootNode()
-	nextNodes, err := rootNode.getChildren(trieStorage)
+	nextNodes, err := rootNode.getChildren(pmt.TrieContext)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +39,8 @@ func newBaseIterator(trie common.Trie, rootHash []byte) (*baseIterator, error) {
 			node: rootNode,
 			hash: rootHash,
 		},
-		nextNodes: nextNodes,
-		db:        trieStorage,
+		nextNodes:   nextNodes,
+		trieContext: pmt.TrieContext,
 	}, nil
 }
 
@@ -64,12 +63,12 @@ func (it *baseIterator) next() ([]nodeWithHash, error) {
 	}
 
 	it.currentNode = n
-	return it.currentNode.node.getChildren(it.db)
+	return it.currentNode.node.getChildren(it.trieContext)
 }
 
 // MarshalizedNode marshalizes the current node, and then returns the serialized node
 func (it *baseIterator) MarshalizedNode() ([]byte, error) {
-	return it.currentNode.node.getEncodedNode()
+	return it.currentNode.node.getEncodedNode(it.trieContext)
 }
 
 // GetHash returns the current node hash

--- a/trie/baseNode.go
+++ b/trie/baseNode.go
@@ -2,16 +2,11 @@ package trie
 
 import (
 	"sync"
-
-	"github.com/multiversx/mx-chain-core-go/hashing"
-	"github.com/multiversx/mx-chain-core-go/marshal"
 )
 
 type baseNode struct {
-	mutex  sync.RWMutex
-	dirty  bool
-	marsh  marshal.Marshalizer
-	hasher hashing.Hasher
+	mutex sync.RWMutex
+	dirty bool
 }
 
 func (bn *baseNode) isDirty() bool {
@@ -26,20 +21,4 @@ func (bn *baseNode) setDirty(dirty bool) {
 	defer bn.mutex.Unlock()
 
 	bn.dirty = dirty
-}
-
-func (bn *baseNode) getMarshalizer() marshal.Marshalizer {
-	return bn.marsh
-}
-
-func (bn *baseNode) setMarshalizer(marshalizer marshal.Marshalizer) {
-	bn.marsh = marshalizer
-}
-
-func (bn *baseNode) getHasher() hashing.Hasher {
-	return bn.hasher
-}
-
-func (bn *baseNode) setHasher(hasher hashing.Hasher) {
-	bn.hasher = hasher
 }

--- a/trie/branchNode_test.go
+++ b/trie/branchNode_test.go
@@ -1012,7 +1012,7 @@ func TestBranchNode_SizeInBytes(t *testing.T) {
 			dirty: false,
 		},
 	}
-	assert.Equal(t, len(collapsed1)+len(collapsed2)+1+17*pointerSizeInBytes+len(bn.ChildrenVersion), bn.sizeInBytes())
+	assert.Equal(t, len(collapsed1)+len(collapsed2)+1+17*pointerSizeInBytes+len(bn.ChildrenVersion)+18*mutexSizeInBytes, bn.sizeInBytes())
 }
 
 func TestBranchNode_commitSnapshotContextDone(t *testing.T) {

--- a/trie/branchNode_test.go
+++ b/trie/branchNode_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/multiversx/mx-chain-go/storage/cache"
 	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
-	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
-	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
 	"github.com/multiversx/mx-chain-go/trie/keyBuilder"
 	"github.com/multiversx/mx-chain-go/trie/statistics"
 	"github.com/multiversx/mx-chain-go/trie/trieBatchManager"
@@ -40,6 +38,24 @@ func getTestMarshalizerAndHasher() (marshal.Marshalizer, hashing.Hasher) {
 	return marsh, hash
 }
 
+func getDefaultTrieContext() common.TrieContext {
+	args := GetDefaultTrieStorageManagerParameters()
+	trieStorage, _ := NewTrieStorageManager(args)
+	return &trieContext{
+		StorageManager: trieStorage,
+		Marshalizer:    &marshal.GogoProtoMarshalizer{},
+		Hasher:         &testscommon.KeccakMock{},
+	}
+}
+
+func getTrieContextWithCustomStorage(storage common.StorageManager) common.TrieContext {
+	return &trieContext{
+		StorageManager: storage,
+		Marshalizer:    &marshal.GogoProtoMarshalizer{},
+		Hasher:         &testscommon.KeccakMock{},
+	}
+}
+
 func getTrieDataWithDefaultVersion(key string, val string) core.TrieData {
 	return core.TrieData{
 		Key:     []byte(key),
@@ -48,20 +64,24 @@ func getTrieDataWithDefaultVersion(key string, val string) core.TrieData {
 	}
 }
 
-func getBnAndCollapsedBn(marshalizer marshal.Marshalizer, hasher hashing.Hasher) (*branchNode, *branchNode) {
+func getBnAndCollapsedBn() (*branchNode, *branchNode) {
 	var children [nrOfChildren]node
 	ChildrenHashes := make([][]byte, nrOfChildren)
 
-	children[2], _ = newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"), marshalizer, hasher)
-	children[6], _ = newLeafNode(getTrieDataWithDefaultVersion("doe", "doe"), marshalizer, hasher)
-	children[13], _ = newLeafNode(getTrieDataWithDefaultVersion("doge", "doge"), marshalizer, hasher)
-	bn, _ := newBranchNode(marshalizer, hasher)
+	children[2] = newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"))
+	children[6] = newLeafNode(getTrieDataWithDefaultVersion("doe", "doe"))
+	children[13] = newLeafNode(getTrieDataWithDefaultVersion("doge", "doge"))
+	bn := newBranchNode()
 	bn.children = children
 
-	ChildrenHashes[2], _ = encodeNodeAndGetHash(children[2])
-	ChildrenHashes[6], _ = encodeNodeAndGetHash(children[6])
-	ChildrenHashes[13], _ = encodeNodeAndGetHash(children[13])
-	collapsedBn, _ := newBranchNode(marshalizer, hasher)
+	trieCtx := &trieContext{
+		Marshalizer: &marshal.GogoProtoMarshalizer{},
+		Hasher:      &testscommon.KeccakMock{},
+	}
+	ChildrenHashes[2], _ = encodeNodeAndGetHash(children[2], trieCtx)
+	ChildrenHashes[6], _ = encodeNodeAndGetHash(children[6], trieCtx)
+	ChildrenHashes[13], _ = encodeNodeAndGetHash(children[13], trieCtx)
+	collapsedBn := newBranchNode()
 	collapsedBn.ChildrenHashes = ChildrenHashes
 	bn.ChildrenHashes = ChildrenHashes
 
@@ -90,9 +110,11 @@ func newEmptyTrie() (*patriciaMerkleTrie, *trieStorageManager) {
 	trieStorage, _ := NewTrieStorageManager(args)
 	thr, _ := throttler.NewNumGoRoutinesThrottler(10)
 	tr := &patriciaMerkleTrie{
-		trieStorage:             trieStorage,
-		marshalizer:             args.Marshalizer,
-		hasher:                  args.Hasher,
+		TrieContext: &trieContext{
+			StorageManager: trieStorage,
+			Marshalizer:    args.Marshalizer,
+			Hasher:         args.Hasher,
+		},
 		maxTrieLevelInMemory:    5,
 		chanClose:               make(chan struct{}),
 		enableEpochsHandler:     &enableEpochsHandlerMock.EnableEpochsHandlerStub{},
@@ -153,32 +175,31 @@ func TestBranchNode_isDirty(t *testing.T) {
 func TestBranchNode_commit(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	marsh, hasher := getTestMarshalizerAndHasher()
-	bn, collapsedBn := getBnAndCollapsedBn(marsh, hasher)
-
-	hash, _ := encodeNodeAndGetHash(collapsedBn)
+	trieCtx := getDefaultTrieContext()
+	bn, collapsedBn := getBnAndCollapsedBn()
+	hash, _ := encodeNodeAndGetHash(collapsedBn, trieCtx)
 
 	manager := getTestGoroutinesManager()
-	bn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), db, db)
+	bn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	assert.Nil(t, manager.GetError())
 
-	encNode, _ := db.Get(hash)
-	n, _ := decodeNode(encNode, marsh, hasher)
-	h1, _ := encodeNodeAndGetHash(collapsedBn)
-	h2, _ := encodeNodeAndGetHash(n)
+	encNode, _ := trieCtx.Get(hash)
+	n, _ := decodeNode(encNode, trieCtx)
+	h1, _ := encodeNodeAndGetHash(collapsedBn, trieCtx)
+	h2, _ := encodeNodeAndGetHash(n, trieCtx)
 	assert.Equal(t, h1, h2)
 }
 
 func TestBranchNode_getEncodedNode(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	trieCtx := getTrieContextWithCustomStorage(nil)
+	bn, _ := getBnAndCollapsedBn()
 
-	expectedEncodedNode, _ := bn.marsh.Marshal(bn)
+	expectedEncodedNode, _ := trieCtx.Marshal(bn)
 	expectedEncodedNode = append(expectedEncodedNode, branch)
 
-	encNode, err := bn.getEncodedNode()
+	encNode, err := bn.getEncodedNode(trieCtx)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedEncodedNode, encNode)
 }
@@ -188,7 +209,7 @@ func TestBranchNode_getEncodedNodeEmpty(t *testing.T) {
 
 	bn := emptyDirtyBranchNode()
 
-	encNode, err := bn.getEncodedNode()
+	encNode, err := bn.getEncodedNode(getTrieContextWithCustomStorage(nil))
 	assert.True(t, errors.Is(err, ErrEmptyBranchNode))
 	assert.Nil(t, encNode)
 }
@@ -198,7 +219,7 @@ func TestBranchNode_getEncodedNodeNil(t *testing.T) {
 
 	var bn *branchNode
 
-	encNode, err := bn.getEncodedNode()
+	encNode, err := bn.getEncodedNode(getTrieContextWithCustomStorage(nil))
 	assert.True(t, errors.Is(err, ErrNilBranchNode))
 	assert.Nil(t, encNode)
 }
@@ -209,9 +230,9 @@ func TestBranchNode_resolveIfCollapsed(t *testing.T) {
 	t.Run("child pos out of range", func(t *testing.T) {
 		t.Parallel()
 
-		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn, _ := getBnAndCollapsedBn()
 
-		childNode, childHash, err := bn.resolveIfCollapsed(17, nil)
+		childNode, childHash, err := bn.resolveIfCollapsed(17, getTrieContextWithCustomStorage(nil))
 		assert.Equal(t, ErrChildPosOutOfRange, err)
 		assert.Nil(t, childNode)
 		assert.Nil(t, childHash)
@@ -219,16 +240,16 @@ func TestBranchNode_resolveIfCollapsed(t *testing.T) {
 	t.Run("resolve collapsed node", func(t *testing.T) {
 		t.Parallel()
 
-		db := testscommon.NewMemDbMock()
-		bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn, collapsedBn := getBnAndCollapsedBn()
 		childPos := byte(2)
 
-		bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
-		resolved, _ := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"), bn.marsh, bn.hasher)
+		trieCtx := getDefaultTrieContext()
+		bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
+		resolved := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"))
 		resolved.dirty = false
-		resolvedHash, _ := encodeNodeAndGetHash(resolved)
+		resolvedHash, _ := encodeNodeAndGetHash(resolved, trieCtx)
 
-		childNode, childHash, err := collapsedBn.resolveIfCollapsed(childPos, db)
+		childNode, childHash, err := collapsedBn.resolveIfCollapsed(childPos, trieCtx)
 		assert.Nil(t, err)
 		assert.Equal(t, resolved, collapsedBn.children[childPos])
 		assert.Equal(t, resolved, childNode)
@@ -237,21 +258,21 @@ func TestBranchNode_resolveIfCollapsed(t *testing.T) {
 	t.Run("invalid node state", func(t *testing.T) {
 		t.Parallel()
 
-		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn, _ := getBnAndCollapsedBn()
 		bn.ChildrenHashes = make([][]byte, nrOfChildren)
 
-		childNode, childHash, err := bn.resolveIfCollapsed(2, nil)
+		childNode, childHash, err := bn.resolveIfCollapsed(2, getTrieContextWithCustomStorage(nil))
 		assert.Equal(t, ErrInvalidNodeState, err)
 		assert.Nil(t, childNode)
 		assert.Nil(t, childHash)
 	})
 	t.Run("node is not collapsed", func(t *testing.T) {
-		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn, _ := getBnAndCollapsedBn()
 
-		resolved, _ := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"), bn.marsh, bn.hasher)
-		resolvedHash, _ := encodeNodeAndGetHash(resolved)
+		resolved := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"))
+		resolvedHash, _ := encodeNodeAndGetHash(resolved, getTrieContextWithCustomStorage(nil))
 
-		childNode, childHash, err := bn.resolveIfCollapsed(2, nil)
+		childNode, childHash, err := bn.resolveIfCollapsed(2, getTrieContextWithCustomStorage(nil))
 		assert.Nil(t, err)
 		assert.Equal(t, resolved, childNode)
 		assert.Equal(t, childHash, resolvedHash)
@@ -261,11 +282,11 @@ func TestBranchNode_resolveIfCollapsed(t *testing.T) {
 func TestBranchNode_tryGet(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	val, maxDepth, err := bn.tryGet(key, 0, nil)
+	val, maxDepth, err := bn.tryGet(key, 0, getTrieContextWithCustomStorage(nil))
 	assert.Equal(t, []byte("dog"), val)
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(1), maxDepth)
@@ -274,10 +295,10 @@ func TestBranchNode_tryGet(t *testing.T) {
 func TestBranchNode_tryGetEmptyKey(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	var key []byte
 
-	val, maxDepth, err := bn.tryGet(key, 0, nil)
+	val, maxDepth, err := bn.tryGet(key, 0, getTrieContextWithCustomStorage(nil))
 	assert.Nil(t, err)
 	assert.Nil(t, val)
 	assert.Equal(t, uint32(0), maxDepth)
@@ -286,10 +307,10 @@ func TestBranchNode_tryGetEmptyKey(t *testing.T) {
 func TestBranchNode_tryGetChildPosOutOfRange(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	key := []byte("dog")
 
-	val, maxDepth, err := bn.tryGet(key, 0, nil)
+	val, maxDepth, err := bn.tryGet(key, 0, getTrieContextWithCustomStorage(nil))
 	assert.Equal(t, ErrChildPosOutOfRange, err)
 	assert.Nil(t, val)
 	assert.Equal(t, uint32(0), maxDepth)
@@ -298,10 +319,10 @@ func TestBranchNode_tryGetChildPosOutOfRange(t *testing.T) {
 func TestBranchNode_tryGetNilChild(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	nilChildKey := []byte{3}
 
-	val, maxDepth, err := bn.tryGet(nilChildKey, 0, nil)
+	val, maxDepth, err := bn.tryGet(nilChildKey, 0, getTrieContextWithCustomStorage(nil))
 	assert.Nil(t, err)
 	assert.Nil(t, val)
 	assert.Equal(t, uint32(0), maxDepth)
@@ -310,15 +331,14 @@ func TestBranchNode_tryGetNilChild(t *testing.T) {
 func TestBranchNode_tryGetCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-
-	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	bn, collapsedBn := getBnAndCollapsedBn()
+	trieCtx := getDefaultTrieContext()
+	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	val, maxDepth, err := collapsedBn.tryGet(key, 0, db)
+	val, maxDepth, err := collapsedBn.tryGet(key, 0, trieCtx)
 	assert.Equal(t, []byte("dog"), val)
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(1), maxDepth)
@@ -327,18 +347,18 @@ func TestBranchNode_tryGetCollapsedNode(t *testing.T) {
 func TestBranchNode_getNext(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	nextNode, _ := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"), bn.marsh, bn.hasher)
+	bn, _ := getBnAndCollapsedBn()
+	nextNode := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"))
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
-	db := testscommon.NewMemDbMock()
-	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
-	data, err := bn.getNext(key, db)
+	trieCtx := getDefaultTrieContext()
+	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
+	data, err := bn.getNext(key, trieCtx)
 	assert.NotNil(t, data)
 
-	h1, _ := encodeNodeAndGetHash(nextNode)
-	h2, _ := encodeNodeAndGetHash(data.currentNode)
-	nextNodeBytes, _ := nextNode.getEncodedNode()
+	h1, _ := encodeNodeAndGetHash(nextNode, trieCtx)
+	h2, _ := encodeNodeAndGetHash(data.currentNode, trieCtx)
+	nextNodeBytes, _ := nextNode.getEncodedNode(trieCtx)
 	assert.Equal(t, nextNodeBytes, data.encodedNode)
 	assert.Equal(t, h1, h2)
 	assert.Equal(t, []byte("dog"), data.hexKey)
@@ -348,10 +368,10 @@ func TestBranchNode_getNext(t *testing.T) {
 func TestBranchNode_getNextWrongKey(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	key := []byte("dog")
 
-	data, err := bn.getNext(key, nil)
+	data, err := bn.getNext(key, getTrieContextWithCustomStorage(nil))
 	assert.Nil(t, data)
 	assert.Equal(t, ErrChildPosOutOfRange, err)
 }
@@ -359,11 +379,11 @@ func TestBranchNode_getNextWrongKey(t *testing.T) {
 func TestBranchNode_getNextNilChild(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	nilChildPos := byte(4)
 	key := append([]byte{nilChildPos}, []byte("dog")...)
 
-	data, err := bn.getNext(key, nil)
+	data, err := bn.getNext(key, getTrieContextWithCustomStorage(nil))
 	assert.Nil(t, data)
 	assert.Equal(t, ErrNodeNotFound, err)
 }
@@ -371,30 +391,30 @@ func TestBranchNode_getNextNilChild(t *testing.T) {
 func TestBranchNode_insert(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	nodeKey := []byte{0, 2, 3}
 
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
 
-	newBn := bn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
+	newBn := bn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), getTrieContextWithCustomStorage(nil))
 	assert.NotNil(t, newBn)
 	assert.Nil(t, goRoutinesManager.GetError())
 
 	nodeKeyRemainder := nodeKey[1:]
-	bn.children[0], _ = newLeafNode(getTrieDataWithDefaultVersion(string(nodeKeyRemainder), "dogs"), bn.marsh, bn.hasher)
+	bn.children[0] = newLeafNode(getTrieDataWithDefaultVersion(string(nodeKeyRemainder), "dogs"))
 	assert.Equal(t, bn, newBn)
 }
 
 func TestBranchNode_insertEmptyKey(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion("", "dogs")}
 
-	newBn := bn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
+	newBn := bn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), getTrieContextWithCustomStorage(nil))
 	assert.Equal(t, ErrValueTooShort, goRoutinesManager.GetError())
 	assert.Nil(t, newBn)
 }
@@ -402,12 +422,12 @@ func TestBranchNode_insertEmptyKey(t *testing.T) {
 func TestBranchNode_insertChildPosOutOfRange(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion("dog", "dogs")}
 
-	newBn := bn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
+	newBn := bn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), getTrieContextWithCustomStorage(nil))
 	assert.Equal(t, ErrChildPosOutOfRange, goRoutinesManager.GetError())
 	assert.Nil(t, newBn)
 }
@@ -415,40 +435,40 @@ func TestBranchNode_insertChildPosOutOfRange(t *testing.T) {
 func TestBranchNode_insertCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, collapsedBn := getBnAndCollapsedBn()
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
-	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	trieCtx := getDefaultTrieContext()
+	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
-	newBn := collapsedBn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), db)
+	newBn := collapsedBn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), trieCtx)
 	assert.NotNil(t, newBn)
 	assert.Nil(t, goRoutinesManager.GetError())
 
-	val, _, _ := newBn.tryGet(key, 0, db)
+	val, _, _ := newBn.tryGet(key, 0, trieCtx)
 	assert.Equal(t, []byte("dogs"), val)
 }
 
 func TestBranchNode_insertInStoredBnOnExistingPos(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
+	trieCtx := getDefaultTrieContext()
 
-	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	expectedHashes := [][]byte{bn.ChildrenHashes[2]}
 
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	newNode := bn.insert(data, goRoutinesManager, modifiedHashes, db)
+	newNode := bn.insert(data, goRoutinesManager, modifiedHashes, trieCtx)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 
@@ -479,19 +499,19 @@ func slicesContainSameElements(s1 [][]byte, s2 [][]byte) bool {
 func TestBranchNode_insertInStoredBnOnNilPos(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	nilChildPos := byte(11)
 	key := append([]byte{nilChildPos}, []byte("dog")...)
+	trieCtx := getDefaultTrieContext()
 
-	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	var expectedHashes [][]byte
 
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	newNode := bn.insert(data, goRoutinesManager, modifiedHashes, db)
+	newNode := bn.insert(data, goRoutinesManager, modifiedHashes, trieCtx)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.True(t, slicesContainSameElements(expectedHashes, modifiedHashes.Get()))
@@ -500,7 +520,7 @@ func TestBranchNode_insertInStoredBnOnNilPos(t *testing.T) {
 func TestBranchNode_insertInDirtyBnOnNilPos(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	nilChildPos := byte(11)
 	key := append([]byte{nilChildPos}, []byte("dog")...)
 
@@ -508,7 +528,7 @@ func TestBranchNode_insertInDirtyBnOnNilPos(t *testing.T) {
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	newNode := bn.insert(data, goRoutinesManager, modifiedHashes, nil)
+	newNode := bn.insert(data, goRoutinesManager, modifiedHashes, getTrieContextWithCustomStorage(nil))
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
@@ -517,7 +537,7 @@ func TestBranchNode_insertInDirtyBnOnNilPos(t *testing.T) {
 func TestBranchNode_insertInDirtyBnOnExistingPos(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 
@@ -525,7 +545,7 @@ func TestBranchNode_insertInDirtyBnOnExistingPos(t *testing.T) {
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	newNode := bn.insert(data, goRoutinesManager, modifiedHashes, nil)
+	newNode := bn.insert(data, goRoutinesManager, modifiedHashes, getTrieContextWithCustomStorage(nil))
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
@@ -534,9 +554,9 @@ func TestBranchNode_insertInDirtyBnOnExistingPos(t *testing.T) {
 func TestBranchNode_delete(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 
-	expectedBn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	expectedBn, _ := getBnAndCollapsedBn()
 	expectedBn.children[2] = nil
 	expectedBn.ChildrenHashes[2] = nil
 
@@ -545,31 +565,32 @@ func TestBranchNode_delete(t *testing.T) {
 	data := []core.TrieData{{Key: key}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
+	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), getTrieContextWithCustomStorage(nil))
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 
-	expectedBnHash, _ := encodeNodeAndGetHash(expectedBn)
-	newBnHash, _ := encodeNodeAndGetHash(newBn)
+	trieCtx := getTrieContextWithCustomStorage(nil)
+	expectedBnHash, _ := encodeNodeAndGetHash(expectedBn, trieCtx)
+	newBnHash, _ := encodeNodeAndGetHash(newBn, trieCtx)
 	assert.Equal(t, expectedBnHash, newBnHash)
 }
 
 func TestBranchNode_deleteFromStoredBn(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	childPos := byte(2)
 	lnKey := append([]byte{childPos}, []byte("dog")...)
+	trieCtx := getDefaultTrieContext()
 
-	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	lnHash := bn.ChildrenHashes[2]
 	expectedHashes := [][]byte{lnHash}
 
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{{Key: lnKey}}
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	dirty, _ := bn.delete(data, goRoutinesManager, modifiedHashes, db)
+	dirty, _ := bn.delete(data, goRoutinesManager, modifiedHashes, trieCtx)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.True(t, slicesContainSameElements(expectedHashes, modifiedHashes.Get()))
@@ -578,14 +599,14 @@ func TestBranchNode_deleteFromStoredBn(t *testing.T) {
 func TestBranchNode_deleteFromDirtyBn(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	childPos := byte(2)
 	lnKey := append([]byte{childPos}, []byte("dog")...)
 	data := []core.TrieData{{Key: lnKey}}
 
 	goRoutinesManager := getTestGoroutinesManager()
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	dirty, _ := bn.delete(data, goRoutinesManager, modifiedHashes, nil)
+	dirty, _ := bn.delete(data, goRoutinesManager, modifiedHashes, getTrieContextWithCustomStorage(nil))
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
@@ -594,14 +615,14 @@ func TestBranchNode_deleteFromDirtyBn(t *testing.T) {
 func TestBranchNode_deleteNonexistentNodeFromChild(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("butterfly")...)
 	data := []core.TrieData{{Key: key}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
+	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), getTrieContextWithCustomStorage(nil))
 	assert.False(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, bn, newBn)
@@ -610,11 +631,11 @@ func TestBranchNode_deleteNonexistentNodeFromChild(t *testing.T) {
 func TestBranchNode_deleteEmptykey(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	data := []core.TrieData{{Key: []byte{}}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
+	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), getTrieContextWithCustomStorage(nil))
 	assert.False(t, dirty)
 	assert.Equal(t, ErrValueTooShort, goRoutinesManager.GetError())
 	assert.Nil(t, newBn)
@@ -623,20 +644,20 @@ func TestBranchNode_deleteEmptykey(t *testing.T) {
 func TestBranchNode_deleteCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	trieCtx := getDefaultTrieContext()
+	bn, collapsedBn := getBnAndCollapsedBn()
+	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
 	childPos := byte(2)
 	key := append([]byte{childPos}, []byte("dog")...)
 	data := []core.TrieData{{Key: key}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	dirty, newBn := collapsedBn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), db)
+	dirty, newBn := collapsedBn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), trieCtx)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 
-	val, _, err := newBn.tryGet(key, 0, db)
+	val, _, err := newBn.tryGet(key, 0, trieCtx)
 	assert.Nil(t, val)
 	assert.Nil(t, err)
 }
@@ -644,23 +665,23 @@ func TestBranchNode_deleteCollapsedNode(t *testing.T) {
 func TestBranchNode_deleteAndReduceBn(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	bn.ChildrenHashes[13] = nil
 	var children [nrOfChildren]node
 	firstChildPos := byte(2)
 	secondChildPos := byte(6)
-	children[firstChildPos], _ = newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"), bn.marsh, bn.hasher)
-	children[secondChildPos], _ = newLeafNode(getTrieDataWithDefaultVersion("doe", "doe"), bn.marsh, bn.hasher)
+	children[firstChildPos] = newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"))
+	children[secondChildPos] = newLeafNode(getTrieDataWithDefaultVersion("doe", "doe"))
 	bn.children = children
 
 	key := append([]byte{firstChildPos}, []byte("dog")...)
-	ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string(key), "dog"), bn.marsh, bn.hasher)
+	ln := newLeafNode(getTrieDataWithDefaultVersion(string(key), "dog"))
 
 	key = append([]byte{secondChildPos}, []byte("doe")...)
 	data := []core.TrieData{{Key: key}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
+	dirty, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), getTrieContextWithCustomStorage(nil))
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, ln, newBn)
@@ -669,16 +690,16 @@ func TestBranchNode_deleteAndReduceBn(t *testing.T) {
 func TestBranchNode_reduceNode(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := newBranchNode(getTestMarshalizerAndHasher())
+	bn := newBranchNode()
 	var children [nrOfChildren]node
 	childPos := byte(2)
-	children[childPos], _ = newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"), bn.marsh, bn.hasher)
+	children[childPos] = newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"))
 	bn.children = children
 
 	key := append([]byte{childPos}, []byte("dog")...)
-	ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string(key), "dog"), bn.marsh, bn.hasher)
+	ln := newLeafNode(getTrieDataWithDefaultVersion(string(key), "dog"))
 
-	n, newChildHash, err := bn.children[childPos].reduceNode(int(childPos), bn.ChildrenHashes[childPos], nil)
+	n, newChildHash, err := bn.children[childPos].reduceNode(int(childPos), bn.ChildrenHashes[childPos], getTrieContextWithCustomStorage(nil))
 	assert.Equal(t, ln, n)
 	assert.Nil(t, err)
 	assert.True(t, newChildHash)
@@ -687,7 +708,7 @@ func TestBranchNode_reduceNode(t *testing.T) {
 func TestBranchNode_getChildPosition(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	nr, pos := getChildPosition(bn)
 	assert.Equal(t, 3, nr)
 	assert.Equal(t, 13, pos)
@@ -783,9 +804,9 @@ func TestReduceBranchNodeWithLeafNodeValueShouldWork(t *testing.T) {
 func TestBranchNode_getChildren(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 
-	children, err := bn.getChildren(nil)
+	children, err := bn.getChildren(getTrieContextWithCustomStorage(nil))
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(children))
 }
@@ -793,11 +814,11 @@ func TestBranchNode_getChildren(t *testing.T) {
 func TestBranchNode_getChildrenCollapsedBn(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	trieCtx := getDefaultTrieContext()
+	bn, collapsedBn := getBnAndCollapsedBn()
+	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
-	children, err := collapsedBn.getChildren(db)
+	children, err := collapsedBn.getChildren(trieCtx)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(children))
 }
@@ -814,7 +835,7 @@ func TestBranchNode_setDirty(t *testing.T) {
 func TestBranchNode_loadChildren(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshalizerAndHasher()
+	_, hasher := getTestMarshalizerAndHasher()
 	tr := initTrie()
 	rootNode := tr.GetRootNode()
 	nodes, _ := getEncodedTrieNodesAndHashes(tr)
@@ -828,10 +849,11 @@ func TestBranchNode_loadChildren(t *testing.T) {
 	secondChildIndex := 7
 
 	bn := getCollapsedBn(t, rootNode)
+	trieCtx := getDefaultTrieContext()
 
 	getNode := func(hash []byte) (node, error) {
 		cacheData, _ := nodesCacher.Get(hash)
-		return trieNode(cacheData, marsh, hasher)
+		return trieNode(cacheData, trieCtx)
 	}
 
 	missing, _, err := bn.loadChildren(getNode)
@@ -860,7 +882,7 @@ func TestPatriciaMerkleTrie_CommitCollapsedDirtyTrieShouldWork(t *testing.T) {
 	tr.Update([]byte("zzz"), []byte("zzz"))
 	_ = tr.Commit(hashesCollector.NewDisabledHashesCollector())
 	rootHash, _ := tr.RootHash()
-	collapsedTrie, _ := tr.recreate(rootHash, "", tr.trieStorage)
+	collapsedTrie, _ := tr.recreate(rootHash, "", tr.TrieContext)
 	collapsedRoot := collapsedTrie.GetRootNode()
 
 	collapsedTrie.Delete([]byte("zzz"))
@@ -874,7 +896,7 @@ func TestPatriciaMerkleTrie_CommitCollapsedDirtyTrieShouldWork(t *testing.T) {
 }
 
 func BenchmarkMarshallNodeJson(b *testing.B) {
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	marsh := marshal.JsonMarshalizer{}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -882,58 +904,24 @@ func BenchmarkMarshallNodeJson(b *testing.B) {
 	}
 }
 
-func TestBranchNode_newBranchNodeNilMarshalizerShouldErr(t *testing.T) {
-	t.Parallel()
-
-	bn, err := newBranchNode(nil, &hashingMocks.HasherMock{})
-	assert.Nil(t, bn)
-	assert.Equal(t, ErrNilMarshalizer, err)
-}
-
-func TestBranchNode_newBranchNodeNilHasherShouldErr(t *testing.T) {
-	t.Parallel()
-
-	bn, err := newBranchNode(&marshallerMock.MarshalizerMock{}, nil)
-	assert.Nil(t, bn)
-	assert.Equal(t, ErrNilHasher, err)
-}
-
 func TestBranchNode_newBranchNodeOkVals(t *testing.T) {
 	t.Parallel()
 
 	var children [nrOfChildren]node
-	marsh, hasher := getTestMarshalizerAndHasher()
-	bn, err := newBranchNode(marsh, hasher)
-
-	assert.Nil(t, err)
+	bn := newBranchNode()
 	assert.Equal(t, make([][]byte, nrOfChildren), bn.ChildrenHashes)
 	assert.Equal(t, children, bn.children)
-	assert.Equal(t, marsh, bn.marsh)
-	assert.Equal(t, hasher, bn.hasher)
 	assert.True(t, bn.dirty)
-}
-
-func TestBranchNode_getMarshalizer(t *testing.T) {
-	t.Parallel()
-
-	expectedMarsh := &marshallerMock.MarshalizerMock{}
-	bn := &branchNode{
-		baseNode: &baseNode{
-			marsh: expectedMarsh,
-		},
-	}
-
-	marsh := bn.getMarshalizer()
-	assert.Equal(t, expectedMarsh, marsh)
 }
 
 func TestBranchNode_commitCollapsesTrieIfMaxTrieLevelInMemoryIsReached(t *testing.T) {
 	t.Parallel()
 
-	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, collapsedBn := getBnAndCollapsedBn()
 
 	manager := getTestGoroutinesManager()
-	bn.commitDirty(0, 1, manager, hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+	trieCtx := getDefaultTrieContext()
+	bn.commitDirty(0, 1, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	assert.Nil(t, manager.GetError())
 
 	assert.Equal(t, collapsedBn.ChildrenHashes, bn.ChildrenHashes)
@@ -943,13 +931,12 @@ func TestBranchNode_commitCollapsesTrieIfMaxTrieLevelInMemoryIsReached(t *testin
 func TestBranchNode_reduceNodeBnChild(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshalizerAndHasher()
 	en, _ := getEnAndCollapsedEn()
 	pos := 5
-	expectedNode, _ := newExtensionNode([]byte{byte(pos)}, en.child, marsh, hasher)
+	expectedNode, _ := newExtensionNode([]byte{byte(pos)}, en.child)
 	expectedNode.ChildHash = en.ChildHash
 
-	newNode, newChildHash, err := en.child.reduceNode(pos, en.ChildHash, nil)
+	newNode, newChildHash, err := en.child.reduceNode(pos, en.ChildHash, getTrieContextWithCustomStorage(nil))
 	assert.Nil(t, err)
 	assert.Equal(t, expectedNode, newNode)
 	assert.False(t, newChildHash)
@@ -961,13 +948,13 @@ func TestBranchNode_printShouldNotPanicEvenIfNodeIsCollapsed(t *testing.T) {
 	bnWriter := bytes.NewBuffer(make([]byte, 0))
 	collapsedBnWriter := bytes.NewBuffer(make([]byte, 0))
 
-	db := testscommon.NewMemDbMock()
-	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, collapsedBn := getBnAndCollapsedBn()
+	trieCtx := getDefaultTrieContext()
 	collapsedBn.setDirty(false)
-	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
-	bn.print(bnWriter, 0, db)
-	collapsedBn.print(collapsedBnWriter, 0, db)
+	bn.print(bnWriter, 0, trieCtx)
+	collapsedBn.print(collapsedBnWriter, 0, trieCtx)
 
 	assert.Equal(t, bnWriter.Bytes(), collapsedBnWriter.Bytes())
 }
@@ -975,7 +962,7 @@ func TestBranchNode_printShouldNotPanicEvenIfNodeIsCollapsed(t *testing.T) {
 func TestBranchNode_getNextHashAndKey(t *testing.T) {
 	t.Parallel()
 
-	_, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	_, collapsedBn := getBnAndCollapsedBn()
 	proofVerified, nextHash, nextKey := collapsedBn.getNextHashAndKey([]byte{2})
 
 	assert.False(t, proofVerified)
@@ -986,7 +973,7 @@ func TestBranchNode_getNextHashAndKey(t *testing.T) {
 func TestBranchNode_getNextHashAndKeyNilKey(t *testing.T) {
 	t.Parallel()
 
-	_, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	_, collapsedBn := getBnAndCollapsedBn()
 	proofVerified, nextHash, nextKey := collapsedBn.getNextHashAndKey(nil)
 
 	assert.False(t, proofVerified)
@@ -1015,27 +1002,25 @@ func TestBranchNode_SizeInBytes(t *testing.T) {
 	collapsed2 := []byte("collapsed2")
 	bn = &branchNode{
 		CollapsedBn: CollapsedBn{
-			ChildrenHashes: [][]byte{collapsed1, collapsed2},
+			ChildrenHashes:  [][]byte{collapsed1, collapsed2},
+			ChildrenVersion: []byte{1},
 		},
 		children: [17]node{},
 		baseNode: &baseNode{
-			dirty:  false,
-			marsh:  nil,
-			hasher: nil,
+			dirty: false,
 		},
 	}
-	assert.Equal(t, len(collapsed1)+len(collapsed2)+1+19*pointerSizeInBytes, bn.sizeInBytes())
+	assert.Equal(t, len(collapsed1)+len(collapsed2)+1+17*pointerSizeInBytes+len(bn.ChildrenVersion), bn.sizeInBytes())
 }
 
 func TestBranchNode_commitSnapshotContextDone(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := bn.commitSnapshot(db, nil, nil, ctx, statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, []byte("nodeBytes"), 0)
+	err := bn.commitSnapshot(getDefaultTrieContext(), nil, nil, ctx, statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, []byte("nodeBytes"), 0)
 	assert.Equal(t, core.ErrContextClosing, err)
 }
 
@@ -1046,11 +1031,15 @@ func TestBranchNode_commitSnapshotDbIsClosing(t *testing.T) {
 	db.GetCalled = func(key []byte) ([]byte, error) {
 		return nil, core.ErrContextClosing
 	}
+	args := GetDefaultTrieStorageManagerParameters()
+	args.MainStorer = db
+	trieStorage, _ := NewTrieStorageManager(args)
+	trieCtx := getTrieContextWithCustomStorage(trieStorage)
 
-	_, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	nodeBytes, _ := collapsedBn.getEncodedNode()
+	_, collapsedBn := getBnAndCollapsedBn()
+	nodeBytes, _ := collapsedBn.getEncodedNode(trieCtx)
 	missingNodesChan := make(chan []byte, 10)
-	err := collapsedBn.commitSnapshot(db, nil, missingNodesChan, context.Background(), statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, nodeBytes, 0)
+	err := collapsedBn.commitSnapshot(trieCtx, nil, missingNodesChan, context.Background(), statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, nodeBytes, 0)
 	assert.True(t, core.IsClosingError(err))
 	assert.Equal(t, 0, len(missingNodesChan))
 }
@@ -1062,11 +1051,15 @@ func TestBranchNode_commitSnapshotChildIsMissingErr(t *testing.T) {
 	db.GetCalled = func(key []byte) ([]byte, error) {
 		return nil, core.NewGetNodeFromDBErrWithKey(key, ErrKeyNotFound, "test")
 	}
+	args := GetDefaultTrieStorageManagerParameters()
+	args.MainStorer = db
+	trieStorage, _ := NewTrieStorageManager(args)
+	trieCtx := getTrieContextWithCustomStorage(trieStorage)
 
-	_, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	_, collapsedBn := getBnAndCollapsedBn()
 	missingNodesChan := make(chan []byte, 10)
-	nodeBytes, _ := collapsedBn.getEncodedNode()
-	err := collapsedBn.commitSnapshot(db, nil, missingNodesChan, context.Background(), statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, nodeBytes, 0)
+	nodeBytes, _ := collapsedBn.getEncodedNode(trieCtx)
+	err := collapsedBn.commitSnapshot(trieCtx, nil, missingNodesChan, context.Background(), statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, nodeBytes, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(missingNodesChan))
 }
@@ -1077,7 +1070,7 @@ func TestBranchNode_getVersion(t *testing.T) {
 	t.Run("nil ChildrenVersion", func(t *testing.T) {
 		t.Parallel()
 
-		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn, _ := getBnAndCollapsedBn()
 
 		version, err := bn.getVersion()
 		assert.Equal(t, core.NotSpecified, version)
@@ -1087,7 +1080,7 @@ func TestBranchNode_getVersion(t *testing.T) {
 	t.Run("NotSpecified for all children", func(t *testing.T) {
 		t.Parallel()
 
-		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn, _ := getBnAndCollapsedBn()
 		bn.ChildrenVersion = make([]byte, nrOfChildren)
 		bn.ChildrenVersion[2] = byte(core.NotSpecified)
 		bn.ChildrenVersion[6] = byte(core.NotSpecified)
@@ -1101,7 +1094,7 @@ func TestBranchNode_getVersion(t *testing.T) {
 	t.Run("one child with autoBalanceEnabled", func(t *testing.T) {
 		t.Parallel()
 
-		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn, _ := getBnAndCollapsedBn()
 		bn.ChildrenVersion = make([]byte, nrOfChildren)
 		bn.ChildrenVersion[2] = byte(core.NotSpecified)
 		bn.ChildrenVersion[6] = byte(core.AutoBalanceEnabled)
@@ -1115,7 +1108,7 @@ func TestBranchNode_getVersion(t *testing.T) {
 	t.Run("AutoBalanceEnabled for all children", func(t *testing.T) {
 		t.Parallel()
 
-		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn, _ := getBnAndCollapsedBn()
 		bn.ChildrenVersion = make([]byte, nrOfChildren)
 		bn.ChildrenVersion[2] = byte(core.AutoBalanceEnabled)
 		bn.ChildrenVersion[6] = byte(core.AutoBalanceEnabled)
@@ -1130,7 +1123,7 @@ func TestBranchNode_getVersion(t *testing.T) {
 func TestBranchNode_getValueReturnsEmptyByteSlice(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	assert.Equal(t, []byte{}, bn.getValue())
 }
 
@@ -1140,7 +1133,7 @@ func TestBranchNode_VerifyChildrenVersionIsSetCorrectlyAfterInsertAndDelete(t *t
 	t.Run("revert child from version 1 to 0", func(t *testing.T) {
 		t.Parallel()
 
-		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn, _ := getBnAndCollapsedBn()
 		bn.ChildrenVersion = make([]byte, nrOfChildren)
 		bn.ChildrenVersion[2] = byte(core.AutoBalanceEnabled)
 
@@ -1152,7 +1145,7 @@ func TestBranchNode_VerifyChildrenVersionIsSetCorrectlyAfterInsertAndDelete(t *t
 			Version: 0,
 		}
 
-		newBn := bn.insert([]core.TrieData{data}, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), &testscommon.MemDbMock{})
+		newBn := bn.insert([]core.TrieData{data}, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), getDefaultTrieContext())
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Nil(t, newBn.(*branchNode).ChildrenVersion)
 	})
@@ -1160,14 +1153,14 @@ func TestBranchNode_VerifyChildrenVersionIsSetCorrectlyAfterInsertAndDelete(t *t
 	t.Run("remove migrated child", func(t *testing.T) {
 		t.Parallel()
 
-		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn, _ := getBnAndCollapsedBn()
 		bn.ChildrenVersion = make([]byte, nrOfChildren)
 		bn.ChildrenVersion[2] = byte(core.AutoBalanceEnabled)
 		childKey := []byte{2, 'd', 'o', 'g'}
 		data := []core.TrieData{{Key: childKey}}
 
 		goRoutinesManager := getTestGoroutinesManager()
-		_, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), &testscommon.MemDbMock{})
+		_, newBn := bn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), getDefaultTrieContext())
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Nil(t, newBn.(*branchNode).ChildrenVersion)
 	})
@@ -1409,7 +1402,7 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 	t.Run("empty data should err", func(t *testing.T) {
 		t.Parallel()
 
-		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn, _ := getBnAndCollapsedBn()
 		var data []core.TrieData
 
 		goRoutinesManager := getTestGoroutinesManager()
@@ -1424,10 +1417,10 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 	t.Run("insert one child in !dirty node", func(t *testing.T) {
 		t.Parallel()
 
-		db := testscommon.NewMemDbMock()
-		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn, _ := getBnAndCollapsedBn()
 		manager := getTestGoroutinesManager()
-		bn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), db, db)
+		trieCtx := getDefaultTrieContext()
+		bn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.Nil(t, manager.GetError())
 		assert.False(t, bn.dirty)
 		newData := []core.TrieData{
@@ -1441,7 +1434,7 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 		goRoutinesManager := getTestGoroutinesManager()
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		bnModified := &atomic.Flag{}
-		bn.insertOnNilChild(newData, childPos, goRoutinesManager, modifiedHashes, bnModified, db)
+		bn.insertOnNilChild(newData, childPos, goRoutinesManager, modifiedHashes, bnModified, trieCtx)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Equal(t, 0, len(modifiedHashes.Get()))
 		assert.True(t, bn.dirty)
@@ -1452,8 +1445,7 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 	t.Run("insert one child in dirty node", func(t *testing.T) {
 		t.Parallel()
 
-		db := testscommon.NewMemDbMock()
-		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn, _ := getBnAndCollapsedBn()
 		assert.True(t, bn.dirty)
 		newData := []core.TrieData{
 			{
@@ -1466,7 +1458,7 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 		goRoutinesManager := getTestGoroutinesManager()
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		bnModified := &atomic.Flag{}
-		bn.insertOnNilChild(newData, childPos, goRoutinesManager, modifiedHashes, bnModified, db)
+		bn.insertOnNilChild(newData, childPos, goRoutinesManager, modifiedHashes, bnModified, getDefaultTrieContext())
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 0
 		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
@@ -1478,8 +1470,7 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 	t.Run("insert multiple children", func(t *testing.T) {
 		t.Parallel()
 
-		db := testscommon.NewMemDbMock()
-		bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+		bn, _ := getBnAndCollapsedBn()
 		newData := []core.TrieData{
 			{
 				Key:     []byte{1, 2, 3},
@@ -1496,7 +1487,7 @@ func TestBranchNode_insertOnNilChild(t *testing.T) {
 		goRoutinesManager := getTestGoroutinesManager()
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		bnModified := &atomic.Flag{}
-		bn.insertOnNilChild(newData, childPos, goRoutinesManager, modifiedHashes, bnModified, db)
+		bn.insertOnNilChild(newData, childPos, goRoutinesManager, modifiedHashes, bnModified, getDefaultTrieContext())
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 0
 		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
@@ -1515,16 +1506,15 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 	t.Run("insert on existing child multiple children", func(t *testing.T) {
 		t.Parallel()
 
+		trieCtx := getDefaultTrieContext()
 		childPos := byte(2)
-		db := testscommon.NewMemDbMock()
 		var children [nrOfChildren]node
-		marshaller, hasher := getTestMarshalizerAndHasher()
-		children[2], _ = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 5}), "dog"), marshaller, hasher)
-		children[6], _ = newLeafNode(getTrieDataWithDefaultVersion("doe", "doe"), marshaller, hasher)
-		bn, _ := newBranchNode(marshaller, hasher)
+		children[2] = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 5}), "dog"))
+		children[6] = newLeafNode(getTrieDataWithDefaultVersion("doe", "doe"))
+		bn := newBranchNode()
 		bn.children = children
-		bn.ChildrenHashes[2], _ = encodeNodeAndGetHash(bn.children[2])
-		bn.ChildrenHashes[6], _ = encodeNodeAndGetHash(bn.children[6])
+		bn.ChildrenHashes[2], _ = encodeNodeAndGetHash(bn.children[2], trieCtx)
+		bn.ChildrenHashes[6], _ = encodeNodeAndGetHash(bn.children[6], trieCtx)
 		newData := []core.TrieData{
 			{
 				Key:     []byte{1, 2, 3},
@@ -1538,10 +1528,10 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 			},
 		}
 		manager := getTestGoroutinesManager()
-		bn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), db, db)
+		bn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.Nil(t, manager.GetError())
 		assert.False(t, bn.dirty)
-		originalHash, _ := encodeNodeAndGetHash(bn)
+		originalHash, _ := encodeNodeAndGetHash(bn, trieCtx)
 		assert.True(t, len(originalHash) > 0)
 		originalChildHash := bn.ChildrenHashes[childPos]
 		assert.True(t, len(originalChildHash) > 0)
@@ -1549,7 +1539,7 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 		goRoutinesManager := getTestGoroutinesManager()
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		bnModified := &atomic.Flag{}
-		bn.insertOnChild(newData, int(childPos), goRoutinesManager, modifiedHashes, bnModified, db)
+		bn.insertOnChild(newData, int(childPos), goRoutinesManager, modifiedHashes, bnModified, trieCtx)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.True(t, bnModified.IsSet())
 		assert.True(t, bn.dirty)
@@ -1570,18 +1560,17 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 	t.Run("insert on existing child same node", func(t *testing.T) {
 		t.Parallel()
 
+		trieCtx := getDefaultTrieContext()
 		childPos := byte(2)
-		db := testscommon.NewMemDbMock()
 		var children [nrOfChildren]node
-		marshaller, hasher := getTestMarshalizerAndHasher()
 		key := []byte{1, 2, 5}
 		value := "dog"
-		children[2], _ = newLeafNode(getTrieDataWithDefaultVersion(string(key), value), marshaller, hasher)
-		children[6], _ = newLeafNode(getTrieDataWithDefaultVersion("doe", "doe"), marshaller, hasher)
-		bn, _ := newBranchNode(marshaller, hasher)
+		children[2] = newLeafNode(getTrieDataWithDefaultVersion(string(key), value))
+		children[6] = newLeafNode(getTrieDataWithDefaultVersion("doe", "doe"))
+		bn := newBranchNode()
 		bn.children = children
-		bn.ChildrenHashes[2], _ = encodeNodeAndGetHash(bn.children[2])
-		bn.ChildrenHashes[6], _ = encodeNodeAndGetHash(bn.children[6])
+		bn.ChildrenHashes[2], _ = encodeNodeAndGetHash(bn.children[2], trieCtx)
+		bn.ChildrenHashes[6], _ = encodeNodeAndGetHash(bn.children[6], trieCtx)
 		newData := []core.TrieData{
 			{
 				Key:     key,
@@ -1590,14 +1579,14 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 			},
 		}
 		manager := getTestGoroutinesManager()
-		bn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), db, db)
+		bn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.Nil(t, manager.GetError())
 		assert.False(t, bn.dirty)
 
 		goRoutinesManager := getTestGoroutinesManager()
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
 		bnModified := &atomic.Flag{}
-		bn.insertOnChild(newData, int(childPos), goRoutinesManager, modifiedHashes, bnModified, db)
+		bn.insertOnChild(newData, int(childPos), goRoutinesManager, modifiedHashes, bnModified, trieCtx)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.False(t, bnModified.IsSet())
 		assert.False(t, bn.dirty)
@@ -1611,15 +1600,14 @@ func TestBranchNode_insertOnExistingChild(t *testing.T) {
 func TestBranchNode_insertBatch(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
+	trieCtx := getDefaultTrieContext()
 	var children [nrOfChildren]node
-	marshaller, hasher := getTestMarshalizerAndHasher()
-	children[2], _ = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{3, 4, 5}), "dog"), marshaller, hasher)
-	children[6], _ = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{7, 8, 9}), "doe"), marshaller, hasher)
-	bn, _ := newBranchNode(marshaller, hasher)
+	children[2] = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{3, 4, 5}), "dog"))
+	children[6] = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{7, 8, 9}), "doe"))
+	bn := newBranchNode()
 	bn.children = children
-	childHash1, _ := encodeNodeAndGetHash(children[2])
-	childHash2, _ := encodeNodeAndGetHash(children[6])
+	childHash1, _ := encodeNodeAndGetHash(children[2], trieCtx)
+	childHash2, _ := encodeNodeAndGetHash(children[6], trieCtx)
 	bn.ChildrenHashes[2] = childHash1
 	bn.ChildrenHashes[6] = childHash2
 
@@ -1642,13 +1630,13 @@ func TestBranchNode_insertBatch(t *testing.T) {
 		},
 	}
 	manager := getTestGoroutinesManager()
-	bn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), db, db)
+	bn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	assert.Nil(t, manager.GetError())
 	assert.False(t, bn.dirty)
 
 	goRoutinesManager := getTestGoroutinesManager()
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	newNode := bn.insert(newData, goRoutinesManager, modifiedHashes, db)
+	newNode := bn.insert(newData, goRoutinesManager, modifiedHashes, trieCtx)
 	assert.Nil(t, goRoutinesManager.GetError())
 	expectedNumTrieNodesChanged := 1
 	assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
@@ -1668,24 +1656,24 @@ func TestBranchNode_insertBatch(t *testing.T) {
 }
 
 func getNewBn() *branchNode {
-	marsh, hasher := getTestMarshalizerAndHasher()
+	trieCtx := getDefaultTrieContext()
 	var children [nrOfChildren]node
-	childBn, _ := newBranchNode(marsh, hasher)
-	childBn.children[1], _ = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{3, 4, 5}), "dog"), marsh, hasher)
-	childBn.children[3], _ = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{7, 8, 9}), "doe"), marsh, hasher)
-	childBn.ChildrenHashes[1], _ = encodeNodeAndGetHash(childBn.children[1])
-	childBn.ChildrenHashes[3], _ = encodeNodeAndGetHash(childBn.children[3])
+	childBn := newBranchNode()
+	childBn.children[1] = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{3, 4, 5}), "dog"))
+	childBn.children[3] = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{7, 8, 9}), "doe"))
+	childBn.ChildrenHashes[1], _ = encodeNodeAndGetHash(childBn.children[1], trieCtx)
+	childBn.ChildrenHashes[3], _ = encodeNodeAndGetHash(childBn.children[3], trieCtx)
 
-	children[4], _ = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{3, 4, 5}), "dog"), marsh, hasher)
-	children[7], _ = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{7, 8, 9}), "doe"), marsh, hasher)
+	children[4] = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{3, 4, 5}), "dog"))
+	children[7] = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{7, 8, 9}), "doe"))
 	children[9] = childBn
-	bn, _ := newBranchNode(marsh, hasher)
+	bn := newBranchNode()
 	bn.children = children
-	bn.ChildrenHashes[4], _ = encodeNodeAndGetHash(bn.children[4])
-	bn.ChildrenHashes[7], _ = encodeNodeAndGetHash(bn.children[7])
-	bn.ChildrenHashes[9], _ = encodeNodeAndGetHash(childBn)
+	bn.ChildrenHashes[4], _ = encodeNodeAndGetHash(bn.children[4], trieCtx)
+	bn.ChildrenHashes[7], _ = encodeNodeAndGetHash(bn.children[7], trieCtx)
+	bn.ChildrenHashes[9], _ = encodeNodeAndGetHash(childBn, trieCtx)
 
-	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	return bn
 }
 
@@ -1707,9 +1695,10 @@ func TestBranchNode_deleteBatch(t *testing.T) {
 			},
 		}
 
+		trieCtx := getDefaultTrieContext()
 		goRoutinesManager := getTestGoroutinesManager()
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		dirty, newNode := bn.delete(data, goRoutinesManager, modifiedHashes, testscommon.NewMemDbMock())
+		dirty, newNode := bn.delete(data, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.True(t, dirty)
 		assert.True(t, newNode.isDirty())
@@ -1742,9 +1731,10 @@ func TestBranchNode_deleteBatch(t *testing.T) {
 			},
 		}
 
+		trieCtx := getDefaultTrieContext()
 		goRoutinesManager := getTestGoroutinesManager()
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		dirty, newNode := bn.delete(data, goRoutinesManager, modifiedHashes, testscommon.NewMemDbMock())
+		dirty, newNode := bn.delete(data, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.True(t, dirty)
 		assert.True(t, newNode.isDirty())
@@ -1775,9 +1765,10 @@ func TestBranchNode_deleteBatch(t *testing.T) {
 			},
 		}
 
+		trieCtx := getDefaultTrieContext()
 		goRoutinesManager := getTestGoroutinesManager()
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		dirty, newNode := bn.delete(data, goRoutinesManager, modifiedHashes, testscommon.NewMemDbMock())
+		dirty, newNode := bn.delete(data, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.True(t, dirty)
 		assert.Nil(t, newNode)

--- a/trie/depthFirstSync.go
+++ b/trie/depthFirstSync.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core"
-	"github.com/multiversx/mx-chain-core-go/hashing"
-	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/storage"
 )
@@ -19,9 +17,7 @@ type depthFirstTrieSyncer struct {
 	topic                     string
 	rootHash                  []byte
 	waitTimeBetweenChecks     time.Duration
-	marshaller                marshal.Marshalizer
-	hasher                    hashing.Hasher
-	db                        common.TrieStorageInteractor
+	trieContext               common.TrieContext
 	requestHandler            RequestHandler
 	interceptedNodesCacher    storage.Cacher
 	mutOperation              sync.RWMutex
@@ -47,11 +43,13 @@ func NewDepthFirstTrieSyncer(arg ArgTrieSyncer) (*depthFirstTrieSyncer, error) {
 	}
 
 	d := &depthFirstTrieSyncer{
-		requestHandler:            arg.RequestHandler,
-		interceptedNodesCacher:    arg.InterceptedNodes,
-		db:                        stsm,
-		marshaller:                arg.Marshalizer,
-		hasher:                    arg.Hasher,
+		requestHandler:         arg.RequestHandler,
+		interceptedNodesCacher: arg.InterceptedNodes,
+		trieContext: &trieContext{
+			StorageManager: stsm,
+			Marshalizer:    arg.Marshalizer,
+			Hasher:         arg.Hasher,
+		},
 		topic:                     arg.Topic,
 		shardId:                   arg.ShardId,
 		waitTimeBetweenChecks:     time.Millisecond * 100,
@@ -240,7 +238,7 @@ func (d *depthFirstTrieSyncer) processFirstExistingNode() (bool, error) {
 }
 
 func (d *depthFirstTrieSyncer) storeTrieNode(element node) error {
-	numBytes, err := encodeNodeAndCommitToDB(element, d.db)
+	numBytes, err := encodeNodeAndCommitToDB(element, d.trieContext)
 	if err != nil {
 		return err
 	}
@@ -281,9 +279,7 @@ func (d *depthFirstTrieSyncer) getNode(hash []byte) (node, error) {
 		return getNodeFromCacheOrStorage(
 			hash,
 			d.interceptedNodesCacher,
-			d.db,
-			d.marshaller,
-			d.hasher,
+			d.trieContext,
 		)
 	}
 	return d.getNodeFromCache(hash)
@@ -293,8 +289,7 @@ func (d *depthFirstTrieSyncer) getNodeFromCache(hash []byte) (node, error) {
 	return getNodeFromCache(
 		hash,
 		d.interceptedNodesCacher,
-		d.marshaller,
-		d.hasher,
+		d.trieContext,
 	)
 }
 

--- a/trie/doubleListSync.go
+++ b/trie/doubleListSync.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core"
-	"github.com/multiversx/mx-chain-core-go/hashing"
-	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/storage"
 )
@@ -29,9 +27,7 @@ type doubleListTrieSyncer struct {
 	topic                     string
 	rootHash                  []byte
 	waitTimeBetweenChecks     time.Duration
-	marshalizer               marshal.Marshalizer
-	hasher                    hashing.Hasher
-	db                        common.TrieStorageInteractor
+	trieContext               common.TrieContext
 	requestHandler            RequestHandler
 	interceptedNodesCacher    storage.Cacher
 	mutOperation              sync.RWMutex
@@ -61,11 +57,13 @@ func NewDoubleListTrieSyncer(arg ArgTrieSyncer) (*doubleListTrieSyncer, error) {
 	}
 
 	d := &doubleListTrieSyncer{
-		requestHandler:            arg.RequestHandler,
-		interceptedNodesCacher:    arg.InterceptedNodes,
-		db:                        stsm,
-		marshalizer:               arg.Marshalizer,
-		hasher:                    arg.Hasher,
+		requestHandler:         arg.RequestHandler,
+		interceptedNodesCacher: arg.InterceptedNodes,
+		trieContext: &trieContext{
+			StorageManager: stsm,
+			Marshalizer:    arg.Marshalizer,
+			Hasher:         arg.Hasher,
+		},
 		topic:                     arg.Topic,
 		shardId:                   arg.ShardId,
 		waitTimeBetweenChecks:     time.Millisecond * 100,
@@ -204,7 +202,7 @@ func (d *doubleListTrieSyncer) processMissingHashes() {
 
 func (d *doubleListTrieSyncer) processExistingNodes() error {
 	for hash, element := range d.existingNodes {
-		numBytes, err := encodeNodeAndCommitToDB(element, d.db)
+		numBytes, err := encodeNodeAndCommitToDB(element, d.trieContext)
 		if err != nil {
 			return err
 		}
@@ -250,9 +248,7 @@ func (d *doubleListTrieSyncer) getNode(hash []byte) (node, error) {
 		return getNodeFromCacheOrStorage(
 			hash,
 			d.interceptedNodesCacher,
-			d.db,
-			d.marshalizer,
-			d.hasher,
+			d.trieContext,
 		)
 	}
 	return d.getNodeFromCache(hash)
@@ -262,8 +258,7 @@ func (d *doubleListTrieSyncer) getNodeFromCache(hash []byte) (node, error) {
 	return getNodeFromCache(
 		hash,
 		d.interceptedNodesCacher,
-		d.marshalizer,
-		d.hasher,
+		d.trieContext,
 	)
 }
 

--- a/trie/export_test.go
+++ b/trie/export_test.go
@@ -21,7 +21,10 @@ func (ts *trieSyncer) trieNodeIntercepted(hash []byte, val interface{}) {
 		return
 	}
 
-	interceptedNode, err := trieNode(val, marshalizer, hasherMock)
+	interceptedNode, err := trieNode(val, &trieContext{
+		Marshalizer: marshalizer,
+		Hasher:      hasherMock,
+	})
 	if err != nil {
 		return
 	}

--- a/trie/extensionNode.go
+++ b/trie/extensionNode.go
@@ -682,8 +682,7 @@ func (en *extensionNode) sizeInBytes() int {
 		return 0
 	}
 
-	childVersionSizeInBytes := 4
-	nodeSize := len(en.Key) + len(en.ChildHash) + childVersionSizeInBytes + pointerSizeInBytes + dirtyFlagSizeInBytes + 2*mutexSizeInBytes
+	nodeSize := len(en.Key) + len(en.ChildHash) + versionSizeInBytes + pointerSizeInBytes + dirtyFlagSizeInBytes + 2*mutexSizeInBytes
 
 	return nodeSize
 }

--- a/trie/extensionNode_test.go
+++ b/trie/extensionNode_test.go
@@ -700,7 +700,7 @@ func TestExtensionNode_SizeInBytes(t *testing.T) {
 			dirty: false,
 		},
 	}
-	assert.Equal(t, len(collapsed)+len(key)+1+pointerSizeInBytes+4, en.sizeInBytes())
+	assert.Equal(t, len(collapsed)+len(key)+1+pointerSizeInBytes+4+2*mutexSizeInBytes, en.sizeInBytes())
 }
 
 func TestExtensionNode_commitSnapshotContextDone(t *testing.T) {

--- a/trie/extensionNode_test.go
+++ b/trie/extensionNode_test.go
@@ -15,21 +15,17 @@ import (
 	"github.com/multiversx/mx-chain-go/state/hashesCollector"
 	"github.com/multiversx/mx-chain-go/storage/cache"
 	"github.com/multiversx/mx-chain-go/testscommon"
-	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
-	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
 	"github.com/multiversx/mx-chain-go/trie/keyBuilder"
 	"github.com/multiversx/mx-chain-go/trie/statistics"
 	"github.com/stretchr/testify/assert"
 )
 
 func getEnAndCollapsedEn() (*extensionNode, *extensionNode) {
-	child, collapsedChild := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	en, _ := newExtensionNode([]byte("d"), child, child.marsh, child.hasher)
+	child, collapsedChild := getBnAndCollapsedBn()
+	en, _ := newExtensionNode([]byte("d"), child)
 
-	childHash, _ := encodeNodeAndGetHash(collapsedChild)
+	childHash, _ := encodeNodeAndGetHash(collapsedChild, getTrieContextWithCustomStorage(nil))
 	collapsedEn := &extensionNode{CollapsedEn: CollapsedEn{Key: []byte("d"), ChildHash: childHash}, baseNode: &baseNode{}}
-	collapsedEn.marsh = child.marsh
-	collapsedEn.hasher = child.hasher
 	en.ChildHash = childHash
 	return en, collapsedEn
 }
@@ -37,7 +33,7 @@ func getEnAndCollapsedEn() (*extensionNode, *extensionNode) {
 func TestExtensionNode_newExtensionNode(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	expectedEn := &extensionNode{
 		CollapsedEn: CollapsedEn{
 			Key:       []byte("dog"),
@@ -45,12 +41,10 @@ func TestExtensionNode_newExtensionNode(t *testing.T) {
 		},
 		child: bn,
 		baseNode: &baseNode{
-			dirty:  true,
-			marsh:  bn.marsh,
-			hasher: bn.hasher,
+			dirty: true,
 		},
 	}
-	en, _ := newExtensionNode([]byte("dog"), bn, bn.marsh, bn.hasher)
+	en, _ := newExtensionNode([]byte("dog"), bn)
 	assert.Equal(t, expectedEn, en)
 }
 
@@ -67,50 +61,51 @@ func TestExtensionNode_isDirty(t *testing.T) {
 func TestExtensionNode_commit(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
+	trieCtx := getDefaultTrieContext()
 	en, collapsedEn := getEnAndCollapsedEn()
-	hash, _ := encodeNodeAndGetHash(collapsedEn)
+	hash, _ := encodeNodeAndGetHash(collapsedEn, trieCtx)
 
 	manager := getTestGoroutinesManager()
-	en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), db, db)
+	en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	assert.Nil(t, manager.GetError())
 
-	encNode, _ := db.Get(hash)
-	n, _ := decodeNode(encNode, en.marsh, en.hasher)
+	encNode, _ := trieCtx.Get(hash)
+	n, _ := decodeNode(encNode, trieCtx)
 
-	h1, _ := encodeNodeAndGetHash(collapsedEn)
-	h2, _ := encodeNodeAndGetHash(n)
+	h1, _ := encodeNodeAndGetHash(collapsedEn, trieCtx)
+	h2, _ := encodeNodeAndGetHash(n, trieCtx)
 	assert.Equal(t, h1, h2)
 }
 
 func TestExtensionNode_commitCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
+	trieCtx := getDefaultTrieContext()
 	_, collapsedEn := getEnAndCollapsedEn()
-	hash, _ := encodeNodeAndGetHash(collapsedEn)
+	hash, _ := encodeNodeAndGetHash(collapsedEn, trieCtx)
 
 	collapsedEn.dirty = true
 	manager := getTestGoroutinesManager()
-	collapsedEn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), db, db)
+	collapsedEn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	assert.Nil(t, manager.GetError())
 
-	encNode, _ := db.Get(hash)
-	n, _ := decodeNode(encNode, collapsedEn.marsh, collapsedEn.hasher)
+	encNode, _ := trieCtx.Get(hash)
+	n, _ := decodeNode(encNode, trieCtx)
 
-	h1, _ := encodeNodeAndGetHash(collapsedEn)
-	h2, _ := encodeNodeAndGetHash(n)
+	h1, _ := encodeNodeAndGetHash(collapsedEn, trieCtx)
+	h2, _ := encodeNodeAndGetHash(n, trieCtx)
 	assert.Equal(t, h1, h2)
 }
 
 func TestExtensionNode_getEncodedNode(t *testing.T) {
 	t.Parallel()
 
+	trieCtx := getTrieContextWithCustomStorage(nil)
 	en, _ := getEnAndCollapsedEn()
-	expectedEncodedNode, _ := en.marsh.Marshal(en)
+	expectedEncodedNode, _ := trieCtx.Marshal(en)
 	expectedEncodedNode = append(expectedEncodedNode, extension)
 
-	encNode, err := en.getEncodedNode()
+	encNode, err := en.getEncodedNode(trieCtx)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedEncodedNode, encNode)
 }
@@ -120,7 +115,7 @@ func TestExtensionNode_getEncodedNodeEmpty(t *testing.T) {
 
 	en := &extensionNode{}
 
-	encNode, err := en.getEncodedNode()
+	encNode, err := en.getEncodedNode(getTrieContextWithCustomStorage(nil))
 	assert.True(t, errors.Is(err, ErrEmptyExtensionNode))
 	assert.Nil(t, encNode)
 }
@@ -130,7 +125,7 @@ func TestExtensionNode_getEncodedNodeNil(t *testing.T) {
 
 	var en *extensionNode
 
-	encNode, err := en.getEncodedNode()
+	encNode, err := en.getEncodedNode(getTrieContextWithCustomStorage(nil))
 	assert.True(t, errors.Is(err, ErrNilExtensionNode))
 	assert.Nil(t, encNode)
 }
@@ -141,20 +136,20 @@ func TestExtensionNode_resolveIfCollapsed(t *testing.T) {
 	t.Run("resolve collapsed node", func(t *testing.T) {
 		t.Parallel()
 
-		db := testscommon.NewMemDbMock()
+		trieCtx := getDefaultTrieContext()
 		en, collapsedEn := getEnAndCollapsedEn()
-		en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
-		_, resolved := getBnAndCollapsedBn(en.marsh, en.hasher)
+		en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
+		_, resolved := getBnAndCollapsedBn()
 
-		child, childHash, err := collapsedEn.resolveIfCollapsed(db)
+		child, childHash, err := collapsedEn.resolveIfCollapsed(trieCtx)
 		assert.Nil(t, err)
 		assert.Equal(t, en.child.(*branchNode).ChildrenHashes[2], child.(*branchNode).ChildrenHashes[2])
 		assert.Equal(t, en.child.(*branchNode).ChildrenHashes[6], child.(*branchNode).ChildrenHashes[6])
 		assert.Equal(t, en.child.(*branchNode).ChildrenHashes[13], child.(*branchNode).ChildrenHashes[13])
 		assert.Equal(t, en.ChildHash, childHash)
 
-		h1, _ := encodeNodeAndGetHash(resolved)
-		h2, _ := encodeNodeAndGetHash(collapsedEn.child)
+		h1, _ := encodeNodeAndGetHash(resolved, trieCtx)
+		h2, _ := encodeNodeAndGetHash(collapsedEn.child, trieCtx)
 		assert.Equal(t, h1, h2)
 	})
 	t.Run("invalid node state", func(t *testing.T) {
@@ -163,7 +158,7 @@ func TestExtensionNode_resolveIfCollapsed(t *testing.T) {
 		en, _ := getEnAndCollapsedEn()
 		en.ChildHash = nil
 
-		child, childHash, err := en.resolveIfCollapsed(nil)
+		child, childHash, err := en.resolveIfCollapsed(getTrieContextWithCustomStorage(nil))
 		assert.Equal(t, ErrInvalidNodeState, err)
 		assert.Nil(t, child)
 		assert.Nil(t, childHash)
@@ -173,7 +168,7 @@ func TestExtensionNode_resolveIfCollapsed(t *testing.T) {
 
 		en, _ := getEnAndCollapsedEn()
 
-		child, childHash, err := en.resolveIfCollapsed(nil)
+		child, childHash, err := en.resolveIfCollapsed(getTrieContextWithCustomStorage(nil))
 		assert.Nil(t, err)
 		assert.Equal(t, en.child, child)
 		assert.Equal(t, en.ChildHash, childHash)
@@ -187,7 +182,7 @@ func TestExtensionNode_isCollapsed(t *testing.T) {
 	assert.True(t, collapsedEn.isCollapsed())
 	assert.False(t, en.isCollapsed())
 
-	collapsedEn.child, _ = newLeafNode(getTrieDataWithDefaultVersion("og", "dog"), en.marsh, en.hasher)
+	collapsedEn.child = newLeafNode(getTrieDataWithDefaultVersion("og", "dog"))
 	assert.False(t, collapsedEn.isCollapsed())
 }
 
@@ -203,7 +198,7 @@ func TestExtensionNode_tryGet(t *testing.T) {
 	key := append(enKey, bnKey...)
 	key = append(key, lnKey...)
 
-	val, maxDepth, err := en.tryGet(key, 0, nil)
+	val, maxDepth, err := en.tryGet(key, 0, getTrieContextWithCustomStorage(nil))
 	assert.Equal(t, dogBytes, val)
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(2), maxDepth)
@@ -215,7 +210,7 @@ func TestExtensionNode_tryGetEmptyKey(t *testing.T) {
 	en, _ := getEnAndCollapsedEn()
 	var key []byte
 
-	val, maxDepth, err := en.tryGet(key, 0, nil)
+	val, maxDepth, err := en.tryGet(key, 0, getTrieContextWithCustomStorage(nil))
 	assert.Nil(t, err)
 	assert.Nil(t, val)
 	assert.Equal(t, uint32(0), maxDepth)
@@ -227,7 +222,7 @@ func TestExtensionNode_tryGetWrongKey(t *testing.T) {
 	en, _ := getEnAndCollapsedEn()
 	key := []byte("gdo")
 
-	val, maxDepth, err := en.tryGet(key, 0, nil)
+	val, maxDepth, err := en.tryGet(key, 0, getTrieContextWithCustomStorage(nil))
 	assert.Nil(t, err)
 	assert.Nil(t, val)
 	assert.Equal(t, uint32(0), maxDepth)
@@ -236,9 +231,9 @@ func TestExtensionNode_tryGetWrongKey(t *testing.T) {
 func TestExtensionNode_tryGetCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
+	trieCtx := getDefaultTrieContext()
 	en, collapsedEn := getEnAndCollapsedEn()
-	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
 	enKey := []byte{100}
 	bnKey := []byte{2}
@@ -246,7 +241,7 @@ func TestExtensionNode_tryGetCollapsedNode(t *testing.T) {
 	key := append(enKey, bnKey...)
 	key = append(key, lnKey...)
 
-	val, maxDepth, err := collapsedEn.tryGet(key, 0, db)
+	val, maxDepth, err := collapsedEn.tryGet(key, 0, trieCtx)
 	assert.Equal(t, []byte("dog"), val)
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(2), maxDepth)
@@ -256,8 +251,8 @@ func TestExtensionNode_getNext(t *testing.T) {
 	t.Parallel()
 
 	en, _ := getEnAndCollapsedEn()
-	db := testscommon.NewMemDbMock()
-	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	trieCtx := getDefaultTrieContext()
+	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
 	enKey := []byte{100}
 	bnKey := []byte{2}
@@ -265,8 +260,8 @@ func TestExtensionNode_getNext(t *testing.T) {
 	key := append(enKey, bnKey...)
 	key = append(key, lnKey...)
 
-	data, err := en.getNext(key, db)
-	child, childBytes, _ := getNodeFromDBAndDecode(en.ChildHash, db, en.marsh, en.hasher)
+	data, err := en.getNext(key, trieCtx)
+	child, childBytes, _ := getNodeFromDBAndDecode(en.ChildHash, trieCtx)
 	assert.NotNil(t, data)
 	assert.Equal(t, childBytes, data.encodedNode)
 	assert.Equal(t, child, data.currentNode)
@@ -282,7 +277,7 @@ func TestExtensionNode_getNextWrongKey(t *testing.T) {
 	lnKey := []byte("dog")
 	key := append(bnKey, lnKey...)
 
-	data, err := en.getNext(key, nil)
+	data, err := en.getNext(key, getTrieContextWithCustomStorage(nil))
 	assert.Nil(t, data)
 	assert.Equal(t, ErrNodeNotFound, err)
 }
@@ -296,43 +291,43 @@ func TestExtensionNode_insert(t *testing.T) {
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
-	newNode := en.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
+	newNode := en.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), getTrieContextWithCustomStorage(nil))
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 
-	val, _, _ := newNode.tryGet(key, 0, nil)
+	val, _, _ := newNode.tryGet(key, 0, getTrieContextWithCustomStorage(nil))
 	assert.Equal(t, []byte("dogs"), val)
 }
 
 func TestExtensionNode_insertCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
+	trieCtx := getDefaultTrieContext()
 	en, collapsedEn := getEnAndCollapsedEn()
 	key := []byte{100, 15, 5, 6}
 
-	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
-	newNode := collapsedEn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), db)
+	newNode := collapsedEn.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), trieCtx)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 
-	val, _, _ := newNode.tryGet(key, 0, db)
+	val, _, _ := newNode.tryGet(key, 0, trieCtx)
 	assert.Equal(t, []byte("dogs"), val)
 }
 
 func TestExtensionNode_insertInStoredEnSameKey(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
+	trieCtx := getDefaultTrieContext()
 	en, _ := getEnAndCollapsedEn()
 	enKey := []byte{100}
 	key := append(enKey, []byte{11, 12}...)
 
-	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	bnHash := en.ChildHash
 	expectedHashes := [][]byte{bnHash}
 
@@ -340,7 +335,7 @@ func TestExtensionNode_insertInStoredEnSameKey(t *testing.T) {
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(key), "dogs")}
 
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	newNode := en.insert(data, goRoutinesManager, modifiedHashes, db)
+	newNode := en.insert(data, goRoutinesManager, modifiedHashes, trieCtx)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, expectedHashes, modifiedHashes.Get())
@@ -349,22 +344,22 @@ func TestExtensionNode_insertInStoredEnSameKey(t *testing.T) {
 func TestExtensionNode_insertInStoredEnDifferentKey(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	trieCtx := getDefaultTrieContext()
+	bn, _ := getBnAndCollapsedBn()
 	enKey := []byte{1}
-	en, _ := newExtensionNode(enKey, bn, bn.marsh, bn.hasher)
+	en, _ := newExtensionNode(enKey, bn)
 	nodeKey := []byte{11, 12}
-	childHash, _ := encodeNodeAndGetHash(en.child)
+	childHash, _ := encodeNodeAndGetHash(en.child, trieCtx)
 	en.ChildHash = childHash
 
-	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	expectedHashes := [][]byte{childHash}
 
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
 
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	newNode := en.insert(data, goRoutinesManager, modifiedHashes, db)
+	newNode := en.insert(data, goRoutinesManager, modifiedHashes, trieCtx)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.True(t, slicesContainSameElements(expectedHashes, modifiedHashes.Get()))
@@ -380,7 +375,7 @@ func TestExtensionNode_insertInDirtyEnSameKey(t *testing.T) {
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
 
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
+	newNode := en.insert(data, goRoutinesManager, modifiedHashes, getTrieContextWithCustomStorage(nil))
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
@@ -389,18 +384,18 @@ func TestExtensionNode_insertInDirtyEnSameKey(t *testing.T) {
 func TestExtensionNode_insertInDirtyEnDifferentKey(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
+	bn, _ := getBnAndCollapsedBn()
 	enKey := []byte{1}
-	en, _ := newExtensionNode(enKey, bn, bn.marsh, bn.hasher)
+	en, _ := newExtensionNode(enKey, bn)
 	nodeKey := []byte{11, 12}
-	childHash, _ := encodeNodeAndGetHash(en.child)
+	childHash, _ := encodeNodeAndGetHash(en.child, getTrieContextWithCustomStorage(nil))
 	en.ChildHash = childHash
 
 	goRoutinesManager := getTestGoroutinesManager()
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), "dogs")}
 
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
+	newNode := en.insert(data, goRoutinesManager, modifiedHashes, getTrieContextWithCustomStorage(nil))
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
@@ -417,23 +412,24 @@ func TestExtensionNode_delete(t *testing.T) {
 	lnKey := dogBytes
 	key := append(enKey, bnKey...)
 	key = append(key, lnKey...)
+	trieCtx := getTrieContextWithCustomStorage(nil)
 
-	val, _, _ := en.tryGet(key, 0, nil)
+	val, _, _ := en.tryGet(key, 0, trieCtx)
 	assert.Equal(t, dogBytes, val)
 	data := []core.TrieData{{Key: key}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	dirty, _ := en.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
+	dirty, _ := en.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), trieCtx)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
-	val, _, _ = en.tryGet(key, 0, nil)
+	val, _, _ = en.tryGet(key, 0, trieCtx)
 	assert.Nil(t, val)
 }
 
 func TestExtensionNode_deleteFromStoredEn(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
+	trieCtx := getDefaultTrieContext()
 	en, _ := getEnAndCollapsedEn()
 	enKey := []byte{100}
 	bnKey := []byte{2}
@@ -442,7 +438,7 @@ func TestExtensionNode_deleteFromStoredEn(t *testing.T) {
 	key = append(key, lnKey...)
 	lnPathKey := key
 
-	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	bnHash := en.ChildHash
 	lnHash := en.child.(*branchNode).ChildrenHashes[2]
 	expectedHashes := [][]byte{lnHash, bnHash}
@@ -450,7 +446,7 @@ func TestExtensionNode_deleteFromStoredEn(t *testing.T) {
 
 	goRoutinesManager := getTestGoroutinesManager()
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	dirty, _ := en.delete(data, goRoutinesManager, modifiedHashes, db)
+	dirty, _ := en.delete(data, goRoutinesManager, modifiedHashes, trieCtx)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.True(t, slicesContainSameElements(expectedHashes, modifiedHashes.Get()))
@@ -465,7 +461,7 @@ func TestExtensionNode_deleteFromDirtyEn(t *testing.T) {
 
 	goRoutinesManager := getTestGoroutinesManager()
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	dirty, _ := en.delete(data, goRoutinesManager, modifiedHashes, nil)
+	dirty, _ := en.delete(data, goRoutinesManager, modifiedHashes, getTrieContextWithCustomStorage(nil))
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
@@ -474,9 +470,9 @@ func TestExtensionNode_deleteFromDirtyEn(t *testing.T) {
 func TestExtensionNode_deleteCollapsedNode(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
+	trieCtx := getDefaultTrieContext()
 	en, collapsedEn := getEnAndCollapsedEn()
-	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
 	enKey := []byte{100}
 	bnKey := []byte{2}
@@ -484,34 +480,31 @@ func TestExtensionNode_deleteCollapsedNode(t *testing.T) {
 	key := append(enKey, bnKey...)
 	key = append(key, lnKey...)
 
-	val, _, _ := en.tryGet(key, 0, db)
+	val, _, _ := en.tryGet(key, 0, trieCtx)
 	assert.Equal(t, []byte("dog"), val)
 	data := []core.TrieData{{Key: key}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	dirty, newNode := collapsedEn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), db)
+	dirty, newNode := collapsedEn.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), trieCtx)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
-	val, _, _ = newNode.tryGet(key, 0, db)
+	val, _, _ = newNode.tryGet(key, 0, trieCtx)
 	assert.Nil(t, val)
 }
 
 func TestExtensionNode_reduceNode(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshalizerAndHasher()
-	bn, _ := getBnAndCollapsedBn(marsh, hasher)
-	en, _ := newExtensionNode([]byte{100, 111, 103}, bn, marsh, hasher)
-	childHash, _ := encodeNodeAndGetHash(bn)
+	bn, _ := getBnAndCollapsedBn()
+	en, _ := newExtensionNode([]byte{100, 111, 103}, bn)
+	childHash, _ := encodeNodeAndGetHash(bn, getTrieContextWithCustomStorage(nil))
 	en.ChildHash = childHash
 
 	expected := &extensionNode{CollapsedEn: CollapsedEn{Key: []byte{2, 100, 111, 103}}, baseNode: &baseNode{dirty: true}}
-	expected.marsh = en.marsh
-	expected.hasher = en.hasher
 	expected.child = en.child
 	expected.ChildHash = en.ChildHash
 
-	n, newChildPos, err := en.reduceNode(2, en.ChildHash, nil)
+	n, newChildPos, err := en.reduceNode(2, en.ChildHash, getTrieContextWithCustomStorage(nil))
 	assert.Equal(t, expected, n)
 	assert.Nil(t, err)
 	assert.True(t, newChildPos)
@@ -546,7 +539,7 @@ func TestExtensionNode_getChildren(t *testing.T) {
 
 	en, _ := getEnAndCollapsedEn()
 
-	children, err := en.getChildren(nil)
+	children, err := en.getChildren(getTrieContextWithCustomStorage(nil))
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(children))
 }
@@ -554,11 +547,11 @@ func TestExtensionNode_getChildren(t *testing.T) {
 func TestExtensionNode_getChildrenCollapsedEn(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
+	trieCtx := getDefaultTrieContext()
 	en, collapsedEn := getEnAndCollapsedEn()
-	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
-	children, err := collapsedEn.getChildren(db)
+	children, err := collapsedEn.getChildren(trieCtx)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(children))
 }
@@ -575,7 +568,7 @@ func TestExtensionNode_setDirty(t *testing.T) {
 func TestExtensionNode_loadChildren(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshalizerAndHasher()
+	_, hasher := getTestMarshalizerAndHasher()
 	tr, _ := newEmptyTrie()
 	tr.Update([]byte("dog"), []byte("puppy"))
 	tr.Update([]byte("ddog"), []byte("cat"))
@@ -591,7 +584,7 @@ func TestExtensionNode_loadChildren(t *testing.T) {
 
 	getNode := func(hash []byte) (node, error) {
 		cacheData, _ := nodesCacher.Get(hash)
-		return trieNode(cacheData, marsh, hasher)
+		return trieNode(cacheData, getTrieContextWithCustomStorage(nil))
 	}
 	_, _, err := en.loadChildren(getNode)
 	assert.Nil(t, err)
@@ -608,65 +601,33 @@ func getCollapsedEn(t *testing.T, n node) *extensionNode {
 	return en
 }
 
-func TestExtensionNode_newExtensionNodeNilMarshalizerShouldErr(t *testing.T) {
-	t.Parallel()
-
-	en, err := newExtensionNode([]byte("key"), &branchNode{}, nil, &hashingMocks.HasherMock{})
-	assert.Nil(t, en)
-	assert.Equal(t, ErrNilMarshalizer, err)
-}
-
-func TestExtensionNode_newExtensionNodeNilHasherShouldErr(t *testing.T) {
-	t.Parallel()
-
-	en, err := newExtensionNode([]byte("key"), &branchNode{}, &marshallerMock.MarshalizerMock{}, nil)
-	assert.Nil(t, en)
-	assert.Equal(t, ErrNilHasher, err)
-}
-
 func TestExtensionNode_newExtensionNodeOkVals(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshalizerAndHasher()
 	key := []byte("key")
-	child, _ := getBnAndCollapsedBn(marsh, hasher)
-	en, err := newExtensionNode(key, child, marsh, hasher)
+	child, _ := getBnAndCollapsedBn()
+	en, err := newExtensionNode(key, child)
 
 	assert.Nil(t, err)
 	assert.Equal(t, key, en.Key)
 	assert.Nil(t, en.ChildHash)
 	assert.Equal(t, child, en.child)
-	assert.Equal(t, hasher, en.hasher)
-	assert.Equal(t, marsh, en.marsh)
 	assert.True(t, en.dirty)
-}
-
-func TestExtensionNode_getMarshalizer(t *testing.T) {
-	t.Parallel()
-
-	marsh, _ := getTestMarshalizerAndHasher()
-	en := &extensionNode{
-		baseNode: &baseNode{
-			marsh: marsh,
-		},
-	}
-
-	assert.Equal(t, marsh, en.getMarshalizer())
 }
 
 func TestExtensionNode_commitCollapsesTrieIfMaxTrieLevelInMemoryIsReached(t *testing.T) {
 	t.Parallel()
 
 	en, collapsedEn := getEnAndCollapsedEn()
-
+	trieCtx := getDefaultTrieContext()
 	manager := getTestGoroutinesManager()
-	en.commitDirty(0, 1, manager, hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+	en.commitDirty(0, 1, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	assert.Nil(t, manager.GetError())
 
 	assert.Equal(t, collapsedEn.ChildHash, en.ChildHash)
 	assert.Equal(t, collapsedEn.child, en.child)
-	collapseEnHash, _ := encodeNodeAndGetHash(collapsedEn)
-	enHash, _ := encodeNodeAndGetHash(en)
+	collapseEnHash, _ := encodeNodeAndGetHash(collapsedEn, trieCtx)
+	enHash, _ := encodeNodeAndGetHash(en, trieCtx)
 	assert.Equal(t, collapseEnHash, enHash)
 }
 
@@ -676,13 +637,13 @@ func TestExtensionNode_printShouldNotPanicEvenIfNodeIsCollapsed(t *testing.T) {
 	enWriter := bytes.NewBuffer(make([]byte, 0))
 	collapsedEnWriter := bytes.NewBuffer(make([]byte, 0))
 
-	db := testscommon.NewMemDbMock()
+	trieCtx := getDefaultTrieContext()
 	en, collapsedEn := getEnAndCollapsedEn()
-	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
-	collapsedEn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
+	collapsedEn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
-	en.print(enWriter, 0, db)
-	collapsedEn.print(collapsedEnWriter, 0, db)
+	en.print(enWriter, 0, trieCtx)
+	collapsedEn.print(collapsedEnWriter, 0, trieCtx)
 
 	assert.Equal(t, enWriter.Bytes(), collapsedEnWriter.Bytes())
 }
@@ -730,28 +691,27 @@ func TestExtensionNode_SizeInBytes(t *testing.T) {
 	key := []byte("key")
 	en = &extensionNode{
 		CollapsedEn: CollapsedEn{
-			Key:       key,
-			ChildHash: collapsed,
+			Key:          key,
+			ChildHash:    collapsed,
+			ChildVersion: 1,
 		},
 		child: nil,
 		baseNode: &baseNode{
-			dirty:  false,
-			marsh:  nil,
-			hasher: nil,
+			dirty: false,
 		},
 	}
-	assert.Equal(t, len(collapsed)+len(key)+1+3*pointerSizeInBytes, en.sizeInBytes())
+	assert.Equal(t, len(collapsed)+len(key)+1+pointerSizeInBytes+4, en.sizeInBytes())
 }
 
 func TestExtensionNode_commitSnapshotContextDone(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
+	trieCtx := getDefaultTrieContext()
 	en, _ := getEnAndCollapsedEn()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := en.commitSnapshot(db, nil, nil, ctx, statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, []byte("nodeBytes"), 0)
+	err := en.commitSnapshot(trieCtx, nil, nil, ctx, statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, []byte("nodeBytes"), 0)
 	assert.Equal(t, core.ErrContextClosing, err)
 }
 
@@ -769,11 +729,15 @@ func TestExtensionNode_commitSnapshotDbIsClosing(t *testing.T) {
 	db.GetCalled = func(key []byte) ([]byte, error) {
 		return nil, core.ErrContextClosing
 	}
+	args := GetDefaultTrieStorageManagerParameters()
+	args.MainStorer = db
+	trieStorage, _ := NewTrieStorageManager(args)
+	trieCtx := getTrieContextWithCustomStorage(trieStorage)
 
 	_, collapsedEn := getEnAndCollapsedEn()
 	missingNodesChan := make(chan []byte, 10)
-	nodeBytes, _ := collapsedEn.getEncodedNode()
-	err := collapsedEn.commitSnapshot(db, nil, missingNodesChan, context.Background(), statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, nodeBytes, 0)
+	nodeBytes, _ := collapsedEn.getEncodedNode(trieCtx)
+	err := collapsedEn.commitSnapshot(trieCtx, nil, missingNodesChan, context.Background(), statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, nodeBytes, 0)
 	assert.True(t, core.IsClosingError(err))
 	assert.Equal(t, 0, len(missingNodesChan))
 }
@@ -964,16 +928,16 @@ func Test_removeCommonPrefix(t *testing.T) {
 }
 
 func getEn() *extensionNode {
-	marsh, hasher := getTestMarshalizerAndHasher()
 	var children [nrOfChildren]node
-	children[4], _ = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{3, 4, 5}), "dog"), marsh, hasher)
-	children[7], _ = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{7, 8, 9}), "doe"), marsh, hasher)
-	bn, _ := newBranchNode(marsh, hasher)
+	children[4] = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{3, 4, 5}), "dog"))
+	children[7] = newLeafNode(getTrieDataWithDefaultVersion(string([]byte{7, 8, 9}), "doe"))
+	bn := newBranchNode()
 	bn.children = children
-	bn.ChildrenHashes[4], _ = encodeNodeAndGetHash(children[4])
-	bn.ChildrenHashes[7], _ = encodeNodeAndGetHash(children[7])
-	en, _ := newExtensionNode([]byte{1, 2}, bn, marsh, hasher)
-	childHash, _ := encodeNodeAndGetHash(bn)
+	trieCtx := getTrieContextWithCustomStorage(nil)
+	bn.ChildrenHashes[4], _ = encodeNodeAndGetHash(children[4], trieCtx)
+	bn.ChildrenHashes[7], _ = encodeNodeAndGetHash(children[7], trieCtx)
+	en, _ := newExtensionNode([]byte{1, 2}, bn)
+	childHash, _ := encodeNodeAndGetHash(bn, trieCtx)
 	en.ChildHash = childHash
 	return en
 }
@@ -986,7 +950,8 @@ func TestExtensionNode_insertInSameEn(t *testing.T) {
 
 		en := getEn()
 		manager := getTestGoroutinesManager()
-		en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		trieCtx := getDefaultTrieContext()
+		en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.Nil(t, manager.GetError())
 
 		data := []core.TrieData{
@@ -999,7 +964,7 @@ func TestExtensionNode_insertInSameEn(t *testing.T) {
 		assert.Nil(t, err)
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
+		newNode := en.insert(data, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 0
 		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
@@ -1011,7 +976,8 @@ func TestExtensionNode_insertInSameEn(t *testing.T) {
 
 		en := getEn()
 		manager := getTestGoroutinesManager()
-		en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		trieCtx := getDefaultTrieContext()
+		en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.Nil(t, manager.GetError())
 
 		data := []core.TrieData{
@@ -1024,7 +990,7 @@ func TestExtensionNode_insertInSameEn(t *testing.T) {
 		assert.Nil(t, err)
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
+		newNode := en.insert(data, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 1
 		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
@@ -1048,7 +1014,8 @@ func TestExtensionNode_insertInNewBn(t *testing.T) {
 
 		en := getEn()
 		manager := getTestGoroutinesManager()
-		en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		trieCtx := getDefaultTrieContext()
+		en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.Nil(t, manager.GetError())
 
 		data := []core.TrieData{
@@ -1061,7 +1028,7 @@ func TestExtensionNode_insertInNewBn(t *testing.T) {
 		assert.Nil(t, err)
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
+		newNode := en.insert(data, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 1
 		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
@@ -1083,7 +1050,8 @@ func TestExtensionNode_insertInNewBn(t *testing.T) {
 
 		en := getEn()
 		manager := getTestGoroutinesManager()
-		en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		trieCtx := getDefaultTrieContext()
+		en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.Nil(t, manager.GetError())
 
 		data := []core.TrieData{
@@ -1096,7 +1064,7 @@ func TestExtensionNode_insertInNewBn(t *testing.T) {
 		assert.Nil(t, err)
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		newNode := en.insert(data, goRoutinesManager, modifiedHashes, nil)
+		newNode := en.insert(data, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 1
 		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
@@ -1112,9 +1080,10 @@ func TestExtensionNode_insertInNewBn(t *testing.T) {
 
 		originalEn := getEn()
 		manager := getTestGoroutinesManager()
-		originalEn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		trieCtx := getDefaultTrieContext()
+		originalEn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.Nil(t, manager.GetError())
-		originalHash, _ := encodeNodeAndGetHash(originalEn)
+		originalHash, _ := encodeNodeAndGetHash(originalEn, trieCtx)
 
 		data := []core.TrieData{
 			getTrieDataWithDefaultVersion(string([]byte{1, 3, 6, 7, 16}), "dog"),   // new value
@@ -1126,7 +1095,7 @@ func TestExtensionNode_insertInNewBn(t *testing.T) {
 		assert.Nil(t, err)
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		newNode := originalEn.insert(data, goRoutinesManager, modifiedHashes, nil)
+		newNode := originalEn.insert(data, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 1
 		assert.Equal(t, expectedNumTrieNodesChanged, len(modifiedHashes.Get()))
@@ -1138,7 +1107,7 @@ func TestExtensionNode_insertInNewBn(t *testing.T) {
 		assert.True(t, ok)
 		assert.True(t, bn.dirty)
 
-		enHash, _ := encodeNodeAndGetHash(en)
+		enHash, _ := encodeNodeAndGetHash(en, trieCtx)
 		assert.False(t, bn.children[2].(*branchNode).dirty)
 		assert.Equal(t, originalEn.child, bn.children[2])
 		assert.NotEqual(t, originalHash, enHash)
@@ -1153,7 +1122,8 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 
 		en := getEn()
 		manager := getTestGoroutinesManager()
-		en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		trieCtx := getDefaultTrieContext()
+		en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.Nil(t, manager.GetError())
 
 		data := []core.TrieData{
@@ -1166,7 +1136,7 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		assert.Nil(t, err)
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		dirty, newNode := en.delete(data, goRoutinesManager, modifiedHashes, nil)
+		dirty, newNode := en.delete(data, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.False(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 0
@@ -1178,7 +1148,8 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 
 		en := getEn()
 		manager := getTestGoroutinesManager()
-		en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		trieCtx := getDefaultTrieContext()
+		en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.Nil(t, manager.GetError())
 
 		data := []core.TrieData{
@@ -1190,7 +1161,7 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		assert.Nil(t, err)
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		dirty, newNode := en.delete(data, goRoutinesManager, modifiedHashes, nil)
+		dirty, newNode := en.delete(data, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.True(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 3
@@ -1208,13 +1179,14 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		data := []core.TrieData{
 			getTrieDataWithDefaultVersion(string([]byte{1, 2, 4, 4, 5, 6}), "dog"),
 		}
+		trieCtx := getDefaultTrieContext()
 
 		th, _ := throttler.NewNumGoRoutinesThrottler(5)
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}), "")
 		assert.Nil(t, err)
 
-		newEn := en.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
-		newEn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		newEn := en.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), trieCtx)
+		newEn.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.Nil(t, manager.GetError())
 
 		dataForRemoval := []core.TrieData{
@@ -1222,7 +1194,7 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		}
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		dirty, newNode := newEn.delete(dataForRemoval, goRoutinesManager, modifiedHashes, nil)
+		dirty, newNode := newEn.delete(dataForRemoval, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.True(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 2
@@ -1237,8 +1209,9 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 
 		en := getEn()
 		manager := getTestGoroutinesManager()
+		trieCtx := getDefaultTrieContext()
 		assert.Nil(t, manager.GetError())
-		en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		en.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.Nil(t, manager.GetError())
 
 		data := []core.TrieData{
@@ -1251,7 +1224,7 @@ func TestExtensionNode_deleteBatch(t *testing.T) {
 		assert.Nil(t, err)
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		dirty, newNode := en.delete(data, goRoutinesManager, modifiedHashes, nil)
+		dirty, newNode := en.delete(data, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.True(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())
 		expectedNumTrieNodesChanged := 3

--- a/trie/interface.go
+++ b/trie/interface.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core"
-	"github.com/multiversx/mx-chain-core-go/hashing"
-	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
@@ -26,36 +24,32 @@ type nodeWithHash struct {
 type baseTrieNode interface {
 	setDirty(bool)
 	isDirty() bool
-	getMarshalizer() marshal.Marshalizer
-	setMarshalizer(marshal.Marshalizer)
-	getHasher() hashing.Hasher
-	setHasher(hashing.Hasher)
 }
 
 type node interface {
 	baseTrieNode
-	getEncodedNode() ([]byte, error)
-	tryGet(key []byte, depth uint32, db common.TrieStorageInteractor) ([]byte, uint32, error)
-	getNext(key []byte, db common.TrieStorageInteractor) (*nodeData, error)
-	insert(newData []core.TrieData, goRoutinesManager common.TrieGoroutinesManager, modifiedHashes common.AtomicBytesSlice, db common.TrieStorageInteractor) node
-	delete(data []core.TrieData, goRoutinesManager common.TrieGoroutinesManager, modifiedHashes common.AtomicBytesSlice, db common.TrieStorageInteractor) (bool, node)
-	reduceNode(pos int, hash []byte, db common.TrieStorageInteractor) (node, bool, error)
+	snapshotNode
+	getEncodedNode(trieCtx common.TrieContext) ([]byte, error)
+	tryGet(key []byte, depth uint32, trieCtx common.TrieContext) ([]byte, uint32, error)
+	getNext(key []byte, trieCtx common.TrieContext) (*nodeData, error)
+	insert(newData []core.TrieData, goRoutinesManager common.TrieGoroutinesManager, modifiedHashes common.AtomicBytesSlice, trieCtx common.TrieContext) node
+	delete(data []core.TrieData, goRoutinesManager common.TrieGoroutinesManager, modifiedHashes common.AtomicBytesSlice, trieCtx common.TrieContext) (bool, node)
+	reduceNode(pos int, hash []byte, trieCtx common.TrieContext) (node, bool, error)
 	isEmptyOrNil() error
-	print(writer io.Writer, index int, db common.TrieStorageInteractor)
-	getChildren(db common.TrieStorageInteractor) ([]nodeWithHash, error)
+	print(writer io.Writer, index int, trieCtx common.TrieContext)
+	getChildren(trieCtx common.TrieContext) ([]nodeWithHash, error)
 	getNodeData(common.KeyBuilder) ([]common.TrieNodeData, error)
 	loadChildren(func([]byte) (node, error)) ([][]byte, []nodeWithHash, error)
-	getAllLeavesOnChannel(chan core.KeyValueHolder, common.KeyBuilder, common.TrieLeafParser, common.TrieStorageInteractor, marshal.Marshalizer, chan struct{}, context.Context) error
+	getAllLeavesOnChannel(chan core.KeyValueHolder, common.KeyBuilder, common.TrieLeafParser, chan struct{}, context.Context, common.TrieContext) error
 	getNextHashAndKey([]byte) (bool, []byte, []byte)
 	getValue() []byte
 	getVersion() (core.TrieNodeVersion, error)
-	collectLeavesForMigration(migrationArgs vmcommon.ArgsMigrateDataTrieLeaves, db common.TrieStorageInteractor, keyBuilder common.KeyBuilder) (bool, error)
+	collectLeavesForMigration(migrationArgs vmcommon.ArgsMigrateDataTrieLeaves, keyBuilder common.KeyBuilder, trieCtx common.TrieContext) (bool, error)
 
-	commitDirty(level byte, maxTrieLevelInMemory uint, goRoutinesManager common.TrieGoroutinesManager, hashesCollector common.TrieHashesCollector, originDb common.TrieStorageInteractor, targetDb common.BaseStorer)
-	commitSnapshot(originDb common.TrieStorageInteractor, leavesChan chan core.KeyValueHolder, missingNodesChan chan []byte, ctx context.Context, stats common.TrieStatisticsHandler, idleProvider IdleNodeProvider, nodeBytes []byte, depthLevel int) error
+	commitDirty(level byte, maxTrieLevelInMemory uint, goRoutinesManager common.TrieGoroutinesManager, hashesCollector common.TrieHashesCollector, trieCtx common.TrieContext)
 
 	sizeInBytes() int
-	collectStats(handler common.TrieStatisticsHandler, depthLevel int, nodeSize uint64, db common.TrieStorageInteractor) error
+	collectStats(handler common.TrieStatisticsHandler, depthLevel int, nodeSize uint64, trieCtx common.TrieContext) error
 
 	IsInterfaceNil() bool
 }
@@ -65,7 +59,16 @@ type dbWithGetFromEpoch interface {
 }
 
 type snapshotNode interface {
-	commitSnapshot(originDb common.TrieStorageInteractor, leavesChan chan core.KeyValueHolder, missingNodesChan chan []byte, ctx context.Context, stats common.TrieStatisticsHandler, idleProvider IdleNodeProvider, nodeBytes []byte, depthLevel int) error
+	commitSnapshot(
+		trieCtx common.TrieContext,
+		leavesChan chan core.KeyValueHolder,
+		missingNodesChan chan []byte,
+		ctx context.Context,
+		stats common.TrieStatisticsHandler,
+		idleProvider IdleNodeProvider,
+		nodeBytes []byte,
+		depthLevel int,
+	) error
 }
 
 // RequestHandler defines the methods through which request to data can be made

--- a/trie/leafNode.go
+++ b/trie/leafNode.go
@@ -349,8 +349,7 @@ func (ln *leafNode) sizeInBytes() int {
 		return 0
 	}
 
-	nodeVersionSizeInBytes := 4
-	nodeSize := len(ln.Key) + len(ln.Value) + nodeVersionSizeInBytes + dirtyFlagSizeInBytes + mutexSizeInBytes
+	nodeSize := len(ln.Key) + len(ln.Value) + versionSizeInBytes + dirtyFlagSizeInBytes + mutexSizeInBytes
 
 	return nodeSize
 }

--- a/trie/leafNode.go
+++ b/trie/leafNode.go
@@ -10,8 +10,6 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/core/keyValStorage"
-	"github.com/multiversx/mx-chain-core-go/hashing"
-	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/trie/keyBuilder"
 	"github.com/multiversx/mx-chain-go/trie/leavesRetriever/trieNodeData"
@@ -22,16 +20,7 @@ var _ = node(&leafNode{})
 
 func newLeafNode(
 	newData core.TrieData,
-	marshalizer marshal.Marshalizer,
-	hasher hashing.Hasher,
-) (*leafNode, error) {
-	if check.IfNil(marshalizer) {
-		return nil, ErrNilMarshalizer
-	}
-	if check.IfNil(hasher) {
-		return nil, ErrNilHasher
-	}
-
+) *leafNode {
 	return &leafNode{
 		CollapsedLn: CollapsedLn{
 			Key:     newData.Key,
@@ -39,11 +28,9 @@ func newLeafNode(
 			Version: uint32(newData.Version),
 		},
 		baseNode: &baseNode{
-			dirty:  true,
-			marsh:  marshalizer,
-			hasher: hasher,
+			dirty: true,
 		},
-	}, nil
+	}
 }
 
 func (ln *leafNode) commitDirty(
@@ -51,18 +38,17 @@ func (ln *leafNode) commitDirty(
 	_ uint,
 	goRoutinesManager common.TrieGoroutinesManager,
 	hashesCollector common.TrieHashesCollector,
-	_ common.TrieStorageInteractor,
-	targetDb common.BaseStorer,
+	trieCtx common.TrieContext,
 ) {
 	if !ln.dirty {
 		return
 	}
 
-	saveDirtyNodeToStorage(ln, goRoutinesManager, hashesCollector, targetDb, ln.hasher)
+	saveDirtyNodeToStorage(ln, goRoutinesManager, hashesCollector, trieCtx)
 }
 
 func (ln *leafNode) commitSnapshot(
-	_ common.TrieStorageInteractor,
+	trieCtx common.TrieContext,
 	leavesChan chan core.KeyValueHolder,
 	_ chan []byte,
 	ctx context.Context,
@@ -75,7 +61,7 @@ func (ln *leafNode) commitSnapshot(
 		return core.ErrContextClosing
 	}
 
-	err := writeNodeOnChannel(ln, leavesChan)
+	err := writeNodeOnChannel(ln, leavesChan, trieCtx)
 	if err != nil {
 		return err
 	}
@@ -89,12 +75,12 @@ func (ln *leafNode) commitSnapshot(
 	return nil
 }
 
-func writeNodeOnChannel(ln *leafNode, leavesChan chan core.KeyValueHolder) error {
+func writeNodeOnChannel(ln *leafNode, leavesChan chan core.KeyValueHolder, trieCtx common.TrieContext) error {
 	if leavesChan == nil {
 		return nil
 	}
 
-	hash, err := encodeNodeAndGetHash(ln)
+	hash, err := encodeNodeAndGetHash(ln, trieCtx)
 	if err != nil {
 		return err
 	}
@@ -105,12 +91,12 @@ func writeNodeOnChannel(ln *leafNode, leavesChan chan core.KeyValueHolder) error
 	return nil
 }
 
-func (ln *leafNode) getEncodedNode() ([]byte, error) {
+func (ln *leafNode) getEncodedNode(trieCtx common.TrieContext) ([]byte, error) {
 	err := ln.isEmptyOrNil()
 	if err != nil {
 		return nil, fmt.Errorf("getEncodedNode error %w", err)
 	}
-	marshaledNode, err := ln.marsh.Marshal(ln)
+	marshaledNode, err := trieCtx.Marshal(ln)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +104,7 @@ func (ln *leafNode) getEncodedNode() ([]byte, error) {
 	return marshaledNode, nil
 }
 
-func (ln *leafNode) tryGet(key []byte, currentDepth uint32, _ common.TrieStorageInteractor) (value []byte, maxDepth uint32, err error) {
+func (ln *leafNode) tryGet(key []byte, currentDepth uint32, _ common.TrieContext) (value []byte, maxDepth uint32, err error) {
 	ln.mutex.RLock()
 	defer ln.mutex.RUnlock()
 
@@ -129,7 +115,7 @@ func (ln *leafNode) tryGet(key []byte, currentDepth uint32, _ common.TrieStorage
 	return nil, currentDepth, nil
 }
 
-func (ln *leafNode) getNext(key []byte, _ common.TrieStorageInteractor) (*nodeData, error) {
+func (ln *leafNode) getNext(key []byte, _ common.TrieContext) (*nodeData, error) {
 	if bytes.Equal(key, ln.Key) {
 		return nil, nil
 	}
@@ -140,14 +126,14 @@ func (ln *leafNode) insert(
 	newData []core.TrieData,
 	goRoutinesManager common.TrieGoroutinesManager,
 	modifiedHashes common.AtomicBytesSlice,
-	db common.TrieStorageInteractor,
+	trieCtx common.TrieContext,
 ) node {
 	if len(newData) == 1 && bytes.Equal(newData[0].Key, ln.Key) {
 		return ln.insertInSameLn(newData[0])
 	}
 
 	keyMatchLen, _ := getMinKeyMatchLen(newData, ln.Key)
-	bn := ln.insertInNewBn(newData, keyMatchLen, goRoutinesManager, modifiedHashes, db)
+	bn := ln.insertInNewBn(newData, keyMatchLen, goRoutinesManager, modifiedHashes, trieCtx)
 	if !goRoutinesManager.ShouldContinueProcessing() {
 		return nil
 	}
@@ -156,12 +142,12 @@ func (ln *leafNode) insert(
 		return bn
 	}
 
-	newEn, err := newExtensionNode(ln.Key[:keyMatchLen], bn, ln.marsh, ln.hasher)
+	newEn, err := newExtensionNode(ln.Key[:keyMatchLen], bn)
 	if err != nil {
 		goRoutinesManager.SetError(err)
 		return nil
 	}
-	childHash, err := encodeNodeAndGetHash(bn)
+	childHash, err := encodeNodeAndGetHash(bn, trieCtx)
 	if err != nil {
 		goRoutinesManager.SetError(err)
 		return nil
@@ -196,13 +182,9 @@ func (ln *leafNode) insertInNewBn(
 	keyMatchLen int,
 	goRoutinesManager common.TrieGoroutinesManager,
 	modifiedHashes common.AtomicBytesSlice,
-	db common.TrieStorageInteractor,
+	trieCtx common.TrieContext,
 ) node {
-	bn, err := newBranchNode(ln.marsh, ln.hasher)
-	if err != nil {
-		goRoutinesManager.SetError(err)
-		return nil
-	}
+	bn := newBranchNode()
 
 	lnVersion, err := ln.getVersion()
 	if err != nil {
@@ -223,12 +205,8 @@ func (ln *leafNode) insertInNewBn(
 		Version: lnVersion,
 	}
 
-	oldLn, err := newLeafNode(lnData, ln.marsh, ln.hasher)
-	if err != nil {
-		goRoutinesManager.SetError(err)
-		return nil
-	}
-	oldLnHash, err := encodeNodeAndGetHash(oldLn)
+	oldLn := newLeafNode(lnData)
+	oldLnHash, err := encodeNodeAndGetHash(oldLn, trieCtx)
 	if err != nil {
 		goRoutinesManager.SetError(err)
 		return nil
@@ -238,14 +216,14 @@ func (ln *leafNode) insertInNewBn(
 	bn.setVersionForChild(lnVersion, posForOldLn)
 
 	trimKeys(newData, keyMatchLen)
-	return bn.insert(newData, goRoutinesManager, modifiedHashes, db)
+	return bn.insert(newData, goRoutinesManager, modifiedHashes, trieCtx)
 }
 
 func (ln *leafNode) delete(
 	data []core.TrieData,
 	_ common.TrieGoroutinesManager,
 	_ common.AtomicBytesSlice,
-	_ common.TrieStorageInteractor,
+	_ common.TrieContext,
 ) (bool, node) {
 	ln.mutex.RLock()
 	defer ln.mutex.RUnlock()
@@ -258,7 +236,7 @@ func (ln *leafNode) delete(
 	return false, ln
 }
 
-func (ln *leafNode) reduceNode(pos int, _ []byte, _ common.TrieStorageInteractor) (node, bool, error) {
+func (ln *leafNode) reduceNode(pos int, _ []byte, _ common.TrieContext) (node, bool, error) {
 	k := append([]byte{byte(pos)}, ln.Key...)
 
 	oldLnVersion, err := ln.getVersion()
@@ -272,12 +250,7 @@ func (ln *leafNode) reduceNode(pos int, _ []byte, _ common.TrieStorageInteractor
 		Version: oldLnVersion,
 	}
 
-	newLn, err := newLeafNode(oldLnData, ln.marsh, ln.hasher)
-	if err != nil {
-		return nil, false, err
-	}
-
-	return newLn, true, nil
+	return newLeafNode(oldLnData), true, nil
 }
 
 func (ln *leafNode) isEmptyOrNil() error {
@@ -290,7 +263,7 @@ func (ln *leafNode) isEmptyOrNil() error {
 	return nil
 }
 
-func (ln *leafNode) print(writer io.Writer, _ int, _ common.TrieStorageInteractor) {
+func (ln *leafNode) print(writer io.Writer, _ int, _ common.TrieContext) {
 	if ln == nil {
 		return
 	}
@@ -308,7 +281,7 @@ func (ln *leafNode) print(writer io.Writer, _ int, _ common.TrieStorageInteracto
 	_, _ = fmt.Fprintf(writer, "L: key= %v, %v\n", ln.Key, ln.dirty)
 }
 
-func (ln *leafNode) getChildren(_ common.TrieStorageInteractor) ([]nodeWithHash, error) {
+func (ln *leafNode) getChildren(_ common.TrieContext) ([]nodeWithHash, error) {
 	return nil, nil
 }
 
@@ -320,10 +293,9 @@ func (ln *leafNode) getAllLeavesOnChannel(
 	leavesChannel chan core.KeyValueHolder,
 	keyBuilder common.KeyBuilder,
 	trieLeafParser common.TrieLeafParser,
-	_ common.TrieStorageInteractor,
-	_ marshal.Marshalizer,
 	chanClose chan struct{},
 	ctx context.Context,
+	_ common.TrieContext,
 ) error {
 	err := ln.isEmptyOrNil()
 	if err != nil {
@@ -377,8 +349,8 @@ func (ln *leafNode) sizeInBytes() int {
 		return 0
 	}
 
-	// hasher + marshalizer  + dirty flag = numNodeInnerPointers * pointerSizeInBytes + 1
-	nodeSize := len(ln.Key) + len(ln.Value) + numNodeInnerPointers*pointerSizeInBytes + 1
+	nodeVersionSizeInBytes := 4
+	nodeSize := len(ln.Key) + len(ln.Value) + nodeVersionSizeInBytes + dirtyFlagSizeInBytes + mutexSizeInBytes
 
 	return nodeSize
 }
@@ -387,7 +359,7 @@ func (ln *leafNode) getValue() []byte {
 	return ln.Value
 }
 
-func (ln *leafNode) collectStats(ts common.TrieStatisticsHandler, depthLevel int, nodeSize uint64, _ common.TrieStorageInteractor) error {
+func (ln *leafNode) collectStats(ts common.TrieStatisticsHandler, depthLevel int, nodeSize uint64, _ common.TrieContext) error {
 	version, err := ln.getVersion()
 	if err != nil {
 		return err
@@ -408,8 +380,8 @@ func (ln *leafNode) getVersion() (core.TrieNodeVersion, error) {
 
 func (ln *leafNode) collectLeavesForMigration(
 	migrationArgs vmcommon.ArgsMigrateDataTrieLeaves,
-	_ common.TrieStorageInteractor,
 	keyBuilder common.KeyBuilder,
+	_ common.TrieContext,
 ) (bool, error) {
 	shouldContinue := migrationArgs.TrieMigrator.ConsumeStorageLoadGas()
 	if !shouldContinue {

--- a/trie/leafNode_test.go
+++ b/trie/leafNode_test.go
@@ -489,7 +489,7 @@ func TestLeafNode_SizeInBytes(t *testing.T) {
 			dirty: false,
 		},
 	}
-	assert.Equal(t, len(key)+len(value)+1+4, ln.sizeInBytes())
+	assert.Equal(t, len(key)+len(value)+dirtyFlagSizeInBytes+versionSizeInBytes+mutexSizeInBytes, ln.sizeInBytes())
 }
 
 func TestLeafNode_writeNodeOnChannel(t *testing.T) {

--- a/trie/leafNode_test.go
+++ b/trie/leafNode_test.go
@@ -8,41 +8,34 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/throttler"
-	"github.com/multiversx/mx-chain-core-go/hashing"
-	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/errChan"
 	"github.com/multiversx/mx-chain-go/state/hashesCollector"
 	"github.com/multiversx/mx-chain-go/storage/cache"
 	"github.com/multiversx/mx-chain-go/testscommon"
-	"github.com/multiversx/mx-chain-go/testscommon/hashingMocks"
-	"github.com/multiversx/mx-chain-go/testscommon/marshallerMock"
 	"github.com/multiversx/mx-chain-go/trie/keyBuilder"
 	"github.com/multiversx/mx-chain-go/trie/statistics"
 	"github.com/stretchr/testify/assert"
 )
 
-func getLn(marsh marshal.Marshalizer, hasher hashing.Hasher) *leafNode {
-	newLn, _ := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"), marsh, hasher)
+func getLn() *leafNode {
+	newLn := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"))
 	return newLn
 }
 
 func TestLeafNode_newLeafNode(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshalizerAndHasher()
 	expectedLn := &leafNode{
 		CollapsedLn: CollapsedLn{
 			Key:   []byte("dog"),
 			Value: []byte("dog"),
 		},
 		baseNode: &baseNode{
-			dirty:  true,
-			marsh:  marsh,
-			hasher: hasher,
+			dirty: true,
 		},
 	}
-	ln, _ := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"), marsh, hasher)
+	ln := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"))
 	assert.Equal(t, expectedLn, ln)
 }
 
@@ -59,17 +52,17 @@ func TestLeafNode_isDirty(t *testing.T) {
 func TestLeafNode_commit(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	ln := getLn(getTestMarshalizerAndHasher())
-	hash, _ := encodeNodeAndGetHash(ln)
+	trieCtx := getDefaultTrieContext()
+	ln := getLn()
+	hash, _ := encodeNodeAndGetHash(ln, trieCtx)
 
 	manager := getTestGoroutinesManager()
-	ln.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), db, db)
+	ln.commitDirty(0, 5, manager, hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	assert.Nil(t, manager.GetError())
 
-	encNode, _ := db.Get(hash)
-	n, _ := decodeNode(encNode, ln.marsh, ln.hasher)
-	ln = getLn(ln.marsh, ln.hasher)
+	encNode, _ := trieCtx.Get(hash)
+	n, _ := decodeNode(encNode, trieCtx)
+	ln = getLn()
 	ln.dirty = false
 	assert.Equal(t, ln, n)
 }
@@ -77,11 +70,12 @@ func TestLeafNode_commit(t *testing.T) {
 func TestLeafNode_getEncodedNode(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
-	expectedEncodedNode, _ := ln.marsh.Marshal(ln)
+	trieCtx := getTrieContextWithCustomStorage(nil)
+	ln := getLn()
+	expectedEncodedNode, _ := trieCtx.Marshal(ln)
 	expectedEncodedNode = append(expectedEncodedNode, leaf)
 
-	encNode, err := ln.getEncodedNode()
+	encNode, err := ln.getEncodedNode(trieCtx)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedEncodedNode, encNode)
 }
@@ -91,7 +85,7 @@ func TestLeafNode_getEncodedNodeEmpty(t *testing.T) {
 
 	ln := &leafNode{}
 
-	encNode, err := ln.getEncodedNode()
+	encNode, err := ln.getEncodedNode(getTrieContextWithCustomStorage(nil))
 	assert.True(t, errors.Is(err, ErrEmptyLeafNode))
 	assert.Nil(t, encNode)
 }
@@ -101,7 +95,7 @@ func TestLeafNode_getEncodedNodeNil(t *testing.T) {
 
 	var ln *leafNode
 
-	encNode, err := ln.getEncodedNode()
+	encNode, err := ln.getEncodedNode(getTrieContextWithCustomStorage(nil))
 	assert.True(t, errors.Is(err, ErrNilLeafNode))
 	assert.Nil(t, encNode)
 }
@@ -109,10 +103,10 @@ func TestLeafNode_getEncodedNodeNil(t *testing.T) {
 func TestLeafNode_tryGet(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
+	ln := getLn()
 	key := []byte("dog")
 
-	val, maxDepth, err := ln.tryGet(key, 0, nil)
+	val, maxDepth, err := ln.tryGet(key, 0, getTrieContextWithCustomStorage(nil))
 	assert.Equal(t, []byte("dog"), val)
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(0), maxDepth)
@@ -121,10 +115,10 @@ func TestLeafNode_tryGet(t *testing.T) {
 func TestLeafNode_tryGetWrongKey(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
+	ln := getLn()
 	wrongKey := []byte{1, 2, 3}
 
-	val, maxDepth, err := ln.tryGet(wrongKey, 0, nil)
+	val, maxDepth, err := ln.tryGet(wrongKey, 0, getTrieContextWithCustomStorage(nil))
 	assert.Nil(t, val)
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(0), maxDepth)
@@ -133,10 +127,10 @@ func TestLeafNode_tryGetWrongKey(t *testing.T) {
 func TestLeafNode_getNext(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
+	ln := getLn()
 	key := []byte("dog")
 
-	data, err := ln.getNext(key, nil)
+	data, err := ln.getNext(key, getTrieContextWithCustomStorage(nil))
 	assert.Nil(t, data)
 	assert.Nil(t, err)
 }
@@ -144,10 +138,10 @@ func TestLeafNode_getNext(t *testing.T) {
 func TestLeafNode_getNextWrongKey(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
+	ln := getLn()
 	wrongKey := append([]byte{2}, []byte("dog")...)
 
-	data, err := ln.getNext(wrongKey, nil)
+	data, err := ln.getNext(wrongKey, getTrieContextWithCustomStorage(nil))
 	assert.Nil(t, data)
 	assert.Equal(t, ErrNodeNotFound, err)
 }
@@ -155,38 +149,36 @@ func TestLeafNode_getNextWrongKey(t *testing.T) {
 func TestLeafNode_insertAtSameKey(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
+	ln := getLn()
 	key := "dog"
 	expectedVal := "dogs"
 	data := []core.TrieData{getTrieDataWithDefaultVersion(key, expectedVal)}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	newNode := ln.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
+	newNode := ln.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), getTrieContextWithCustomStorage(nil))
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 
-	val, _, _ := newNode.tryGet([]byte(key), 0, nil)
+	val, _, _ := newNode.tryGet([]byte(key), 0, getTrieContextWithCustomStorage(nil))
 	assert.Equal(t, []byte(expectedVal), val)
 }
 
 func TestLeafNode_insertAtDifferentKey(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshalizerAndHasher()
-
 	lnKey := []byte{2, 100, 111, 103}
-	ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string(lnKey), "dog"), marsh, hasher)
+	ln := newLeafNode(getTrieDataWithDefaultVersion(string(lnKey), "dog"))
 
 	nodeKey := []byte{3, 4, 5}
 	nodeVal := []byte{3, 4, 5}
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string(nodeKey), string(nodeVal))}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	newNode := ln.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
+	newNode := ln.insert(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), getTrieContextWithCustomStorage(nil))
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 
-	val, _, _ := newNode.tryGet(nodeKey, 0, nil)
+	val, _, _ := newNode.tryGet(nodeKey, 0, getTrieContextWithCustomStorage(nil))
 	assert.Equal(t, nodeVal, val)
 	assert.IsType(t, &branchNode{}, newNode)
 }
@@ -194,14 +186,14 @@ func TestLeafNode_insertAtDifferentKey(t *testing.T) {
 func TestLeafNode_insertInStoredLnAtSameKey(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	ln := getLn(getTestMarshalizerAndHasher())
-	ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	trieCtx := getDefaultTrieContext()
+	ln := getLn()
+	ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	data := []core.TrieData{getTrieDataWithDefaultVersion("dog", "dogs")}
 
 	goRoutinesManager := getTestGoroutinesManager()
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	newNode := ln.insert(data, goRoutinesManager, modifiedHashes, db)
+	newNode := ln.insert(data, goRoutinesManager, modifiedHashes, trieCtx)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
@@ -210,15 +202,14 @@ func TestLeafNode_insertInStoredLnAtSameKey(t *testing.T) {
 func TestLeafNode_insertInStoredLnAtDifferentKey(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	marsh, hasher := getTestMarshalizerAndHasher()
-	ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3}), "dog"), marsh, hasher)
-	ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	trieCtx := getDefaultTrieContext()
+	ln := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3}), "dog"))
+	ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string([]byte{4, 5, 6}), "dogs")}
 
 	goRoutinesManager := getTestGoroutinesManager()
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	newNode := ln.insert(data, goRoutinesManager, modifiedHashes, db)
+	newNode := ln.insert(data, goRoutinesManager, modifiedHashes, trieCtx)
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
@@ -227,12 +218,12 @@ func TestLeafNode_insertInStoredLnAtDifferentKey(t *testing.T) {
 func TestLeafNode_insertInDirtyLnAtSameKey(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
+	ln := getLn()
 	data := []core.TrieData{getTrieDataWithDefaultVersion("dog", "dogs")}
 
 	goRoutinesManager := getTestGoroutinesManager()
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	newNode := ln.insert(data, goRoutinesManager, modifiedHashes, nil)
+	newNode := ln.insert(data, goRoutinesManager, modifiedHashes, getTrieContextWithCustomStorage(nil))
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
@@ -241,13 +232,12 @@ func TestLeafNode_insertInDirtyLnAtSameKey(t *testing.T) {
 func TestLeafNode_insertInDirtyLnAtDifferentKey(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshalizerAndHasher()
-	ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3}), "dog"), marsh, hasher)
+	ln := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3}), "dog"))
 	data := []core.TrieData{getTrieDataWithDefaultVersion(string([]byte{4, 5, 6}), "dogs")}
 
 	goRoutinesManager := getTestGoroutinesManager()
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	newNode := ln.insert(data, goRoutinesManager, modifiedHashes, nil)
+	newNode := ln.insert(data, goRoutinesManager, modifiedHashes, getTrieContextWithCustomStorage(nil))
 	assert.NotNil(t, newNode)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
@@ -256,11 +246,11 @@ func TestLeafNode_insertInDirtyLnAtDifferentKey(t *testing.T) {
 func TestLeafNode_deletePresent(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
+	ln := getLn()
 	data := []core.TrieData{{Key: []byte("dog")}}
 
 	goRoutinesManager := getTestGoroutinesManager()
-	dirty, newNode := ln.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), nil)
+	dirty, newNode := ln.delete(data, goRoutinesManager, common.NewModifiedHashesSlice(initialModifiedHashesCapacity), getTrieContextWithCustomStorage(nil))
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Nil(t, newNode)
@@ -269,14 +259,14 @@ func TestLeafNode_deletePresent(t *testing.T) {
 func TestLeafNode_deleteFromStoredLnAtSameKey(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	ln := getLn(getTestMarshalizerAndHasher())
-	ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	trieCtx := getDefaultTrieContext()
+	ln := getLn()
+	ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	data := []core.TrieData{{Key: []byte("dog")}}
 
 	goRoutinesManager := getTestGoroutinesManager()
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	dirty, _ := ln.delete(data, goRoutinesManager, modifiedHashes, db)
+	dirty, _ := ln.delete(data, goRoutinesManager, modifiedHashes, trieCtx)
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
@@ -285,15 +275,15 @@ func TestLeafNode_deleteFromStoredLnAtSameKey(t *testing.T) {
 func TestLeafNode_deleteFromLnAtDifferentKey(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	ln := getLn(getTestMarshalizerAndHasher())
-	ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	trieCtx := getDefaultTrieContext()
+	ln := getLn()
+	ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 	wrongKey := []byte{1, 2, 3}
 	data := []core.TrieData{{Key: wrongKey}}
 
 	goRoutinesManager := getTestGoroutinesManager()
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	dirty, _ := ln.delete(data, goRoutinesManager, modifiedHashes, db)
+	dirty, _ := ln.delete(data, goRoutinesManager, modifiedHashes, trieCtx)
 	assert.False(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
@@ -302,12 +292,12 @@ func TestLeafNode_deleteFromLnAtDifferentKey(t *testing.T) {
 func TestLeafNode_deleteFromDirtyLnAtSameKey(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
+	ln := getLn()
 	data := []core.TrieData{{Key: []byte("dog")}}
 
 	goRoutinesManager := getTestGoroutinesManager()
 	modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-	dirty, _ := ln.delete(data, goRoutinesManager, modifiedHashes, nil)
+	dirty, _ := ln.delete(data, goRoutinesManager, modifiedHashes, getTrieContextWithCustomStorage(nil))
 	assert.True(t, dirty)
 	assert.Nil(t, goRoutinesManager.GetError())
 	assert.Equal(t, [][]byte{}, modifiedHashes.Get())
@@ -316,7 +306,7 @@ func TestLeafNode_deleteFromDirtyLnAtSameKey(t *testing.T) {
 func TestLeafNode_deleteNotPresent(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
+	ln := getLn()
 	wrongKey := []byte{1, 2, 3}
 	data := []core.TrieData{{Key: wrongKey}}
 
@@ -330,9 +320,8 @@ func TestLeafNode_deleteNotPresent(t *testing.T) {
 func TestLeafNode_reduceNode(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshalizerAndHasher()
-	ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{100, 111, 103}), ""), marsh, hasher)
-	expected, _ := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{2, 100, 111, 103}), ""), marsh, hasher)
+	ln := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{100, 111, 103}), ""))
+	expected := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{2, 100, 111, 103}), ""))
 	expected.dirty = true
 
 	n, newChildHash, err := ln.reduceNode(2, nil, nil)
@@ -354,7 +343,7 @@ func TestLeafNode_isEmptyOrNil(t *testing.T) {
 func TestLeafNode_getChildren(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
+	ln := getLn()
 
 	children, err := ln.getChildren(nil)
 	assert.Nil(t, err)
@@ -448,55 +437,22 @@ func TestLeafNode_deleteDifferentKeyShouldNotModifyTrie(t *testing.T) {
 	assert.Equal(t, [][]byte{}, tr.GetOldHashes())
 }
 
-func TestLeafNode_newLeafNodeNilMarshalizerShouldErr(t *testing.T) {
-	t.Parallel()
-
-	ln, err := newLeafNode(getTrieDataWithDefaultVersion("key", "val"), nil, &hashingMocks.HasherMock{})
-	assert.Nil(t, ln)
-	assert.Equal(t, ErrNilMarshalizer, err)
-}
-
-func TestLeafNode_newLeafNodeNilHasherShouldErr(t *testing.T) {
-	t.Parallel()
-
-	ln, err := newLeafNode(getTrieDataWithDefaultVersion("key", "val"), &marshallerMock.MarshalizerMock{}, nil)
-	assert.Nil(t, ln)
-	assert.Equal(t, ErrNilHasher, err)
-}
-
 func TestLeafNode_newLeafNodeOkVals(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshalizerAndHasher()
 	key := []byte("key")
 	val := []byte("val")
-	ln, err := newLeafNode(getTrieDataWithDefaultVersion("key", "val"), marsh, hasher)
+	ln := newLeafNode(getTrieDataWithDefaultVersion("key", "val"))
 
-	assert.Nil(t, err)
 	assert.Equal(t, key, ln.Key)
 	assert.Equal(t, val, ln.Value)
-	assert.Equal(t, hasher, ln.hasher)
-	assert.Equal(t, marsh, ln.marsh)
 	assert.True(t, ln.dirty)
-}
-
-func TestLeafNode_getMarshalizer(t *testing.T) {
-	t.Parallel()
-
-	marsh, _ := getTestMarshalizerAndHasher()
-	ln := &leafNode{
-		baseNode: &baseNode{
-			marsh: marsh,
-		},
-	}
-
-	assert.Equal(t, marsh, ln.getMarshalizer())
 }
 
 func TestLeafNode_getNextHashAndKey(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
+	ln := getLn()
 	proofVerified, nextHash, nextKey := ln.getNextHashAndKey([]byte("dog"))
 
 	assert.True(t, proofVerified)
@@ -525,26 +481,26 @@ func TestLeafNode_SizeInBytes(t *testing.T) {
 	key := []byte("key")
 	ln = &leafNode{
 		CollapsedLn: CollapsedLn{
-			Key:   key,
-			Value: value,
+			Key:     key,
+			Value:   value,
+			Version: 1,
 		},
 		baseNode: &baseNode{
-			dirty:  false,
-			marsh:  nil,
-			hasher: nil,
+			dirty: false,
 		},
 	}
-	assert.Equal(t, len(key)+len(value)+1+2*pointerSizeInBytes, ln.sizeInBytes())
+	assert.Equal(t, len(key)+len(value)+1+4, ln.sizeInBytes())
 }
 
 func TestLeafNode_writeNodeOnChannel(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
-	lnHash, _ := encodeNodeAndGetHash(ln)
+	trieCtx := getDefaultTrieContext()
+	ln := getLn()
+	lnHash, _ := encodeNodeAndGetHash(ln, trieCtx)
 	leavesChannel := make(chan core.KeyValueHolder, 2)
 
-	err := writeNodeOnChannel(ln, leavesChannel)
+	err := writeNodeOnChannel(ln, leavesChannel, trieCtx)
 	assert.Nil(t, err)
 
 	retrievedLn := <-leavesChannel
@@ -555,19 +511,19 @@ func TestLeafNode_writeNodeOnChannel(t *testing.T) {
 func TestLeafNode_commitSnapshotContextDone(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	ln := getLn(marshalizer, hasherMock)
+	trieCtx := getDefaultTrieContext()
+	ln := getLn()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := ln.commitSnapshot(db, nil, nil, ctx, statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, []byte("nodeBytes"), 0)
+	err := ln.commitSnapshot(trieCtx, nil, nil, ctx, statistics.NewTrieStatistics(), &testscommon.ProcessStatusHandlerStub{}, []byte("nodeBytes"), 0)
 	assert.Equal(t, core.ErrContextClosing, err)
 }
 
 func TestLeafNode_getValue(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
+	ln := getLn()
 	assert.Equal(t, ln.Value, ln.getValue())
 }
 
@@ -577,7 +533,7 @@ func TestLeafNode_getVersion(t *testing.T) {
 	t.Run("invalid node version", func(t *testing.T) {
 		t.Parallel()
 
-		ln := getLn(getTestMarshalizerAndHasher())
+		ln := getLn()
 		ln.Version = math.MaxUint8 + 1
 
 		version, err := ln.getVersion()
@@ -588,7 +544,7 @@ func TestLeafNode_getVersion(t *testing.T) {
 	t.Run("NotSpecified version", func(t *testing.T) {
 		t.Parallel()
 
-		ln := getLn(getTestMarshalizerAndHasher())
+		ln := getLn()
 
 		version, err := ln.getVersion()
 		assert.Equal(t, core.NotSpecified, version)
@@ -598,7 +554,7 @@ func TestLeafNode_getVersion(t *testing.T) {
 	t.Run("AutoBalanceEnabled version", func(t *testing.T) {
 		t.Parallel()
 
-		ln := getLn(getTestMarshalizerAndHasher())
+		ln := getLn()
 		ln.Version = uint32(core.AutoBalanceEnabled)
 
 		version, err := ln.getVersion()
@@ -621,7 +577,7 @@ func TestLeafNode_getNodeData(t *testing.T) {
 	t.Run("gets data from child", func(t *testing.T) {
 		t.Parallel()
 
-		ln := getLn(getTestMarshalizerAndHasher())
+		ln := getLn()
 		val := []byte("dog")
 
 		kb := keyBuilder.NewKeyBuilder()
@@ -642,11 +598,10 @@ func TestLeafNode_insertBatch(t *testing.T) {
 	t.Run("insert in same leaf node different val", func(t *testing.T) {
 		t.Parallel()
 
-		marshaller, hasher := getTestMarshalizerAndHasher()
-		ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dog"), marshaller, hasher)
-
+		ln := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dog"))
+		trieCtx := getDefaultTrieContext()
 		newData := []core.TrieData{getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dogs")}
-		ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.False(t, ln.dirty)
 
 		th, _ := throttler.NewNumGoRoutinesThrottler(5)
@@ -654,7 +609,7 @@ func TestLeafNode_insertBatch(t *testing.T) {
 		assert.Nil(t, err)
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		newNode := ln.insert(newData, goRoutinesManager, modifiedHashes, nil)
+		newNode := ln.insert(newData, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.True(t, newNode.isDirty())
 		assert.Equal(t, [][]byte{}, modifiedHashes.Get())
@@ -663,11 +618,10 @@ func TestLeafNode_insertBatch(t *testing.T) {
 	t.Run("insert in same leaf node same val", func(t *testing.T) {
 		t.Parallel()
 
-		marshaller, hasher := getTestMarshalizerAndHasher()
-		ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dog"), marshaller, hasher)
-
+		ln := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dog"))
+		trieCtx := getDefaultTrieContext()
 		newData := []core.TrieData{getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dog")}
-		ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.False(t, ln.dirty)
 
 		th, _ := throttler.NewNumGoRoutinesThrottler(5)
@@ -675,7 +629,7 @@ func TestLeafNode_insertBatch(t *testing.T) {
 		assert.Nil(t, err)
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		newNode := ln.insert(newData, goRoutinesManager, modifiedHashes, nil)
+		newNode := ln.insert(newData, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Nil(t, newNode)
 		assert.Equal(t, 0, len(modifiedHashes.Get()))
@@ -683,15 +637,14 @@ func TestLeafNode_insertBatch(t *testing.T) {
 	t.Run("branch at the beginning after insert", func(t *testing.T) {
 		t.Parallel()
 
-		marshaller, hasher := getTestMarshalizerAndHasher()
-		ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dog"), marshaller, hasher)
-
+		ln := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dog"))
+		trieCtx := getDefaultTrieContext()
 		newData := []core.TrieData{
 			getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dogs"),
 			getTrieDataWithDefaultVersion(string([]byte{2, 3, 4, 5, 16}), "dog"),
 			getTrieDataWithDefaultVersion(string([]byte{3, 4, 5, 6, 16}), "dog"),
 		}
-		ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.False(t, ln.dirty)
 
 		th, _ := throttler.NewNumGoRoutinesThrottler(5)
@@ -699,7 +652,7 @@ func TestLeafNode_insertBatch(t *testing.T) {
 		assert.Nil(t, err)
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		newNode := ln.insert(newData, goRoutinesManager, modifiedHashes, nil)
+		newNode := ln.insert(newData, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Equal(t, [][]byte{}, modifiedHashes.Get())
 		bn, ok := newNode.(*branchNode)
@@ -708,21 +661,20 @@ func TestLeafNode_insertBatch(t *testing.T) {
 		assert.NotNil(t, []byte("dog"), bn.children[2].(*leafNode).Value)
 		assert.NotNil(t, []byte("dog"), bn.children[3].(*leafNode).Value)
 		assert.True(t, bn.dirty)
-		bnHash, _ := encodeNodeAndGetHash(bn)
+		bnHash, _ := encodeNodeAndGetHash(bn, trieCtx)
 		assert.NotEqual(t, 0, len(bnHash))
 	})
 	t.Run("extension node at the beginning after insert ", func(t *testing.T) {
 		t.Parallel()
 
-		marshaller, hasher := getTestMarshalizerAndHasher()
-		ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dog"), marshaller, hasher)
-
+		ln := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dog"))
+		trieCtx := getDefaultTrieContext()
 		newData := []core.TrieData{
 			getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dogs"),
 			getTrieDataWithDefaultVersion(string([]byte{1, 2, 4, 5, 16}), "dog"),
 			getTrieDataWithDefaultVersion(string([]byte{1, 2, 5, 6, 16}), "dog"),
 		}
-		ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 		assert.False(t, ln.dirty)
 
 		th, _ := throttler.NewNumGoRoutinesThrottler(5)
@@ -730,14 +682,14 @@ func TestLeafNode_insertBatch(t *testing.T) {
 		assert.Nil(t, err)
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		newNode := ln.insert(newData, goRoutinesManager, modifiedHashes, nil)
+		newNode := ln.insert(newData, goRoutinesManager, modifiedHashes, getTrieContextWithCustomStorage(nil))
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Equal(t, [][]byte{}, modifiedHashes.Get())
 		en, ok := newNode.(*extensionNode)
 		assert.True(t, ok)
 		assert.Equal(t, []byte{1, 2}, en.Key)
 		assert.True(t, en.dirty)
-		enHash, _ := encodeNodeAndGetHash(en)
+		enHash, _ := encodeNodeAndGetHash(en, trieCtx)
 		assert.NotEqual(t, 0, len(enHash))
 	})
 }
@@ -748,21 +700,21 @@ func TestLeafNode_deleteBatch(t *testing.T) {
 	t.Run("delete existing", func(t *testing.T) {
 		t.Parallel()
 
-		marshaller, hasher := getTestMarshalizerAndHasher()
-		ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dog"), marshaller, hasher)
+		ln := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dog"))
+		trieCtx := getDefaultTrieContext()
 		newData := []core.TrieData{
 			getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), ""),
 			getTrieDataWithDefaultVersion(string([]byte{2, 2, 3, 4, 16}), ""),
 			getTrieDataWithDefaultVersion(string([]byte{3, 2, 3, 4, 16}), ""),
 		}
-		ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
 		th, _ := throttler.NewNumGoRoutinesThrottler(5)
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}), "")
 		assert.Nil(t, err)
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		dirty, newNode := ln.delete(newData, goRoutinesManager, modifiedHashes, nil)
+		dirty, newNode := ln.delete(newData, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.True(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Nil(t, newNode)
@@ -771,20 +723,20 @@ func TestLeafNode_deleteBatch(t *testing.T) {
 	t.Run("delete not existing", func(t *testing.T) {
 		t.Parallel()
 
-		marshaller, hasher := getTestMarshalizerAndHasher()
-		ln, _ := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dog"), marshaller, hasher)
+		ln := newLeafNode(getTrieDataWithDefaultVersion(string([]byte{1, 2, 3, 4, 16}), "dog"))
+		trieCtx := getDefaultTrieContext()
 		newData := []core.TrieData{
 			getTrieDataWithDefaultVersion(string([]byte{2, 2, 3, 4, 16}), ""),
 			getTrieDataWithDefaultVersion(string([]byte{3, 2, 3, 4, 16}), ""),
 		}
-		ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), testscommon.NewMemDbMock(), testscommon.NewMemDbMock())
+		ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
 		th, _ := throttler.NewNumGoRoutinesThrottler(5)
 		goRoutinesManager, err := NewGoroutinesManager(th, errChan.NewErrChanWrapper(), make(chan struct{}), "")
 		assert.Nil(t, err)
 
 		modifiedHashes := common.NewModifiedHashesSlice(initialModifiedHashesCapacity)
-		dirty, newNode := ln.delete(newData, goRoutinesManager, modifiedHashes, nil)
+		dirty, newNode := ln.delete(newData, goRoutinesManager, modifiedHashes, trieCtx)
 		assert.False(t, dirty)
 		assert.Nil(t, goRoutinesManager.GetError())
 		assert.Equal(t, ln, newNode)

--- a/trie/node.go
+++ b/trie/node.go
@@ -19,6 +19,7 @@ const (
 	pointerSizeInBytes   = 8
 	mutexSizeInBytes     = 24
 	dirtyFlagSizeInBytes = 1
+	versionSizeInBytes   = 4
 	pollingIdleNode      = time.Millisecond
 )
 

--- a/trie/node_extension.go
+++ b/trie/node_extension.go
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/hashing"
 )
 
 const faultyChance = 1000000
 
-func shouldTestNode(n node, key []byte) bool {
-	hasher := n.getHasher()
+func shouldTestNode(hasher hashing.Hasher, key []byte) bool {
 	randomness := string(key) + core.GetAnonymizedMachineID("") + fmt.Sprintf("%d", time.Now().UnixNano())
 	buff := hasher.Compute(randomness)
 	checkVal := binary.BigEndian.Uint32(buff)

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -429,6 +429,10 @@ func TestPatriciaMerkleTrie_oldRootAndOldHashesAreResetAfterEveryCommit(t *testi
 	assert.Equal(t, 0, len(tr.RootManager.(*rootManager).oldRootHash))
 }
 
+func TestNode_NodeExtension(t *testing.T) {
+	assert.False(t, shouldTestNode(hasherMock, make([]byte, 0)))
+}
+
 func TestSnapshotGetTestPoint(t *testing.T) {
 	t.Parallel()
 

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/atomic"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/common/errChan"
-	dataMock "github.com/multiversx/mx-chain-go/dataRetriever/mock"
 	"github.com/multiversx/mx-chain-go/state/hashesCollector"
 	"github.com/multiversx/mx-chain-go/state/parsers"
 	"github.com/multiversx/mx-chain-go/testscommon"
@@ -25,17 +24,18 @@ import (
 func TestNode_encodeNodeAndGetHashBranchNode(t *testing.T) {
 	t.Parallel()
 
-	bn, _ := newBranchNode(getTestMarshalizerAndHasher())
+	trieCtx := getTrieContextWithCustomStorage(nil)
+	bn := newBranchNode()
 	encChildren := make([][]byte, nrOfChildren)
 	encChildren[1] = []byte("dog")
 	encChildren[10] = []byte("doge")
 	bn.ChildrenHashes = encChildren
 
-	encNode, _ := bn.marsh.Marshal(bn)
+	encNode, _ := trieCtx.Marshal(bn)
 	encNode = append(encNode, branch)
-	expextedHash := bn.hasher.Compute(string(encNode))
+	expextedHash := trieCtx.Compute(string(encNode))
 
-	hash, err := encodeNodeAndGetHash(bn)
+	hash, err := encodeNodeAndGetHash(bn, trieCtx)
 	assert.Nil(t, err)
 	assert.Equal(t, expextedHash, hash)
 }
@@ -43,24 +43,20 @@ func TestNode_encodeNodeAndGetHashBranchNode(t *testing.T) {
 func TestNode_encodeNodeAndGetHashExtensionNode(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshalizerAndHasher()
+	trieCtx := getTrieContextWithCustomStorage(nil)
 	en := &extensionNode{
 		CollapsedEn: CollapsedEn{
 			Key:       []byte{2},
 			ChildHash: []byte("doge"),
 		},
-		baseNode: &baseNode{
-
-			marsh:  marsh,
-			hasher: hasher,
-		},
+		baseNode: &baseNode{},
 	}
 
-	encNode, _ := marsh.Marshal(en)
+	encNode, _ := trieCtx.Marshal(en)
 	encNode = append(encNode, extension)
-	expextedHash := hasher.Compute(string(encNode))
+	expextedHash := trieCtx.Compute(string(encNode))
 
-	hash, err := encodeNodeAndGetHash(en)
+	hash, err := encodeNodeAndGetHash(en, trieCtx)
 	assert.Nil(t, err)
 	assert.Equal(t, expextedHash, hash)
 }
@@ -69,13 +65,13 @@ func TestNode_encodeNodeAndGetHashLeafNode(t *testing.T) {
 	t.Parallel()
 
 	marsh, hasher := getTestMarshalizerAndHasher()
-	ln, _ := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"), marsh, hasher)
+	ln := newLeafNode(getTrieDataWithDefaultVersion("dog", "dog"))
 
 	encNode, _ := marsh.Marshal(ln)
 	encNode = append(encNode, leaf)
 	expextedHash := hasher.Compute(string(encNode))
 
-	hash, err := encodeNodeAndGetHash(ln)
+	hash, err := encodeNodeAndGetHash(ln, getTrieContextWithCustomStorage(nil))
 	assert.Nil(t, err)
 	assert.Equal(t, expextedHash, hash)
 }
@@ -83,107 +79,107 @@ func TestNode_encodeNodeAndGetHashLeafNode(t *testing.T) {
 func TestNode_encodeNodeAndCommitToDBBranchNode(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	_, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	encNode, _ := collapsedBn.marsh.Marshal(collapsedBn)
+	trieCtx := getDefaultTrieContext()
+	_, collapsedBn := getBnAndCollapsedBn()
+	encNode, _ := trieCtx.Marshal(collapsedBn)
 	encNode = append(encNode, branch)
-	nodeHash := collapsedBn.hasher.Compute(string(encNode))
+	nodeHash := trieCtx.Compute(string(encNode))
 
-	_, err := encodeNodeAndCommitToDB(collapsedBn, db)
+	_, err := encodeNodeAndCommitToDB(collapsedBn, trieCtx)
 	assert.Nil(t, err)
 
-	val, _ := db.Get(nodeHash)
+	val, _ := trieCtx.Get(nodeHash)
 	assert.Equal(t, encNode, val)
 }
 
 func TestNode_encodeNodeAndCommitToDBExtensionNode(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
+	trieCtx := getDefaultTrieContext()
 	_, collapsedEn := getEnAndCollapsedEn()
-	encNode, _ := collapsedEn.marsh.Marshal(collapsedEn)
+	encNode, _ := trieCtx.Marshal(collapsedEn)
 	encNode = append(encNode, extension)
-	nodeHash := collapsedEn.hasher.Compute(string(encNode))
+	nodeHash := trieCtx.Compute(string(encNode))
 
-	_, err := encodeNodeAndCommitToDB(collapsedEn, db)
+	_, err := encodeNodeAndCommitToDB(collapsedEn, trieCtx)
 	assert.Nil(t, err)
 
-	val, _ := db.Get(nodeHash)
+	val, _ := trieCtx.Get(nodeHash)
 	assert.Equal(t, encNode, val)
 }
 
 func TestNode_encodeNodeAndCommitToDBLeafNode(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	ln := getLn(getTestMarshalizerAndHasher())
-	encNode, _ := ln.marsh.Marshal(ln)
+	trieCtx := getDefaultTrieContext()
+	ln := getLn()
+	encNode, _ := trieCtx.Marshal(ln)
 	encNode = append(encNode, leaf)
-	nodeHash := ln.hasher.Compute(string(encNode))
+	nodeHash := trieCtx.Compute(string(encNode))
 
-	_, err := encodeNodeAndCommitToDB(ln, db)
+	_, err := encodeNodeAndCommitToDB(ln, trieCtx)
 	assert.Nil(t, err)
 
-	val, _ := db.Get(nodeHash)
+	val, _ := trieCtx.Get(nodeHash)
 	assert.Equal(t, encNode, val)
 }
 
 func TestNode_getNodeFromDBAndDecodeBranchNode(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	bn, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	trieCtx := getDefaultTrieContext()
+	bn, collapsedBn := getBnAndCollapsedBn()
+	bn.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
-	encNode, _ := bn.marsh.Marshal(collapsedBn)
+	encNode, _ := trieCtx.Marshal(collapsedBn)
 	encNode = append(encNode, branch)
-	nodeHash := bn.hasher.Compute(string(encNode))
+	nodeHash := trieCtx.Compute(string(encNode))
 
-	nodeInstance, nodeBytes, err := getNodeFromDBAndDecode(nodeHash, db, bn.marsh, bn.hasher)
+	nodeInstance, nodeBytes, err := getNodeFromDBAndDecode(nodeHash, trieCtx)
 	assert.Nil(t, err)
 	assert.Equal(t, encNode, nodeBytes)
 
-	h1, _ := encodeNodeAndGetHash(collapsedBn)
-	h2, _ := encodeNodeAndGetHash(nodeInstance)
+	h1, _ := encodeNodeAndGetHash(collapsedBn, trieCtx)
+	h2, _ := encodeNodeAndGetHash(nodeInstance, trieCtx)
 	assert.Equal(t, h1, h2)
 }
 
 func TestNode_getNodeFromDBAndDecodeExtensionNode(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
+	trieCtx := getDefaultTrieContext()
 	en, collapsedEn := getEnAndCollapsedEn()
-	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	en.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
-	encNode, _ := en.marsh.Marshal(collapsedEn)
+	encNode, _ := trieCtx.Marshal(collapsedEn)
 	encNode = append(encNode, extension)
-	nodeHash := en.hasher.Compute(string(encNode))
+	nodeHash := trieCtx.Compute(string(encNode))
 
-	nodeInstance, nodeBytes, err := getNodeFromDBAndDecode(nodeHash, db, en.marsh, en.hasher)
+	nodeInstance, nodeBytes, err := getNodeFromDBAndDecode(nodeHash, trieCtx)
 	assert.Nil(t, err)
 	assert.Equal(t, encNode, nodeBytes)
 
-	h1, _ := encodeNodeAndGetHash(collapsedEn)
-	h2, _ := encodeNodeAndGetHash(nodeInstance)
+	h1, _ := encodeNodeAndGetHash(collapsedEn, trieCtx)
+	h2, _ := encodeNodeAndGetHash(nodeInstance, trieCtx)
 	assert.Equal(t, h1, h2)
 }
 
 func TestNode_getNodeFromDBAndDecodeLeafNode(t *testing.T) {
 	t.Parallel()
 
-	db := testscommon.NewMemDbMock()
-	ln := getLn(getTestMarshalizerAndHasher())
-	ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), db, db)
+	trieCtx := getDefaultTrieContext()
+	ln := getLn()
+	ln.commitDirty(0, 5, getTestGoroutinesManager(), hashesCollector.NewDisabledHashesCollector(), trieCtx)
 
-	encNode, _ := ln.marsh.Marshal(ln)
+	encNode, _ := trieCtx.Marshal(ln)
 	encNode = append(encNode, leaf)
-	nodeHash := ln.hasher.Compute(string(encNode))
+	nodeHash := trieCtx.Compute(string(encNode))
 
-	nodeInstance, nodeBytes, err := getNodeFromDBAndDecode(nodeHash, db, ln.marsh, ln.hasher)
+	nodeInstance, nodeBytes, err := getNodeFromDBAndDecode(nodeHash, trieCtx)
 	assert.Nil(t, err)
 	assert.Equal(t, encNode, nodeBytes)
 
-	ln = getLn(ln.marsh, ln.hasher)
+	ln = getLn()
 	ln.dirty = false
 	assert.Equal(t, ln, nodeInstance)
 }
@@ -200,59 +196,63 @@ func TestNode_concat(t *testing.T) {
 func TestNode_decodeNodeBranchNode(t *testing.T) {
 	t.Parallel()
 
-	_, collapsedBn := getBnAndCollapsedBn(getTestMarshalizerAndHasher())
-	encNode, _ := collapsedBn.marsh.Marshal(collapsedBn)
+	trieCtx := getTrieContextWithCustomStorage(nil)
+	_, collapsedBn := getBnAndCollapsedBn()
+	encNode, _ := trieCtx.Marshal(collapsedBn)
 	encNode = append(encNode, branch)
 
-	nodeInstance, err := decodeNode(encNode, collapsedBn.marsh, collapsedBn.hasher)
+	nodeInstance, err := decodeNode(encNode, trieCtx)
 	assert.Nil(t, err)
 
-	h1, _ := encodeNodeAndGetHash(collapsedBn)
-	h2, _ := encodeNodeAndGetHash(nodeInstance)
+	h1, _ := encodeNodeAndGetHash(collapsedBn, trieCtx)
+	h2, _ := encodeNodeAndGetHash(nodeInstance, trieCtx)
 	assert.Equal(t, h1, h2)
 }
 
 func TestNode_decodeNodeExtensionNode(t *testing.T) {
 	t.Parallel()
 
+	trieCtx := getTrieContextWithCustomStorage(nil)
 	_, collapsedEn := getEnAndCollapsedEn()
-	encNode, _ := collapsedEn.marsh.Marshal(collapsedEn)
+	encNode, _ := trieCtx.Marshal(collapsedEn)
 	encNode = append(encNode, extension)
 
-	nodeInstance, err := decodeNode(encNode, collapsedEn.marsh, collapsedEn.hasher)
+	nodeInstance, err := decodeNode(encNode, trieCtx)
 	assert.Nil(t, err)
 
-	h1, _ := encodeNodeAndGetHash(collapsedEn)
-	h2, _ := encodeNodeAndGetHash(nodeInstance)
+	h1, _ := encodeNodeAndGetHash(collapsedEn, trieCtx)
+	h2, _ := encodeNodeAndGetHash(nodeInstance, trieCtx)
 	assert.Equal(t, h1, h2)
 }
 
 func TestNode_decodeNodeLeafNode(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
-	encNode, _ := ln.marsh.Marshal(ln)
+	trieCtx := getTrieContextWithCustomStorage(nil)
+	ln := getLn()
+	encNode, _ := trieCtx.Marshal(ln)
 	encNode = append(encNode, leaf)
 
-	nodeInstance, err := decodeNode(encNode, ln.marsh, ln.hasher)
+	nodeInstance, err := decodeNode(encNode, trieCtx)
 	assert.Nil(t, err)
 	ln.dirty = false
 
-	h1, _ := encodeNodeAndGetHash(ln)
-	h2, _ := encodeNodeAndGetHash(nodeInstance)
+	h1, _ := encodeNodeAndGetHash(ln, trieCtx)
+	h2, _ := encodeNodeAndGetHash(nodeInstance, trieCtx)
 	assert.Equal(t, h1, h2)
 }
 
 func TestNode_decodeNodeInvalidNode(t *testing.T) {
 	t.Parallel()
 
-	ln := getLn(getTestMarshalizerAndHasher())
+	trieCtx := getTrieContextWithCustomStorage(nil)
+	ln := getLn()
 	invalidNode := byte(6)
 
-	encNode, _ := ln.marsh.Marshal(ln)
+	encNode, _ := trieCtx.Marshal(ln)
 	encNode = append(encNode, invalidNode)
 
-	nodeInstance, err := decodeNode(encNode, ln.marsh, ln.hasher)
+	nodeInstance, err := decodeNode(encNode, trieCtx)
 	assert.Nil(t, nodeInstance)
 	assert.Equal(t, ErrInvalidNode, err)
 }
@@ -260,10 +260,10 @@ func TestNode_decodeNodeInvalidNode(t *testing.T) {
 func TestNode_decodeNodeInvalidEncoding(t *testing.T) {
 	t.Parallel()
 
-	marsh, hasher := getTestMarshalizerAndHasher()
+	trieCtx := getTrieContextWithCustomStorage(nil)
 	var encNode []byte
 
-	nodeInstance, err := decodeNode(encNode, marsh, hasher)
+	nodeInstance, err := decodeNode(encNode, trieCtx)
 	assert.Nil(t, nodeInstance)
 	assert.Equal(t, ErrInvalidEncoding, err)
 }
@@ -427,30 +427,6 @@ func TestPatriciaMerkleTrie_oldRootAndOldHashesAreResetAfterEveryCommit(t *testi
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(tr.GetOldHashes()))
 	assert.Equal(t, 0, len(tr.RootManager.(*rootManager).oldRootHash))
-}
-
-func TestNode_NodeExtension(t *testing.T) {
-	n := &branchNode{
-		baseNode: &baseNode{
-			hasher: &dataMock.HasherStub{
-				ComputeCalled: func(s string) []byte {
-					return []byte{0, 0, 0, 0}
-				},
-			},
-		},
-	}
-	assert.True(t, shouldTestNode(n, make([]byte, 0)))
-
-	n = &branchNode{
-		baseNode: &baseNode{
-			hasher: &dataMock.HasherStub{
-				ComputeCalled: func(s string) []byte {
-					return []byte{0, 0, 0, 1}
-				},
-			},
-		},
-	}
-	assert.False(t, shouldTestNode(n, make([]byte, 0)))
 }
 
 func TestSnapshotGetTestPoint(t *testing.T) {

--- a/trie/proofVerifier.go
+++ b/trie/proofVerifier.go
@@ -21,8 +21,10 @@ func NewMerkleProofVerifier(marshalizer marshal.Marshalizer, hasher hashing.Hash
 
 	return &merkleProofVerifier{
 		trie: &patriciaMerkleTrie{
-			marshalizer: marshalizer,
-			hasher:      hasher,
+			TrieContext: &trieContext{
+				Marshalizer: marshalizer,
+				Hasher:      hasher,
+			},
 		},
 	}, nil
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- Each trie node hold a pointer to the marshaller and one to the hasher. These will use extra memory.
  
## Proposed changes
- Remove the pointers to the marshaller and hasher for all trie nodes. Instead, pass these as arguments.
- Group the `marshaller`, `hasher` and `trieStorage` in another component. These are usually used together, so it will make the code more readable by passing a single component instead of three.

## Testing procedure
- Normal testing procedure

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
