### PR TITLE
Change struct and func description to match struct/function names

### DIFF
--- a/api/groups/validatorGroup_test.go
+++ b/api/groups/validatorGroup_test.go
@@ -34,7 +34,7 @@ func TestNewValidatorGroup(t *testing.T) {
 	})
 }
 
-// ValidatorStatisticsResponse is the response for the validator statistics endpoint.
+// validatorStatisticsResponse is the response for the validator statistics endpoint.
 type validatorStatisticsResponse struct {
 	Result map[string]*validator.ValidatorStatistics `json:"statistics"`
 	Error  string                                    `json:"error"`

--- a/api/middleware/sourceThrottler.go
+++ b/api/middleware/sourceThrottler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/multiversx/mx-chain-go/api/shared"
 )
 
-// globalThrottler is a middleware limiter used to limit total number of requests originating from the same source
+// sourceThrottler is a middleware limiter used to limit total number of requests originating from the same source
 type sourceThrottler struct {
 	mutRequests    sync.Mutex
 	sourceRequests map[string]uint32

--- a/cmd/termui/view/termuic/processCloser.go
+++ b/cmd/termui/view/termuic/processCloser.go
@@ -6,7 +6,7 @@ import (
 	"syscall"
 )
 
-// StopApplication is used to stop application when Ctrl+C is pressed
+// stopApplication is used to stop application when Ctrl+C is pressed
 func stopApplication() {
 	if p, err := os.FindProcess(os.Getpid()); err != nil {
 		return

--- a/common/statistics/stateStatistics.go
+++ b/common/statistics/stateStatistics.go
@@ -84,7 +84,7 @@ func (ss *stateStatistics) Persister(epoch uint32) uint64 {
 	return ss.numPersister[epoch]
 }
 
-// IncrWitePersister will increment persister write counter
+// IncrWritePersister will increment persister write counter
 func (ss *stateStatistics) IncrWritePersister(epoch uint32) {
 	ss.mutPersisters.Lock()
 	defer ss.mutPersisters.Unlock()

--- a/dataRetriever/provider/miniBlocks.go
+++ b/dataRetriever/provider/miniBlocks.go
@@ -142,7 +142,7 @@ func (mbp *miniBlockProvider) GetMiniBlocksFromStorer(hashes [][]byte) ([]*block
 	return miniBlocksAndHashes, missingMiniBlocksHashes
 }
 
-// getMiniBlocksFromStorer returns a list of mini blocks from storage and a list of missing hashes
+// getMiniBlockFromStorer returns a list of mini blocks from storage and a list of missing hashes
 func (mbp *miniBlockProvider) getMiniBlockFromStorer(hash []byte) *block.MiniBlock {
 	buff, err := mbp.miniBlockStorage.Get(hash)
 	if err != nil {

--- a/node/chainSimulator/components/testOnlyProcessingNode.go
+++ b/node/chainSimulator/components/testOnlyProcessingNode.go
@@ -429,7 +429,7 @@ func (node *testOnlyProcessingNode) GetStatusCoreComponents() factory.StatusCore
 	return node.StatusCoreComponents
 }
 
-// NetworkComponents will return the network components
+// GetNetworkComponents will return the network components
 func (node *testOnlyProcessingNode) GetNetworkComponents() factory.NetworkComponentsHolder {
 	return node.NetworkComponentsHolder
 }

--- a/process/block/preprocess/transactions.go
+++ b/process/block/preprocess/transactions.go
@@ -873,7 +873,7 @@ func (txs *transactions) computeExistingAndRequestMissingTxsForShards(body *bloc
 	return numMissingTxsForShard
 }
 
-// processAndRemoveBadTransactions processed transactions, if txs are with error it removes them from pool
+// processAndRemoveBadTransaction processed transactions, if txs are with error it removes them from pool
 func (txs *transactions) processAndRemoveBadTransaction(
 	txHash []byte,
 	tx *transaction.Transaction,

--- a/process/block/shardblock.go
+++ b/process/block/shardblock.go
@@ -575,7 +575,7 @@ func (sp *shardProcessor) SetNumProcessedObj(numObj uint64) {
 	sp.txCounter.totalTxs = numObj
 }
 
-// checkMetaHeadersValidity - checks if listed metaheaders are valid as construction
+// checkMetaHeadersValidityAndFinality - checks if listed metaheaders are valid as construction
 func (sp *shardProcessor) checkMetaHeadersValidityAndFinality() error {
 	lastCrossNotarizedHeader, _, err := sp.blockTracker.GetLastCrossNotarizedHeader(core.MetachainShardId)
 	if err != nil {

--- a/process/coordinator/process.go
+++ b/process/coordinator/process.go
@@ -1182,7 +1182,7 @@ func (tc *transactionCoordinator) receivedMiniBlock(key []byte, value interface{
 	}
 }
 
-// processMiniBlockComplete - all transactions must be processed together, otherwise error
+// processCompleteMiniBlock - all transactions must be processed together, otherwise error
 func (tc *transactionCoordinator) processCompleteMiniBlock(
 	preproc process.PreProcessor,
 	miniBlock *block.MiniBlock,

--- a/process/economics/gasConfigHandler.go
+++ b/process/economics/gasConfigHandler.go
@@ -114,8 +114,7 @@ func (handler *gasConfigHandler) getMaxGasLimitPerMiniBlock(epoch uint32) uint64
 	return gc.maxGasLimitPerMiniBlock
 }
 
-//TODO change description for this function
-// getMaxGasLimitPerMiniBlock returns max gas limit per mini block in a specific epoch
+// getGasHigherFactorAccepted returns the maximum gas higher factor accepted for the given epoch
 func (handler *gasConfigHandler) getGasHigherFactorAccepted(epoch uint32) uint64 {
 	gc := handler.getGasConfigForEpoch(epoch)
 	return gc.maxGasHigherFactorAccepted

--- a/process/economics/gasConfigHandler.go
+++ b/process/economics/gasConfigHandler.go
@@ -114,6 +114,7 @@ func (handler *gasConfigHandler) getMaxGasLimitPerMiniBlock(epoch uint32) uint64
 	return gc.maxGasLimitPerMiniBlock
 }
 
+//TODO change description for this function
 // getMaxGasLimitPerMiniBlock returns max gas limit per mini block in a specific epoch
 func (handler *gasConfigHandler) getGasHigherFactorAccepted(epoch uint32) uint64 {
 	gc := handler.getGasConfigForEpoch(epoch)

--- a/process/mock/coreComponentsMock.go
+++ b/process/mock/coreComponentsMock.go
@@ -162,7 +162,7 @@ func (ccm *CoreComponentsMock) RoundNotifier() process.RoundNotifier {
 	return ccm.RoundNotifierField
 }
 
-// EnableEpochsHandler -
+// EnableRoundsHandler -
 func (ccm *CoreComponentsMock) EnableRoundsHandler() process.EnableRoundsHandler {
 	return ccm.EnableRoundsHandlerField
 }

--- a/process/smartContract/processorV2/vmOutputAccountsProcessor.go
+++ b/process/smartContract/processorV2/vmOutputAccountsProcessor.go
@@ -158,7 +158,7 @@ func (oap *VMOutputAccountsProcessor) processStorageUpdatesStep(
 	return nil
 }
 
-// updateSmartContractCode upgrades code for "direct" deployments & upgrades and for "indirect" deployments & upgrades
+// updateSmartContractCodeStep upgrades code for "direct" deployments & upgrades and for "indirect" deployments & upgrades
 // It receives:
 //
 //	(1) the account as found in the State

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -400,7 +400,7 @@ func (boot *baseBootstrap) waitForHeaderAndProofByNonce() error {
 	}
 }
 
-// waitForHeaderHash method wait for header with the requested hash to be received
+// waitForHeaderAndProofByHash method wait for header with the requested hash to be received
 func (boot *baseBootstrap) waitForHeaderAndProofByHash() error {
 	select {
 	case <-boot.chRcvHdrHash:

--- a/process/sync/storageBootstrap/metricsLoader/loadPersistentMetrics.go
+++ b/process/sync/storageBootstrap/metricsLoader/loadPersistentMetrics.go
@@ -47,7 +47,7 @@ func getTotalTxsAndHdrs(metrics map[string]uint64) (uint64, uint64) {
 	return numTxs, numHdrs
 }
 
-// LoadMetricsFromDb will load from storage metrics
+// loadMetricsFromDb will load from storage metrics
 func loadMetricsFromDb(store dataRetriever.StorageService, uint64ByteSliceConverter typeConverters.Uint64ByteSliceConverter, marshalizer marshal.Marshalizer, nonce uint64,
 ) (map[string]uint64, map[string]string) {
 	nonceBytes := uint64ByteSliceConverter.ToByteSlice(nonce)

--- a/process/transaction/metaProcess.go
+++ b/process/transaction/metaProcess.go
@@ -17,7 +17,7 @@ import (
 
 var _ process.TransactionProcessor = (*metaTxProcessor)(nil)
 
-// txProcessor implements TransactionProcessor interface and can modify account states according to a transaction
+// metaTxProcessor implements TransactionProcessor interface and can modify account states according to a transaction
 type metaTxProcessor struct {
 	*baseTxProcessor
 	enableEpochsHandler common.EnableEpochsHandler

--- a/sharding/nodesCoordinator/hashValidatorShuffler.go
+++ b/sharding/nodesCoordinator/hashValidatorShuffler.go
@@ -734,7 +734,7 @@ func computeNeededNodes(destination []Validator, source []Validator, maxNumNodes
 	return numNeededNodes
 }
 
-// distributeNewNodes distributes a list of validators to the given validators map
+// distributeValidators distributes a list of validators to the given validators map
 func distributeValidators(destLists map[uint32][]Validator, validators []Validator, randomness []byte, balanced bool) error {
 	if len(destLists) == 0 {
 		return ErrNilOrEmptyDestinationForDistribute

--- a/state/accountsDB.go
+++ b/state/accountsDB.go
@@ -442,7 +442,7 @@ func (adb *AccountsDB) loadDataTrieConcurrentSafe(accountHandler baseAccountHand
 	return nil
 }
 
-// SaveDataTrie is used to save the data trie (not committing it) and to recompute the new Root value
+// saveDataTrie is used to save the data trie (not committing it) and to recompute the new Root value
 // If data is not dirtied, method will not create its JournalEntries to keep track of data modification
 func (adb *AccountsDB) saveDataTrie(accountHandler baseAccountHandler) error {
 	oldValues, err := accountHandler.SaveDirtyData(adb.mainTrie)
@@ -1033,7 +1033,7 @@ func (adb *AccountsDB) GetTrie(rootHash []byte) (common.Trie, error) {
 	return adb.getMainTrie().Recreate(rootHashHolder)
 }
 
-// Journalize adds a new object to entries list.
+// journalize adds a new object to entries list.
 func (adb *AccountsDB) journalize(entry JournalEntry) {
 	if check.IfNil(entry) {
 		return

--- a/state/journalEntries.go
+++ b/state/journalEntries.go
@@ -107,7 +107,7 @@ func (jea *journalEntryCode) IsInterfaceNil() bool {
 	return jea == nil
 }
 
-// JournalEntryAccount represents a journal entry for account fields change
+// journalEntryAccount represents a journal entry for account fields change
 type journalEntryAccount struct {
 	account vmcommon.AccountHandler
 }
@@ -133,7 +133,7 @@ func (jea *journalEntryAccount) IsInterfaceNil() bool {
 	return jea == nil
 }
 
-// JournalEntryAccountCreation represents a journal entry for account creation
+// journalEntryAccountCreation represents a journal entry for account creation
 type journalEntryAccountCreation struct {
 	address []byte
 	updater Updater

--- a/storage/pruning/export_test.go
+++ b/storage/pruning/export_test.go
@@ -16,7 +16,7 @@ func NewEmptyPruningStorer() *PruningStorer {
 	}
 }
 
-// AddMockActivePersister -
+// AddMockActivePersisters -
 func (ps *PruningStorer) AddMockActivePersisters(epochs []uint32, ordered bool, withMap bool) {
 	for _, e := range epochs {
 		pd := &persisterData{

--- a/testscommon/blockChainHookStub.go
+++ b/testscommon/blockChainHookStub.go
@@ -245,7 +245,7 @@ func (stub *BlockChainHookStub) EpochStartBlockRound() uint64 {
 	return 0
 }
 
-// EpochStartBlockTimeStamp -
+// EpochStartBlockTimeStampMs -
 func (stub *BlockChainHookStub) EpochStartBlockTimeStampMs() uint64 {
 	if stub.EpochStartBlockTimeStampMsCalled != nil {
 		return stub.EpochStartBlockTimeStampMsCalled()

--- a/trie/export_test.go
+++ b/trie/export_test.go
@@ -82,7 +82,7 @@ func IsBaseTrieStorageManager(tsm common.StorageManager) bool {
 	return ok
 }
 
-// IsInEpochTrieStorageManager -
+// IsTrieStorageManagerInEpoch -
 func IsTrieStorageManagerInEpoch(tsm common.StorageManager) bool {
 	_, ok := tsm.(*trieStorageManagerInEpoch)
 	return ok

--- a/update/sync/syncHeaders.go
+++ b/update/sync/syncHeaders.go
@@ -201,7 +201,7 @@ func (h *headersToSync) SyncUnFinishedMetaHeaders(epoch uint32) error {
 	return nil
 }
 
-// SyncEpochStartMetaHeader syncs and validates an epoch start metaHeader
+// syncEpochStartMetaHeader syncs and validates an epoch start metaHeader
 func (h *headersToSync) syncEpochStartMetaHeader(epoch uint32, waitTime time.Duration) error {
 	defer func() {
 		h.mutMeta.Lock()


### PR DESCRIPTION
## Reasoning behind the pull request
Several community PRs pinpoint mismatches between structure or function descriptions and their actual names:
-  chore: fix some function names in comment #7072 
-  chore: make struct comments match struct names #6239 
-  chore: fix some comments #6329 
  
## Proposed changes
- make struct and func comments match their name

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
