### PR TITLE
Fix backup number of inactive rounds computation for multikey nodes

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -972,7 +972,7 @@
 [Redundancy]
     # MaxRoundsOfInactivityAccepted defines the number of rounds missed by a main or higher level backup machine before
     # the current machine will take over and propose/sign blocks. Used in both single-key and multi-key modes.
-    MaxRoundsOfInactivityAccepted = 3
+    MaxRoundsOfInactivityAccepted = 10
 
 [InterceptedDataVerifier]
     CacheSpanInSec = 30

--- a/consensus/spos/bls/v2/subroundStartRound.go
+++ b/consensus/spos/bls/v2/subroundStartRound.go
@@ -224,18 +224,22 @@ func (sr *subroundStartRound) computeNumManagedKeysInConsensusGroup(pubKeys []st
 	numMultiKeysInConsensusGroup := 0
 	for _, pk := range pubKeys {
 		pkBytes := []byte(pk)
+
+		if sr.IsMultiKeyLeaderInCurrentRound() {
+			sr.IncrementRoundsWithoutReceivedMessages(pkBytes)
+		}
+
 		if sr.IsKeyManagedBySelf(pkBytes) {
 			numMultiKeysInConsensusGroup++
 			log.Trace("in consensus group with multi key",
 				"pk", core.GetTrimmedPk(hex.EncodeToString(pkBytes)))
 		}
-		sr.IncrementRoundsWithoutReceivedMessages(pkBytes)
 	}
 
 	return numMultiKeysInConsensusGroup
 }
 
-func (sr *subroundStartRound) indexRoundIfNeeded(pubKeys []string) {
+func (sr *subroundStartRound) indexRoundIfNeeded(_ []string) {
 	sr.outportMutex.RLock()
 	defer sr.outportMutex.RUnlock()
 


### PR DESCRIPTION
## Reasoning behind the pull request
- With the full consensus, there might be an edge case where backups will step in without being the need when managing multiple bls keys
  
## Proposed changes
- updated both config and increment of number of rounds without received message

## Testing procedure
- standard system test + backups + chaos setup

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
