### PR TITLE
Fix code coverage upload

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -38,4 +38,8 @@ jobs:
           make test-coverage
 
       - name: Upload coverage
-        run: bash <(curl -s https://codecov.io/bash) -f coverage.txt -y codecov.yml
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: true
+          files: coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fix upload of code coverage metrics to https://app.codecov.io/gh/multiversx/mx-chain-go.