### PR TITLE
Fix codecov config (exclude files)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,6 @@
 ignore:
-  - "**/*.pb.go"       # wildcards accepted
+    - "**/*.pb.go"
+    - "integrationTests/**"
+    - "testscommon/**"
+    - "**/mock/**"
+    - "**/disabled*.go"


### PR DESCRIPTION
## Reasoning behind the pull request
- For some reason, for `rc/barnard`, some test files aren't excluded from the code coverage report:
  - https://app.codecov.io/gh/multiversx/mx-chain-go/tree/rc%2Fbarnard
- Though, they are excluded from the report on `master`:
  - https://app.codecov.io/gh/multiversx/mx-chain-go/tree/master
- Report of this PR:
  - https://app.codecov.io/gh/multiversx/mx-chain-go/tree/fix-codecov-06-16
  
## Proposed changes
- Explicitly exclude some Go modules from the code coverage report, by adjusting `codecov.yml`.

## Testing procedure
- No testing necessary.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
