### PR TITLE
disable execution

### DIFF
--- a/cmd/node/config/enableEpochs.toml
+++ b/cmd/node/config/enableEpochs.toml
@@ -349,7 +349,7 @@
     AndromedaEnableEpoch = 1
 
     # SupernovaEnableEpoch represents the epoch when sub-second finality will be enabled
-    SupernovaEnableEpoch = 2
+    SupernovaEnableEpoch = 9999
 
     # CheckBuiltInCallOnTransferValueAndFailEnableRound represents the ROUND when the check on transfer value fix is activated
     CheckBuiltInCallOnTransferValueAndFailEnableRound = 1

--- a/process/block/metablock.go
+++ b/process/block/metablock.go
@@ -1037,6 +1037,8 @@ func (mp *metaProcessor) createMiniBlocks(
 		)
 	}
 
+	// TODO: check if execution should be stopped on Metachain, since there is no scheduled or partial execution
+
 	mbsFromMe := mp.txCoordinator.CreateMbsAndProcessTransactionsFromMe(haveTime, randomness)
 	if len(mbsFromMe) > 0 {
 		miniBlocks = append(miniBlocks, mbsFromMe...)


### PR DESCRIPTION
## Reasoning behind the pull request
- Temporarily disable execution of transactions from ME starting with the Supernova release.
- This is required to safely transition to the new asynchronous execution mechanism.

 1. Pause the standard transaction execution flow for a short number of rounds.
 2. Resume miniblock and transaction execution using the new async mechanism.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
