### PR TITLE
Fixes tx cost endpoint

### DIFF
--- a/factory/processing/txSimulatorProcessComponents.go
+++ b/factory/processing/txSimulatorProcessComponents.go
@@ -13,6 +13,7 @@ import (
 	"github.com/multiversx/mx-chain-go/process/coordinator"
 	"github.com/multiversx/mx-chain-go/process/factory/shard"
 	"github.com/multiversx/mx-chain-go/process/smartContract"
+	"github.com/multiversx/mx-chain-go/process/smartContract/processProxy"
 	"github.com/multiversx/mx-chain-go/process/smartContract/scrCommon"
 	"github.com/multiversx/mx-chain-go/process/transaction"
 	"github.com/multiversx/mx-chain-go/process/transactionEvaluator"
@@ -377,7 +378,7 @@ func (pcf *processComponentsFactory) createArgsTxSimulatorProcessorShard(
 		IsGenesisProcessing: false,
 	}
 
-	scProcessor, err := smartContract.NewSmartContractProcessor(scProcArgs)
+	scProcessorProxy, err := processProxy.NewSmartContractProcessorProxy(scProcArgs, pcf.coreData.EpochNotifier())
 	if err != nil {
 		return args, nil, nil, nil, err
 	}
@@ -389,7 +390,7 @@ func (pcf *processComponentsFactory) createArgsTxSimulatorProcessorShard(
 		Marshalizer:         pcf.coreData.InternalMarshalizer(),
 		SignMarshalizer:     pcf.coreData.TxMarshalizer(),
 		ShardCoordinator:    pcf.bootstrapComponents.ShardCoordinator(),
-		ScProcessor:         scProcessor,
+		ScProcessor:         scProcessorProxy,
 		TxFeeHandler:        txFeeHandler,
 		TxTypeHandler:       txTypeHandler,
 		EconomicsFee:        pcf.coreData.EconomicsData(),
@@ -412,5 +413,5 @@ func (pcf *processComponentsFactory) createArgsTxSimulatorProcessorShard(
 	args.TransactionProcessor = txProcessor
 	args.IntermediateProcContainer = intermediateProcessorsContainer
 
-	return args, vmContainerFactory, txTypeHandler, scProcessor, nil
+	return args, vmContainerFactory, txTypeHandler, scProcessorProxy, nil
 }

--- a/integrationTests/chainSimulator/simulate/simulate_test.go
+++ b/integrationTests/chainSimulator/simulate/simulate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/multiversx/mx-chain-go/node/chainSimulator"
 	"github.com/multiversx/mx-chain-go/node/chainSimulator/components/api"
 	"github.com/multiversx/mx-chain-go/node/chainSimulator/configs"
+	"github.com/multiversx/mx-chain-go/node/chainSimulator/dtos"
 	"github.com/stretchr/testify/require"
 )
 
@@ -162,6 +163,77 @@ func TestSimulateIntraShardTxWithGuardian(t *testing.T) {
 	cost, err = cs.GetNodeHandler(0).GetFacadeHandler().ComputeTransactionGasLimit(esdtTransferTx)
 	require.NoError(t, err)
 	require.Equal(t, "failed transaction, gas consumed: insufficient funds", cost.ReturnMessage)
+}
+
+func TestRelayedV3(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	roundDurationInMillis := uint64(6000)
+	roundsPerEpochOpt := core.OptionalUint64{
+		HasValue: true,
+		Value:    20,
+	}
+
+	cs, err := chainSimulator.NewChainSimulator(chainSimulator.ArgsChainSimulator{
+		BypassTxSignatureCheck:   true,
+		TempDir:                  t.TempDir(),
+		PathToInitialConfig:      defaultPathToInitialConfig,
+		NumOfShards:              3,
+		GenesisTimestamp:         time.Now().Unix(),
+		RoundDurationInMillis:    roundDurationInMillis,
+		RoundsPerEpoch:           roundsPerEpochOpt,
+		ApiInterface:             api.NewNoApiInterface(),
+		MinNodesPerShard:         3,
+		MetaChainMinNodes:        3,
+		NumNodesWaitingListMeta:  3,
+		NumNodesWaitingListShard: 3,
+		AlterConfigsFunction: func(cfg *config.Configs) {
+
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cs)
+
+	for idx := 0; idx < 4; idx++ {
+		err = cs.ForceChangeOfEpoch()
+		require.NoError(t, err)
+	}
+
+	initialBalance := big.NewInt(0).Mul(oneEGLD, big.NewInt(10))
+
+	sender, err := cs.GenerateAndMintWalletAddress(0, big.NewInt(0))
+	require.NoError(t, err)
+
+	err = cs.SetStateMultiple([]*dtos.AddressState{
+		{
+			Address: sender.Bech32,
+			Balance: "0",
+			Pairs: map[string]string{
+				"454c524f4e446573647453484f572d633961633237": "12040002d820",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	receiver, err := cs.GenerateAndMintWalletAddress(0, big.NewInt(0))
+	require.NoError(t, err)
+
+	relayer, err := cs.GenerateAndMintWalletAddress(0, initialBalance)
+	require.NoError(t, err)
+
+	err = cs.GenerateBlocks(1)
+	require.NoError(t, err)
+
+	dataTx := "ESDTTransfer@53484f572d633961633237@3e80@5061796d656e7420746f20504f5334@317820564f444b41204d495820323530204d4c20782033322e3030202b20317820574849534b59204d495820323530204d4c20782033322e3030202b203178204a4147455220434f4c4120323530204d4c20782033322e3030202b2031782047494e20544f4e494320323530204d4c20782033322e3030202b2031782043554241204c49425245203235304d4c20782033322e3030"
+	tx := generateTransaction(sender.Bytes, 0, receiver.Bytes, big.NewInt(0), dataTx, 0)
+	tx.RelayerAddr = relayer.Bytes
+
+	cost, err := cs.GetNodeHandler(0).GetFacadeHandler().ComputeTransactionGasLimit(tx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(855001), cost.GasUnits)
+	require.Equal(t, "", cost.ReturnMessage)
 }
 
 func generateTransaction(sender []byte, nonce uint64, receiver []byte, value *big.Int, data string, gasLimit uint64) *transaction.Transaction {


### PR DESCRIPTION
## Reasoning behind the pull request
- This PR addresses an issue with the /transaction/cost endpoint, which failed when handling relayed v3 transactions — specifically when the sender had no EGLD balance. The current behavior incorrectly simulates the transaction execution, causing invalid cost estimations in certain relayed transaction flows.
  
## Proposed changes
- Replaced the existing smart contract processor component with one that accurately simulates relayed transaction execution.

## Testing procedure
	1.	Call /transaction/cost with a v3 relayed transaction where the sender has zero EGLD.
	2.	Confirm that the cost estimation completes successfully and returns a valid gas cost.
	3.	Ensure existing non-relayed flows remain unaffected.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
