### PR TITLE
fix missing mutex protection in round state

### DIFF
--- a/consensus/spos/consensusState.go
+++ b/consensus/spos/consensusState.go
@@ -146,11 +146,11 @@ func (cns *ConsensusState) IsNodeLeaderInCurrentRound(node string) bool {
 
 // GetLeader method gets the leader of the current round
 func (cns *ConsensusState) GetLeader() (string, error) {
-	if cns.consensusGroup == nil {
+	if cns.ConsensusGroup() == nil {
 		return "", ErrNilConsensusGroup
 	}
 
-	if len(cns.consensusGroup) == 0 {
+	if len(cns.ConsensusGroup()) == 0 {
 		return "", ErrEmptyConsensusGroup
 	}
 
@@ -361,7 +361,7 @@ func (cns *ConsensusState) IsLeaderJobDone(currentSubroundId int) bool {
 // IsMultiKeyJobDone method returns true if all the nodes controlled by this instance finished the current job for
 // the current subround and false otherwise
 func (cns *ConsensusState) IsMultiKeyJobDone(currentSubroundId int) bool {
-	for _, validator := range cns.consensusGroup {
+	for _, validator := range cns.ConsensusGroup() {
 		if !cns.keysHandler.IsKeyManagedByCurrentNode([]byte(validator)) {
 			continue
 		}

--- a/consensus/spos/roundConsensus.go
+++ b/consensus/spos/roundConsensus.go
@@ -57,7 +57,7 @@ func (rcns *roundConsensus) ConsensusGroupIndex(pubKey string) (int, error) {
 
 // SelfConsensusGroupIndex returns the index of self public key in current consensus group
 func (rcns *roundConsensus) SelfConsensusGroupIndex() (int, error) {
-	return rcns.ConsensusGroupIndex(rcns.selfPubKey)
+	return rcns.ConsensusGroupIndex(rcns.SelfPubKey())
 }
 
 // SetEligibleList sets the eligible list ID's
@@ -181,7 +181,7 @@ func (rcns *roundConsensus) SetJobDone(key string, subroundId int, value bool) e
 
 // SelfJobDone returns the self state of the action done in subround given by the subroundId parameter
 func (rcns *roundConsensus) SelfJobDone(subroundId int) (bool, error) {
-	return rcns.JobDone(rcns.selfPubKey, subroundId)
+	return rcns.JobDone(rcns.SelfPubKey(), subroundId)
 }
 
 // IsNodeInConsensusGroup method checks if the node is part of consensus group of the current round

--- a/consensus/spos/roundConsensus_test.go
+++ b/consensus/spos/roundConsensus_test.go
@@ -2,6 +2,7 @@ package spos_test
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 
 	"github.com/multiversx/mx-chain-go/consensus"
@@ -9,6 +10,7 @@ import (
 	"github.com/multiversx/mx-chain-go/consensus/spos/bls"
 	"github.com/multiversx/mx-chain-go/testscommon"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func initRoundConsensus() *spos.RoundConsensus {
@@ -37,15 +39,39 @@ func initRoundConsensusWithKeysHandler(keysHandler consensus.KeysHandler) *spos.
 	return spos.NewRoundConsensusWrapper(rcns)
 }
 
-func TestRoundConsensus_NewRoundConsensusShouldWork(t *testing.T) {
+func TestRoundConsensus_NewRoundConsensus(t *testing.T) {
 	t.Parallel()
 
-	rcns := *initRoundConsensus()
+	t.Run("nil keys handler, should fail", func(t *testing.T) {
+		t.Parallel()
 
-	assert.NotNil(t, rcns)
-	assert.Equal(t, 3, len(rcns.ConsensusGroup()))
-	assert.Equal(t, "3", rcns.ConsensusGroup()[2])
-	assert.Equal(t, "2", rcns.SelfPubKey())
+		pubKeys := []string{"1", "2", "3"}
+		eligibleNodes := make(map[string]struct{})
+
+		for i := range pubKeys {
+			eligibleNodes[pubKeys[i]] = struct{}{}
+		}
+
+		rcns, err := spos.NewRoundConsensus(
+			eligibleNodes,
+			len(eligibleNodes),
+			"2",
+			nil,
+		)
+		require.Nil(t, rcns)
+		require.Equal(t, spos.ErrNilKeysHandler, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		rcns := *initRoundConsensus()
+
+		assert.NotNil(t, rcns)
+		assert.Equal(t, 3, len(rcns.ConsensusGroup()))
+		assert.Equal(t, "3", rcns.ConsensusGroup()[2])
+		assert.Equal(t, "2", rcns.SelfPubKey())
+	})
 }
 
 func TestRoundConsensus_ConsensusGroupIndexFound(t *testing.T) {
@@ -310,4 +336,60 @@ func TestRoundConsensus_IncrementRoundsWithoutReceivedMessages(t *testing.T) {
 	roundConsensus := initRoundConsensusWithKeysHandler(keysHandler)
 	roundConsensus.IncrementRoundsWithoutReceivedMessages(managedPkBytes)
 	assert.True(t, wasCalled)
+}
+
+func TestRoundsConsensus_Concurrency(t *testing.T) {
+	t.Parallel()
+
+	rcns := *initRoundConsensus()
+
+	numOperations := 1000
+
+	wg := sync.WaitGroup{}
+	wg.Add(numOperations)
+
+	for i := 0; i < numOperations; i++ {
+		go func(idx int) {
+			switch idx % 6 {
+			case 0:
+				_ = rcns.ComputeSize(0)
+			case 1:
+				_ = rcns.ConsensusGroup()
+			case 2:
+				rcns.SetConsensusGroup([]string{})
+			case 3:
+				_ = rcns.ConsensusGroupSize()
+			case 4:
+				rcns.SetConsensusGroupSize(1)
+			case 5:
+				_ = rcns.EligibleList()
+			case 6:
+				_ = rcns.GetKeysHandler()
+			case 7:
+				_ = rcns.IsKeyManagedBySelf([]byte{})
+			case 8:
+				_ = rcns.IsMultiKeyInConsensusGroup()
+			case 9:
+				_ = rcns.IsNodeInConsensusGroup("")
+			case 10:
+				_ = rcns.Leader()
+			case 11:
+				rcns.SetLeader("")
+			case 12:
+				_ = rcns.SelfPubKey()
+			case 13:
+				rcns.SetSelfPubKey("")
+			case 14:
+				_ = rcns.SetJobDone("key", 0, true)
+			case 15:
+				_, _ = rcns.SelfConsensusGroupIndex()
+			default:
+				assert.Fail(t, "should have not been called")
+			}
+
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
 }

--- a/consensus/spos/roundConsensus_test.go
+++ b/consensus/spos/roundConsensus_test.go
@@ -350,7 +350,7 @@ func TestRoundsConsensus_Concurrency(t *testing.T) {
 
 	for i := 0; i < numOperations; i++ {
 		go func(idx int) {
-			switch idx % 6 {
+			switch idx % 16 {
 			case 0:
 				_ = rcns.ComputeSize(0)
 			case 1:


### PR DESCRIPTION
## Reasoning behind the pull request
- Add missing mutex protection on round consensus methods

## Testing procedure
- System tests with restarts

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
