### PR TITLE
Header queue

### DIFF
--- a/process/queue/errors.go
+++ b/process/queue/errors.go
@@ -1,0 +1,6 @@
+package queue
+
+import "errors"
+
+// ErrNoHeaderForProcessing indicates that there are no headers available in the queue for processing.
+var ErrNoHeaderForProcessing = errors.New("no header for processing")

--- a/process/queue/headersQueue.go
+++ b/process/queue/headersQueue.go
@@ -1,0 +1,73 @@
+package queue
+
+import (
+	"sync"
+
+	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-go/common"
+)
+
+// headersQueue represents a thread-safe queue for storing and processing blockchain headers
+// It provides methods to add headers at the end or beginning of the queue and retrieve them
+// for processing in a FIFO (First In, First Out) manner
+type headersQueue struct {
+	mutex   sync.RWMutex
+	headers []data.HeaderHandler
+}
+
+// NewHeadersQueue creates and returns a new instance of headersQueue
+
+func NewHeadersQueue() (*headersQueue, error) {
+	return &headersQueue{
+		headers: make([]data.HeaderHandler, 0),
+	}, nil
+}
+
+// Add appends a single header to the end of the queue
+func (hq *headersQueue) Add(header data.HeaderHandler) error {
+	if check.IfNil(header) {
+		return common.ErrNilHeaderHandler
+	}
+
+	hq.mutex.Lock()
+	defer hq.mutex.Unlock()
+
+	hq.headers = append(hq.headers, header)
+
+	return nil
+}
+
+// AddFirstMultiple adds multiple headers at the beginning of the queue
+func (hq *headersQueue) AddFirstMultiple(headers []data.HeaderHandler) error {
+	if len(headers) == 0 {
+		return nil
+	}
+
+	hq.mutex.Lock()
+	defer hq.mutex.Unlock()
+
+	hq.headers = append(headers, hq.headers...)
+
+	return nil
+}
+
+// TakeFirstHeaderForProcessing removes and returns the first header from the queue
+func (hq *headersQueue) TakeFirstHeaderForProcessing() (data.HeaderHandler, error) {
+	hq.mutex.Lock()
+	defer hq.mutex.Unlock()
+
+	if len(hq.headers) == 0 {
+		return nil, ErrNoHeaderForProcessing
+	}
+
+	headerForProcessing := hq.headers[0]
+	hq.headers = hq.headers[1:]
+
+	return headerForProcessing, nil
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (hq *headersQueue) IsInterfaceNil() bool {
+	return hq == nil
+}

--- a/process/queue/headersQueue_test.go
+++ b/process/queue/headersQueue_test.go
@@ -1,0 +1,98 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-go/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHeadersQueue(t *testing.T) {
+	t.Parallel()
+
+	hq, err := NewHeadersQueue()
+	require.Nil(t, err)
+	require.NotNil(t, hq)
+	require.NotNil(t, hq.headers)
+	require.Equal(t, 0, len(hq.headers))
+}
+
+func TestHeadersQueue_Add(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil header should return error", func(t *testing.T) {
+		t.Parallel()
+		hq, _ := NewHeadersQueue()
+		err := hq.Add(nil)
+		assert.Equal(t, common.ErrNilHeaderHandler, err)
+	})
+
+	t.Run("valid header should be added", func(t *testing.T) {
+		t.Parallel()
+		hq, _ := NewHeadersQueue()
+		header := &block.Header{Nonce: 1}
+		err := hq.Add(header)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(hq.headers))
+	})
+}
+
+func TestHeadersQueue_AddFirstMultiple(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty slice should not modify queue", func(t *testing.T) {
+		t.Parallel()
+		hq, _ := NewHeadersQueue()
+		err := hq.AddFirstMultiple(nil)
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(hq.headers))
+	})
+
+	t.Run("multiple headers should be added at beginning", func(t *testing.T) {
+		t.Parallel()
+		hq, _ := NewHeadersQueue()
+		existingHeader := &block.Header{Nonce: 1}
+		_ = hq.Add(existingHeader)
+
+		newHeaders := []data.HeaderHandler{
+			&block.Header{Nonce: 2},
+			&block.Header{Nonce: 3},
+		}
+		err := hq.AddFirstMultiple(newHeaders)
+		assert.Nil(t, err)
+		assert.Equal(t, 3, len(hq.headers))
+		assert.Equal(t, uint64(2), hq.headers[0].GetNonce())
+		assert.Equal(t, uint64(3), hq.headers[1].GetNonce())
+		assert.Equal(t, uint64(1), hq.headers[2].GetNonce())
+	})
+}
+
+func TestHeadersQueue_TakeFirstHeaderForProcessing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty queue should return error", func(t *testing.T) {
+		t.Parallel()
+		hq, _ := NewHeadersQueue()
+		header, err := hq.TakeFirstHeaderForProcessing()
+		assert.Nil(t, header)
+		assert.Equal(t, ErrNoHeaderForProcessing, err)
+	})
+
+	t.Run("should return first header and remove it from queue", func(t *testing.T) {
+		t.Parallel()
+		hq, _ := NewHeadersQueue()
+		header1 := &block.Header{Nonce: 1}
+		header2 := &block.Header{Nonce: 2}
+		_ = hq.Add(header1)
+		_ = hq.Add(header2)
+
+		firstHeader, err := hq.TakeFirstHeaderForProcessing()
+		assert.Nil(t, err)
+		assert.Equal(t, uint64(1), firstHeader.GetNonce())
+		assert.Equal(t, 1, len(hq.headers))
+		assert.Equal(t, uint64(2), hq.headers[0].GetNonce())
+	})
+}


### PR DESCRIPTION
## Reasoning behind the pull request
- This PR introduces a thread-safe queue implementation for managing blockchain headers. The `headersQueue` structure provides a FIFO (First In, First Out) mechanism for storing and processing headers with proper synchronization.


## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
