### PR TITLE
Update UnmarshallHeader method for v3

### DIFF
--- a/process/common_test.go
+++ b/process/common_test.go
@@ -2320,11 +2320,15 @@ func TestUnmarshalHeader(t *testing.T) {
 
 	shardHeaderV1 := &block.Header{Nonce: 42, EpochStartMetaHash: []byte{0xaa, 0xbb}}
 	shardHeaderV2 := &block.HeaderV2{Header: &block.Header{Nonce: 43, EpochStartMetaHash: []byte{0xaa, 0xbb}}}
+	shardHeaderV3 := &block.HeaderV3{Nonce: 44, LastExecutionResult: &block.ExecutionResultInfo{NotarizedOnHeaderHash: []byte("hash")}}
 	metaHeader := &block.MetaBlock{Nonce: 7, ValidatorStatsRootHash: []byte{0xcc, 0xdd}}
+	metaHeaderV2 := &block.MetaBlockV2{Nonce: 8, LastExecutionResult: &block.MetaExecutionResultInfo{NotarizedAtHeaderHash: []byte("hash")}}
 
 	shardHeaderV1Buffer, _ := marshalizer.Marshal(shardHeaderV1)
 	shardHeaderV2Buffer, _ := marshalizer.Marshal(shardHeaderV2)
+	shardHeaderV3Buffer, _ := marshalizer.Marshal(shardHeaderV3)
 	metaHeaderBuffer, _ := marshalizer.Marshal(metaHeader)
+	metaHeaderV2Buffer, _ := marshalizer.Marshal(metaHeaderV2)
 
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
@@ -2337,9 +2341,17 @@ func TestUnmarshalHeader(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, shardHeaderV2, header)
 
+		header, err = process.UnmarshalHeader(1, marshalizer, shardHeaderV3Buffer)
+		assert.Nil(t, err)
+		assert.Equal(t, shardHeaderV3, header)
+
 		header, err = process.UnmarshalHeader(core.MetachainShardId, marshalizer, metaHeaderBuffer)
 		assert.Nil(t, err)
 		assert.Equal(t, metaHeader, header)
+
+		header, err = process.UnmarshalHeader(core.MetachainShardId, marshalizer, metaHeaderV2Buffer)
+		assert.Nil(t, err)
+		assert.Equal(t, metaHeaderV2, header)
 	})
 
 	t.Run("should err", func(t *testing.T) {

--- a/process/errors.go
+++ b/process/errors.go
@@ -1284,8 +1284,8 @@ var ErrInvalidInterceptedData = errors.New("invalid intercepted data")
 // ErrMissingHeaderProof signals that the proof for the header is missing
 var ErrMissingHeaderProof = errors.New("missing header proof")
 
-// ErrInvalidHeaderProof signals that an invalid equivalent proof has been provided
-var ErrInvalidHeaderProof = errors.New("invalid equivalent proof")
+// ErrInvalidHeader signals that an invalid header has been provided
+var ErrInvalidHeader = errors.New("invalid header")
 
 // ErrUnexpectedHeaderProof signals that a header proof has been provided unexpectedly
 var ErrUnexpectedHeaderProof = errors.New("unexpected header proof")


### PR DESCRIPTION
## Reasoning behind the pull request
- the common method `UnmarshallHeader` from processing should be updated for header v3
  
## Proposed changes
- updated method

## Testing procedure
- with rc

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
