### PR TITLE
optimize compile breadcrumb flow

### DIFF
--- a/txcache/trackedBlock.go
+++ b/txcache/trackedBlock.go
@@ -65,17 +65,19 @@ func (tb *trackedBlock) compileBreadcrumb(tx *WrappedTransaction) {
 	})
 
 	// compile for fee payer
-	if feePayer != nil && bytes.Equal(sender, feePayer) {
+	if feePayer == nil {
+		return
+	}
+
+	if bytes.Equal(sender, feePayer) {
 		fee := tx.Fee
 		senderBreadcrumb.accumulateConsumedBalance(fee)
 		return
 	}
 
-	if feePayer != nil {
-		feePayerBreadcrumb := tb.getOrCreateBreadcrumb(string(feePayer))
-		fee := tx.Fee
-		feePayerBreadcrumb.accumulateConsumedBalance(fee)
-	}
+	feePayerBreadcrumb := tb.getOrCreateBreadcrumb(string(feePayer))
+	fee := tx.Fee
+	feePayerBreadcrumb.accumulateConsumedBalance(fee)
 }
 
 func (tb *trackedBlock) getOrCreateBreadcrumb(address string) *accountBreadcrumb {

--- a/txcache/trackedBlock.go
+++ b/txcache/trackedBlock.go
@@ -1,6 +1,7 @@
 package txcache
 
 import (
+	"bytes"
 	"math/big"
 
 	"github.com/multiversx/mx-chain-core-go/core"
@@ -45,7 +46,6 @@ func (tb *trackedBlock) compileBreadcrumbs(txs []*WrappedTransaction) {
 }
 
 // TODO add validation when compiling breadcrumb
-// TODO optimize the flow in the case when sender is also fee payer
 func (tb *trackedBlock) compileBreadcrumb(tx *WrappedTransaction) {
 	sender := tx.Tx.GetSndAddr()
 	feePayer := tx.FeePayer
@@ -65,6 +65,12 @@ func (tb *trackedBlock) compileBreadcrumb(tx *WrappedTransaction) {
 	})
 
 	// compile for fee payer
+	if feePayer != nil && bytes.Equal(sender, feePayer) {
+		fee := tx.Fee
+		senderBreadcrumb.accumulateConsumedBalance(fee)
+		return
+	}
+
 	if feePayer != nil {
 		feePayerBreadcrumb := tb.getOrCreateBreadcrumb(string(feePayer))
 		fee := tx.Fee

--- a/txcache/trackedBlock_test.go
+++ b/txcache/trackedBlock_test.go
@@ -282,4 +282,48 @@ func TestTrackedBlock_compileBreadcrumb(t *testing.T) {
 			requireEqualBreadcrumbs(t, expectedBreadcrumbs[key], block.breadcrumbsByAddress[key])
 		}
 	})
+
+	t.Run("sender and fee payer are equal", func(t *testing.T) {
+		t.Parallel()
+
+		block := newTrackedBlock(0, []byte("blockHash1"), []byte("blockRootHash1"), []byte("blockPrevHash1"), nil)
+		block.breadcrumbsByAddress = map[string]*accountBreadcrumb{
+			"alice": newAccountBreadcrumb(core.OptionalUint64{
+				Value:    1,
+				HasValue: true,
+			}, core.OptionalUint64{
+				Value:    1,
+				HasValue: true,
+			}, big.NewInt(5)),
+		}
+		txs := []*WrappedTransaction{
+			{
+				Tx: &transaction.Transaction{
+					SndAddr: []byte("alice"),
+					Nonce:   3,
+				},
+				TransferredValue: big.NewInt(5),
+				FeePayer:         []byte("alice"),
+				Fee:              big.NewInt(2),
+			},
+		}
+
+		block.compileBreadcrumbs(txs)
+		expectedBreadcrumbs := map[string]*accountBreadcrumb{
+			"alice": newAccountBreadcrumb(core.OptionalUint64{
+				Value:    1,
+				HasValue: true,
+			}, core.OptionalUint64{
+				Value:    3,
+				HasValue: true,
+			}, big.NewInt(12)), // initial value in breadcrumb + transferredValue + fee
+		}
+
+		for key := range expectedBreadcrumbs {
+			_, ok := block.breadcrumbsByAddress[key]
+			require.True(t, ok)
+			requireEqualBreadcrumbs(t, expectedBreadcrumbs[key], block.breadcrumbsByAddress[key])
+		}
+
+	})
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- solved a **TODO** related to [this comment](https://github.com/multiversx/mx-chain-go/pull/7080#discussion_r2174380195)
  
## Proposed changes
- avoid double search in map by **checking if the sender is also the fee payer** and accumulate in its breadcrumb
- added a unit test for this case


## Testing procedure
## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
