### PR TITLE
Request handler refactor

### DIFF
--- a/dataRetriever/requestHandlers/requestHandler.go
+++ b/dataRetriever/requestHandlers/requestHandler.go
@@ -11,11 +11,12 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/core/partitioning"
+	logger "github.com/multiversx/mx-chain-logger-go"
+
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/epochStart"
 	"github.com/multiversx/mx-chain-go/process/factory"
-	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
 var _ epochStart.RequestHandler = (*resolverRequestHandler)(nil)
@@ -114,10 +115,16 @@ func (rrh *resolverRequestHandler) getEpoch() uint32 {
 
 // RequestTransaction method asks for transactions from the connected peers
 func (rrh *resolverRequestHandler) RequestTransaction(destShardID uint32, txHashes [][]byte) {
-	rrh.requestByHashes(destShardID, txHashes, factory.TransactionTopic, uniqueTxSuffix)
+	epoch := rrh.getEpoch()
+	rrh.requestByHashes(destShardID, txHashes, factory.TransactionTopic, uniqueTxSuffix, epoch)
 }
 
-func (rrh *resolverRequestHandler) requestByHashes(destShardID uint32, hashes [][]byte, topic string, abbreviatedTopic string) {
+// RequestTransactionsForEpoch method asks for transactions from the connected peers for a specific epoch
+func (rrh *resolverRequestHandler) RequestTransactionsForEpoch(destShardID uint32, txHashes [][]byte, epoch uint32) {
+	rrh.requestByHashes(destShardID, txHashes, factory.TransactionTopic, uniqueTxSuffix, epoch)
+}
+
+func (rrh *resolverRequestHandler) requestByHashes(destShardID uint32, hashes [][]byte, topic string, abbreviatedTopic string, epoch uint32) {
 	suffix := fmt.Sprintf("%s_%d", abbreviatedTopic, destShardID)
 	unrequestedHashes := rrh.getUnrequestedHashes(hashes, suffix)
 	if len(unrequestedHashes) == 0 {
@@ -153,7 +160,7 @@ func (rrh *resolverRequestHandler) requestByHashes(destShardID uint32, hashes []
 
 	rrh.whiteList.Add(unrequestedHashes)
 
-	go rrh.requestHashesWithDataSplit(unrequestedHashes, txRequester)
+	go rrh.requestHashesWithDataSplit(unrequestedHashes, txRequester, epoch)
 
 	rrh.addRequestedItems(unrequestedHashes, suffix)
 }
@@ -161,6 +168,7 @@ func (rrh *resolverRequestHandler) requestByHashes(destShardID uint32, hashes []
 func (rrh *resolverRequestHandler) requestHashesWithDataSplit(
 	unrequestedHashes [][]byte,
 	requester HashSliceRequester,
+	epoch uint32,
 ) {
 	dataSplit := &partitioning.DataSplit{}
 	sliceBatches, err := dataSplit.SplitDataInChunks(unrequestedHashes, rrh.maxTxsToRequest)
@@ -172,7 +180,6 @@ func (rrh *resolverRequestHandler) requestHashesWithDataSplit(
 		)
 	}
 
-	epoch := rrh.getEpoch()
 	for _, batch := range sliceBatches {
 		err = requester.RequestDataFromHashArray(batch, epoch)
 		if err != nil {
@@ -202,16 +209,34 @@ func (rrh *resolverRequestHandler) requestReferenceWithChunkIndex(
 
 // RequestUnsignedTransactions method asks for unsigned transactions from the connected peers
 func (rrh *resolverRequestHandler) RequestUnsignedTransactions(destShardID uint32, scrHashes [][]byte) {
-	rrh.requestByHashes(destShardID, scrHashes, factory.UnsignedTransactionTopic, uniqueScrSuffix)
+	epoch := rrh.getEpoch()
+	rrh.requestByHashes(destShardID, scrHashes, factory.UnsignedTransactionTopic, uniqueScrSuffix, epoch)
+}
+
+// RequestUnsignedTransactionsForEpoch method asks for unsigned transactions from the connected peers for a specific epoch
+func (rrh *resolverRequestHandler) RequestUnsignedTransactionsForEpoch(destShardID uint32, scrHashes [][]byte, epoch uint32) {
+	rrh.requestByHashes(destShardID, scrHashes, factory.UnsignedTransactionTopic, uniqueScrSuffix, epoch)
 }
 
 // RequestRewardTransactions requests for reward transactions from the connected peers
 func (rrh *resolverRequestHandler) RequestRewardTransactions(destShardID uint32, rewardTxHashes [][]byte) {
-	rrh.requestByHashes(destShardID, rewardTxHashes, factory.RewardsTransactionTopic, uniqueRwdSuffix)
+	epoch := rrh.getEpoch()
+	rrh.requestByHashes(destShardID, rewardTxHashes, factory.RewardsTransactionTopic, uniqueRwdSuffix, epoch)
 }
 
-// RequestMiniBlock method asks for miniblock from the connected peers
-func (rrh *resolverRequestHandler) RequestMiniBlock(destShardID uint32, miniblockHash []byte) {
+// RequestRewardTransactionsForEpoch requests for reward transactions from the connected peers for a specific epoch
+func (rrh *resolverRequestHandler) RequestRewardTransactionsForEpoch(destShardID uint32, rewardTxHashes [][]byte, epoch uint32) {
+	rrh.requestByHashes(destShardID, rewardTxHashes, factory.RewardsTransactionTopic, uniqueRwdSuffix, epoch)
+}
+
+// RequestMiniBlock method asks for miniBlock from the connected peers
+func (rrh *resolverRequestHandler) RequestMiniBlock(destShardID uint32, miniBlockHash []byte) {
+	epoch := rrh.getEpoch()
+	rrh.RequestMiniBlockForEpoch(destShardID, miniBlockHash, epoch)
+}
+
+// RequestMiniBlockForEpoch method asks for miniblock from the connected peers for a specific epoch
+func (rrh *resolverRequestHandler) RequestMiniBlockForEpoch(destShardID uint32, miniblockHash []byte, epoch uint32) {
 	suffix := fmt.Sprintf("%s_%d", uniqueMiniblockSuffix, destShardID)
 	if !rrh.testIfRequestIsNeeded(miniblockHash, suffix) {
 		return
@@ -225,7 +250,7 @@ func (rrh *resolverRequestHandler) RequestMiniBlock(destShardID uint32, minibloc
 
 	requester, err := rrh.requestersFinder.CrossShardRequester(factory.MiniBlocksTopic, destShardID)
 	if err != nil {
-		log.Error("RequestMiniBlock.CrossShardRequester",
+		log.Error("RequestMiniBlockForEpoch.CrossShardRequester",
 			"error", err.Error(),
 			"topic", factory.MiniBlocksTopic,
 			"shard", destShardID,
@@ -235,10 +260,9 @@ func (rrh *resolverRequestHandler) RequestMiniBlock(destShardID uint32, minibloc
 
 	rrh.whiteList.Add([][]byte{miniblockHash})
 
-	epoch := rrh.getEpoch()
 	err = requester.RequestDataFromHash(miniblockHash, epoch)
 	if err != nil {
-		log.Debug("RequestMiniBlock.RequestDataFromHash",
+		log.Debug("RequestMiniBlockForEpoch.RequestDataFromHash",
 			"error", err.Error(),
 			"epoch", epoch,
 			"hash", miniblockHash,
@@ -249,10 +273,16 @@ func (rrh *resolverRequestHandler) RequestMiniBlock(destShardID uint32, minibloc
 	rrh.addRequestedItems([][]byte{miniblockHash}, suffix)
 }
 
-// RequestMiniBlocks method asks for miniblocks from the connected peers
-func (rrh *resolverRequestHandler) RequestMiniBlocks(destShardID uint32, miniblocksHashes [][]byte) {
+// RequestMiniBlocks method asks for miniBlocks from the connected peers
+func (rrh *resolverRequestHandler) RequestMiniBlocks(destShardID uint32, miniBlocksHashes [][]byte) {
+	epoch := rrh.getEpoch()
+	rrh.RequestMiniBlocksForEpoch(destShardID, miniBlocksHashes, epoch)
+}
+
+// RequestMiniBlocksForEpoch method asks for miniBlocks from the connected peers for a specific epoch
+func (rrh *resolverRequestHandler) RequestMiniBlocksForEpoch(destShardID uint32, miniBlocksHashes [][]byte, epoch uint32) {
 	suffix := fmt.Sprintf("%s_%d", uniqueMiniblockSuffix, destShardID)
-	unrequestedHashes := rrh.getUnrequestedHashes(miniblocksHashes, suffix)
+	unrequestedHashes := rrh.getUnrequestedHashes(miniBlocksHashes, suffix)
 	if len(unrequestedHashes) == 0 {
 		return
 	}
@@ -264,7 +294,7 @@ func (rrh *resolverRequestHandler) RequestMiniBlocks(destShardID uint32, miniblo
 
 	requester, err := rrh.requestersFinder.CrossShardRequester(factory.MiniBlocksTopic, destShardID)
 	if err != nil {
-		log.Error("RequestMiniBlocks.CrossShardRequester",
+		log.Error("RequestMiniBlocksForEpoch.CrossShardRequester",
 			"error", err.Error(),
 			"topic", factory.MiniBlocksTopic,
 			"shard", destShardID,
@@ -280,10 +310,9 @@ func (rrh *resolverRequestHandler) RequestMiniBlocks(destShardID uint32, miniblo
 
 	rrh.whiteList.Add(unrequestedHashes)
 
-	epoch := rrh.getEpoch()
 	err = miniBlocksRequester.RequestDataFromHashArray(unrequestedHashes, epoch)
 	if err != nil {
-		log.Debug("RequestMiniBlocks.RequestDataFromHashArray",
+		log.Debug("RequestMiniBlocksForEpoch.RequestDataFromHashArray",
 			"error", err.Error(),
 			"epoch", epoch,
 			"num mbs", len(unrequestedHashes),
@@ -296,21 +325,25 @@ func (rrh *resolverRequestHandler) RequestMiniBlocks(destShardID uint32, miniblo
 
 // RequestShardHeader method asks for shard header from the connected peers
 func (rrh *resolverRequestHandler) RequestShardHeader(shardID uint32, hash []byte) {
+	epoch := rrh.getEpoch()
+	rrh.RequestShardHeaderForEpoch(shardID, hash, epoch)
+}
+
+// RequestShardHeaderForEpoch method asks for shard header from the connected peers for a specific epoch
+func (rrh *resolverRequestHandler) RequestShardHeaderForEpoch(shardID uint32, hash []byte, epoch uint32) {
 	suffix := fmt.Sprintf("%s_%d", uniqueHeadersSuffix, shardID)
 	if !rrh.testIfRequestIsNeeded(hash, suffix) {
 		return
 	}
 
-	epoch := rrh.getEpoch()
 	log.Debug("requesting shard header from network",
 		"shard", shardID,
 		"hash", hash,
 		"epoch", epoch,
 	)
-
 	headerRequester, err := rrh.getShardHeaderRequester(shardID)
 	if err != nil {
-		log.Error("RequestShardHeader.getShardHeaderRequester",
+		log.Error("RequestShardHeaderForEpoch.getShardHeaderRequester",
 			"error", err.Error(),
 			"shard", shardID,
 		)
@@ -321,7 +354,7 @@ func (rrh *resolverRequestHandler) RequestShardHeader(shardID uint32, hash []byt
 
 	err = headerRequester.RequestDataFromHash(hash, epoch)
 	if err != nil {
-		log.Debug("RequestShardHeader.RequestDataFromHash",
+		log.Debug("RequestShardHeaderForEpoch.RequestDataFromHash",
 			"error", err.Error(),
 			"epoch", epoch,
 			"hash", hash,
@@ -334,17 +367,22 @@ func (rrh *resolverRequestHandler) RequestShardHeader(shardID uint32, hash []byt
 
 // RequestMetaHeader method asks for meta header from the connected peers
 func (rrh *resolverRequestHandler) RequestMetaHeader(hash []byte) {
+	epoch := rrh.getEpoch()
+	rrh.RequestMetaHeaderForEpoch(hash, epoch)
+}
+
+// RequestMetaHeaderForEpoch method asks for meta header from the connected peers for a specific epoch
+func (rrh *resolverRequestHandler) RequestMetaHeaderForEpoch(hash []byte, epoch uint32) {
 	if !rrh.testIfRequestIsNeeded(hash, uniqueMetaHeadersSuffix) {
 		return
 	}
-
 	log.Debug("requesting meta header from network",
 		"hash", hash,
 	)
 
 	requester, err := rrh.getMetaHeaderRequester()
 	if err != nil {
-		log.Error("RequestMetaHeader.getMetaHeaderRequester",
+		log.Error("RequestMetaHeaderForEpoch.getMetaHeaderRequester",
 			"error", err.Error(),
 			"hash", hash,
 		)
@@ -358,11 +396,9 @@ func (rrh *resolverRequestHandler) RequestMetaHeader(hash []byte) {
 	}
 
 	rrh.whiteList.Add([][]byte{hash})
-
-	epoch := rrh.getEpoch()
 	err = headerRequester.RequestDataFromHash(hash, epoch)
 	if err != nil {
-		log.Debug("RequestMetaHeader.RequestDataFromHash",
+		log.Debug("RequestMetaHeaderForEpoch.RequestDataFromHash",
 			"error", err.Error(),
 			"epoch", epoch,
 			"hash", hash,
@@ -375,6 +411,12 @@ func (rrh *resolverRequestHandler) RequestMetaHeader(hash []byte) {
 
 // RequestShardHeaderByNonce method asks for shard header from the connected peers by nonce
 func (rrh *resolverRequestHandler) RequestShardHeaderByNonce(shardID uint32, nonce uint64) {
+	epoch := rrh.getEpoch()
+	rrh.RequestShardHeaderByNonceForEpoch(shardID, nonce, epoch)
+}
+
+// RequestShardHeaderByNonceForEpoch method asks for shard header from the connected peers by nonce and epoch
+func (rrh *resolverRequestHandler) RequestShardHeaderByNonceForEpoch(shardID uint32, nonce uint64, epoch uint32) {
 	suffix := fmt.Sprintf("%s_%d", uniqueHeadersSuffix, shardID)
 	key := []byte(fmt.Sprintf("%d-%d", shardID, nonce))
 	if !rrh.testIfRequestIsNeeded(key, suffix) {
@@ -388,7 +430,7 @@ func (rrh *resolverRequestHandler) RequestShardHeaderByNonce(shardID uint32, non
 
 	requester, err := rrh.getShardHeaderRequester(shardID)
 	if err != nil {
-		log.Error("RequestShardHeaderByNonce.getShardHeaderRequester",
+		log.Error("RequestShardHeaderByNonceForEpoch.getShardHeaderRequester",
 			"error", err.Error(),
 			"shard", shardID,
 		)
@@ -403,10 +445,9 @@ func (rrh *resolverRequestHandler) RequestShardHeaderByNonce(shardID uint32, non
 
 	rrh.whiteList.Add([][]byte{key})
 
-	epoch := rrh.getEpoch()
 	err = headerRequester.RequestDataFromNonce(nonce, epoch)
 	if err != nil {
-		log.Debug("RequestShardHeaderByNonce.RequestDataFromNonce",
+		log.Debug("RequestShardHeaderByNonceForEpoch.RequestDataFromNonce",
 			"error", err.Error(),
 			"epoch", epoch,
 			"nonce", nonce,
@@ -419,6 +460,12 @@ func (rrh *resolverRequestHandler) RequestShardHeaderByNonce(shardID uint32, non
 
 // RequestTrieNodes method asks for trie nodes from the connected peers
 func (rrh *resolverRequestHandler) RequestTrieNodes(destShardID uint32, hashes [][]byte, topic string) {
+	epoch := rrh.getEpoch()
+	rrh.RequestTrieNodesForEpoch(destShardID, hashes, topic, epoch)
+}
+
+// RequestTrieNodesForEpoch method asks for trie nodes from the connected peers for a specific epoch
+func (rrh *resolverRequestHandler) RequestTrieNodesForEpoch(destShardID uint32, hashes [][]byte, topic string, epoch uint32) {
 	unrequestedHashes := rrh.getUnrequestedHashes(hashes, uniqueTrieNodesSuffix)
 	if len(unrequestedHashes) == 0 {
 		return
@@ -471,7 +518,7 @@ func (rrh *resolverRequestHandler) RequestTrieNodes(destShardID uint32, hashes [
 
 	rrh.logTrieHashesFromAccumulator()
 
-	go rrh.requestHashesWithDataSplit(itemsToRequest, trieRequester)
+	go rrh.requestHashesWithDataSplit(itemsToRequest, trieRequester, epoch)
 
 	rrh.addRequestedItems(itemsToRequest, uniqueTrieNodesSuffix)
 	rrh.lastTrieRequestTime = time.Now()
@@ -535,6 +582,12 @@ func (rrh *resolverRequestHandler) logTrieHashesFromAccumulator() {
 
 // RequestMetaHeaderByNonce method asks for meta header from the connected peers by nonce
 func (rrh *resolverRequestHandler) RequestMetaHeaderByNonce(nonce uint64) {
+	epoch := rrh.getEpoch()
+	rrh.RequestMetaHeaderByNonceForEpoch(nonce, epoch)
+}
+
+// RequestMetaHeaderByNonceForEpoch method asks for meta header from the connected peers by nonce and epoch
+func (rrh *resolverRequestHandler) RequestMetaHeaderByNonceForEpoch(nonce uint64, epoch uint32) {
 	key := []byte(fmt.Sprintf("%d-%d", core.MetachainShardId, nonce))
 	if !rrh.testIfRequestIsNeeded(key, uniqueMetaHeadersSuffix) {
 		return
@@ -546,18 +599,16 @@ func (rrh *resolverRequestHandler) RequestMetaHeaderByNonce(nonce uint64) {
 
 	headerRequester, err := rrh.getMetaHeaderRequester()
 	if err != nil {
-		log.Error("RequestMetaHeaderByNonce.getMetaHeaderRequester",
+		log.Error("RequestMetaHeaderByNonceForEpoch.getMetaHeaderRequester",
 			"error", err.Error(),
 		)
 		return
 	}
 
 	rrh.whiteList.Add([][]byte{key})
-
-	epoch := rrh.getEpoch()
 	err = headerRequester.RequestDataFromNonce(nonce, epoch)
 	if err != nil {
-		log.Debug("RequestMetaHeaderByNonce.RequestDataFromNonce",
+		log.Debug("RequestMetaHeaderByNonceForEpoch.RequestDataFromNonce",
 			"error", err.Error(),
 			"epoch", epoch,
 			"nonce", nonce,
@@ -570,11 +621,15 @@ func (rrh *resolverRequestHandler) RequestMetaHeaderByNonce(nonce uint64) {
 
 // RequestValidatorInfo asks for the validator info associated with a specific hash from connected peers
 func (rrh *resolverRequestHandler) RequestValidatorInfo(hash []byte) {
+	epoch := rrh.getEpoch()
+	rrh.RequestValidatorInfoForEpoch(hash, epoch)
+}
+
+// RequestValidatorInfoForEpoch asks for the validator info associated with a specific hash from connected peers for a specific epoch
+func (rrh *resolverRequestHandler) RequestValidatorInfoForEpoch(hash []byte, epoch uint32) {
 	if !rrh.testIfRequestIsNeeded(hash, uniqueValidatorInfoSuffix) {
 		return
 	}
-
-	epoch := rrh.getEpoch()
 
 	log.Debug("requesting validator info messages from network",
 		"topic", common.ValidatorInfoTopic,
@@ -584,7 +639,7 @@ func (rrh *resolverRequestHandler) RequestValidatorInfo(hash []byte) {
 
 	requester, err := rrh.requestersFinder.MetaChainRequester(common.ValidatorInfoTopic)
 	if err != nil {
-		log.Error("RequestValidatorInfo.MetaChainRequester",
+		log.Error("RequestValidatorInfoForEpoch.MetaChainRequester",
 			"error", err.Error(),
 			"topic", common.ValidatorInfoTopic,
 			"hash", hash,
@@ -597,7 +652,7 @@ func (rrh *resolverRequestHandler) RequestValidatorInfo(hash []byte) {
 
 	err = requester.RequestDataFromHash(hash, epoch)
 	if err != nil {
-		log.Debug("RequestValidatorInfo.RequestDataFromHash",
+		log.Debug("RequestValidatorInfoForEpoch.RequestDataFromHash",
 			"error", err.Error(),
 			"topic", common.ValidatorInfoTopic,
 			"hash", hash,
@@ -611,12 +666,16 @@ func (rrh *resolverRequestHandler) RequestValidatorInfo(hash []byte) {
 
 // RequestValidatorsInfo asks for the validators` info associated with the specified hashes from connected peers
 func (rrh *resolverRequestHandler) RequestValidatorsInfo(hashes [][]byte) {
+	epoch := rrh.getEpoch()
+	rrh.RequestValidatorsInfoForEpoch(hashes, epoch)
+}
+
+// RequestValidatorsInfoForEpoch asks for the validators` info associated with the specified hashes from connected peers for a specific epoch
+func (rrh *resolverRequestHandler) RequestValidatorsInfoForEpoch(hashes [][]byte, epoch uint32) {
 	unrequestedHashes := rrh.getUnrequestedHashes(hashes, uniqueValidatorInfoSuffix)
 	if len(unrequestedHashes) == 0 {
 		return
 	}
-
-	epoch := rrh.getEpoch()
 
 	log.Debug("requesting validator info messages from network",
 		"topic", common.ValidatorInfoTopic,
@@ -626,7 +685,7 @@ func (rrh *resolverRequestHandler) RequestValidatorsInfo(hashes [][]byte) {
 
 	requester, err := rrh.requestersFinder.MetaChainRequester(common.ValidatorInfoTopic)
 	if err != nil {
-		log.Error("RequestValidatorInfo.MetaChainRequester",
+		log.Error("RequestValidatorsInfoForEpoch.MetaChainRequester",
 			"error", err.Error(),
 			"topic", common.ValidatorInfoTopic,
 			"num hashes", len(unrequestedHashes),
@@ -645,7 +704,7 @@ func (rrh *resolverRequestHandler) RequestValidatorsInfo(hashes [][]byte) {
 
 	err = validatorInfoRequester.RequestDataFromHashArray(unrequestedHashes, epoch)
 	if err != nil {
-		log.Debug("RequestValidatorInfo.RequestDataFromHash",
+		log.Debug("RequestValidatorsInfoForEpoch.RequestDataFromHash",
 			"error", err.Error(),
 			"topic", common.ValidatorInfoTopic,
 			"num hashes", len(unrequestedHashes),
@@ -835,7 +894,11 @@ func (rrh *resolverRequestHandler) GetNumPeersToQuery(key string) (int, int, err
 // RequestPeerAuthenticationsByHashes asks for peer authentication messages from specific peers hashes
 func (rrh *resolverRequestHandler) RequestPeerAuthenticationsByHashes(destShardID uint32, hashes [][]byte) {
 	epoch := rrh.getEpoch()
+	rrh.RequestPeerAuthenticationsByHashesForEpoch(destShardID, hashes, epoch)
+}
 
+// RequestPeerAuthenticationsByHashesForEpoch asks for peer authentication messages from specific peers hashes for a specific epoch
+func (rrh *resolverRequestHandler) RequestPeerAuthenticationsByHashesForEpoch(destShardID uint32, hashes [][]byte, epoch uint32) {
 	log.Debug("requesting peer authentication messages from network",
 		"topic", common.PeerAuthenticationTopic,
 		"shard", destShardID,
@@ -845,7 +908,7 @@ func (rrh *resolverRequestHandler) RequestPeerAuthenticationsByHashes(destShardI
 
 	requester, err := rrh.requestersFinder.MetaChainRequester(common.PeerAuthenticationTopic)
 	if err != nil {
-		log.Error("RequestPeerAuthenticationsByHashes.MetaChainRequester",
+		log.Error("RequestPeerAuthenticationsByHashesForEpoch.MetaChainRequester",
 			"error", err.Error(),
 			"topic", common.PeerAuthenticationTopic,
 			"shard", destShardID,
@@ -862,7 +925,7 @@ func (rrh *resolverRequestHandler) RequestPeerAuthenticationsByHashes(destShardI
 
 	err = peerAuthRequester.RequestDataFromHashArray(hashes, epoch)
 	if err != nil {
-		log.Debug("RequestPeerAuthenticationsByHashes.RequestDataFromHashArray",
+		log.Debug("RequestPeerAuthenticationsByHashesForEpoch.RequestDataFromHashArray",
 			"error", err.Error(),
 			"topic", common.PeerAuthenticationTopic,
 			"shard", destShardID,
@@ -873,11 +936,16 @@ func (rrh *resolverRequestHandler) RequestPeerAuthenticationsByHashes(destShardI
 
 // RequestEquivalentProofByHash asks for equivalent proof for the provided header hash
 func (rrh *resolverRequestHandler) RequestEquivalentProofByHash(headerShard uint32, headerHash []byte) {
+	epoch := rrh.getEpoch()
+	rrh.RequestEquivalentProofByHashForEpoch(headerShard, headerHash, epoch)
+}
+
+// RequestEquivalentProofByHashForEpoch asks for equivalent proof for the provided header hash and epoch
+func (rrh *resolverRequestHandler) RequestEquivalentProofByHashForEpoch(headerShard uint32, headerHash []byte, epoch uint32) {
 	if !rrh.testIfRequestIsNeeded(headerHash, uniqueEquivalentProofSuffix) {
 		return
 	}
 
-	epoch := rrh.getEpoch()
 	encodedHash := hex.EncodeToString(headerHash)
 	log.Debug("requesting equivalent proof from network",
 		"headerHash", encodedHash,
@@ -887,7 +955,7 @@ func (rrh *resolverRequestHandler) RequestEquivalentProofByHash(headerShard uint
 
 	requester, err := rrh.getEquivalentProofsRequester(headerShard)
 	if err != nil {
-		log.Error("RequestEquivalentProofByHash.getEquivalentProofsRequester",
+		log.Error("RequestEquivalentProofByHashForEpoch.getEquivalentProofsRequester",
 			"error", err.Error(),
 			"headerHash", encodedHash,
 			"epoch", epoch,
@@ -900,7 +968,7 @@ func (rrh *resolverRequestHandler) RequestEquivalentProofByHash(headerShard uint
 	requestKey := fmt.Sprintf("%s-%d", encodedHash, headerShard)
 	err = requester.RequestDataFromHash([]byte(requestKey), epoch)
 	if err != nil {
-		log.Debug("RequestEquivalentProofByHash.RequestDataFromHash",
+		log.Debug("RequestEquivalentProofByHashForEpoch.RequestDataFromHash",
 			"error", err.Error(),
 			"headerHash", encodedHash,
 			"headerShard", headerShard,
@@ -914,12 +982,17 @@ func (rrh *resolverRequestHandler) RequestEquivalentProofByHash(headerShard uint
 
 // RequestEquivalentProofByNonce asks for equivalent proof for the provided header nonce
 func (rrh *resolverRequestHandler) RequestEquivalentProofByNonce(headerShard uint32, headerNonce uint64) {
+	epoch := rrh.getEpoch()
+	rrh.RequestEquivalentProofByNonceForEpoch(headerShard, headerNonce, epoch)
+}
+
+// RequestEquivalentProofByNonceForEpoch asks for equivalent proof for the provided header nonce and epoch
+func (rrh *resolverRequestHandler) RequestEquivalentProofByNonceForEpoch(headerShard uint32, headerNonce uint64, epoch uint32) {
 	key := common.GetEquivalentProofNonceShardKey(headerNonce, headerShard)
 	if !rrh.testIfRequestIsNeeded([]byte(key), uniqueEquivalentProofSuffix) {
 		return
 	}
 
-	epoch := rrh.getEpoch()
 	log.Debug("requesting equivalent proof by nonce from network",
 		"headerNonce", headerNonce,
 		"headerShard", headerShard,
@@ -928,7 +1001,7 @@ func (rrh *resolverRequestHandler) RequestEquivalentProofByNonce(headerShard uin
 
 	requester, err := rrh.getEquivalentProofsRequester(headerShard)
 	if err != nil {
-		log.Error("RequestEquivalentProofByNonce.getEquivalentProofsRequester",
+		log.Error("RequestEquivalentProofByNonceForEpoch.getEquivalentProofsRequester",
 			"error", err.Error(),
 			"headerNonce", headerNonce,
 		)
@@ -945,7 +1018,7 @@ func (rrh *resolverRequestHandler) RequestEquivalentProofByNonce(headerShard uin
 
 	err = proofsRequester.RequestDataFromNonce([]byte(key), epoch)
 	if err != nil {
-		log.Debug("RequestEquivalentProofByNonce.RequestDataFromNonce",
+		log.Debug("RequestEquivalentProofByNonceForEpoch.RequestDataFromNonce",
 			"error", err.Error(),
 			"headerNonce", headerNonce,
 			"headerShard", headerShard,

--- a/dataRetriever/requestHandlers/requestHandler.go
+++ b/dataRetriever/requestHandlers/requestHandler.go
@@ -113,8 +113,8 @@ func (rrh *resolverRequestHandler) getEpoch() uint32 {
 	return rrh.epoch
 }
 
-// RequestTransaction method asks for transactions from the connected peers
-func (rrh *resolverRequestHandler) RequestTransaction(destShardID uint32, txHashes [][]byte) {
+// RequestTransactions method asks for transactions from the connected peers
+func (rrh *resolverRequestHandler) RequestTransactions(destShardID uint32, txHashes [][]byte) {
 	epoch := rrh.getEpoch()
 	rrh.requestByHashes(destShardID, txHashes, factory.TransactionTopic, uniqueTxSuffix, epoch)
 }

--- a/dataRetriever/requestHandlers/requestHandler_test.go
+++ b/dataRetriever/requestHandlers/requestHandler_test.go
@@ -162,7 +162,7 @@ func TestResolverRequestHandler_RequestTransaction(t *testing.T) {
 			time.Second,
 		)
 
-		rrh.RequestTransaction(0, make([][]byte, 0))
+		rrh.RequestTransactions(0, make([][]byte, 0))
 	})
 	t.Run("error when getting cross shard requester should not panic", func(t *testing.T) {
 		t.Parallel()
@@ -187,7 +187,7 @@ func TestResolverRequestHandler_RequestTransaction(t *testing.T) {
 			time.Second,
 		)
 
-		rrh.RequestTransaction(0, [][]byte{[]byte("txHash")})
+		rrh.RequestTransactions(0, [][]byte{[]byte("txHash")})
 	})
 	t.Run("uncastable requester should not panic", func(t *testing.T) {
 		t.Parallel()
@@ -214,7 +214,7 @@ func TestResolverRequestHandler_RequestTransaction(t *testing.T) {
 			time.Second,
 		)
 
-		rrh.RequestTransaction(0, [][]byte{[]byte("txHash")})
+		rrh.RequestTransactions(0, [][]byte{[]byte("txHash")})
 	})
 	t.Run("should request", func(t *testing.T) {
 		t.Parallel()
@@ -240,7 +240,7 @@ func TestResolverRequestHandler_RequestTransaction(t *testing.T) {
 			time.Second,
 		)
 
-		rrh.RequestTransaction(0, [][]byte{[]byte("txHash")})
+		rrh.RequestTransactions(0, [][]byte{[]byte("txHash")})
 
 		select {
 		case <-chTxRequested:
@@ -276,19 +276,19 @@ func TestResolverRequestHandler_RequestTransaction(t *testing.T) {
 			time.Second,
 		)
 
-		rrh.RequestTransaction(0, [][]byte{[]byte("txHash")})
-		rrh.RequestTransaction(1, [][]byte{[]byte("txHash")})
-		rrh.RequestTransaction(0, [][]byte{[]byte("txHash")})
-		rrh.RequestTransaction(1, [][]byte{[]byte("txHash")})
+		rrh.RequestTransactions(0, [][]byte{[]byte("txHash")})
+		rrh.RequestTransactions(1, [][]byte{[]byte("txHash")})
+		rrh.RequestTransactions(0, [][]byte{[]byte("txHash")})
+		rrh.RequestTransactions(1, [][]byte{[]byte("txHash")})
 
 		time.Sleep(time.Second) // let the go routines finish
 		assert.Equal(t, uint32(2), atomic.LoadUint32(&numRequests))
 		time.Sleep(time.Second) // sweep will take effect
 
-		rrh.RequestTransaction(0, [][]byte{[]byte("txHash")})
-		rrh.RequestTransaction(1, [][]byte{[]byte("txHash")})
-		rrh.RequestTransaction(0, [][]byte{[]byte("txHash")})
-		rrh.RequestTransaction(1, [][]byte{[]byte("txHash")})
+		rrh.RequestTransactions(0, [][]byte{[]byte("txHash")})
+		rrh.RequestTransactions(1, [][]byte{[]byte("txHash")})
+		rrh.RequestTransactions(0, [][]byte{[]byte("txHash")})
+		rrh.RequestTransactions(1, [][]byte{[]byte("txHash")})
 
 		time.Sleep(time.Second) // let the go routines finish
 		assert.Equal(t, uint32(4), atomic.LoadUint32(&numRequests))
@@ -324,7 +324,46 @@ func TestResolverRequestHandler_RequestTransaction(t *testing.T) {
 			time.Second,
 		)
 
-		rrh.RequestTransaction(0, [][]byte{[]byte("txHash")})
+		rrh.RequestTransactions(0, [][]byte{[]byte("txHash")})
+
+		select {
+		case <-chTxRequested:
+		case <-time.After(timeoutSendRequests):
+			assert.Fail(t, "timeout while waiting to call RequestDataFromHashArray")
+		}
+
+		time.Sleep(time.Second)
+	})
+}
+
+func TestResolverRequestHandler_RequestTransactionsForEpoch(t *testing.T) {
+	t.Run("should request for given epoch", func(t *testing.T) {
+		t.Parallel()
+
+		requestEpoch := uint32(1)
+		chTxRequested := make(chan struct{})
+		txRequester := &dataRetrieverMocks.HashSliceRequesterStub{
+			RequestDataFromHashArrayCalled: func(hashes [][]byte, epoch uint32) error {
+				require.Equal(t, requestEpoch, epoch)
+				chTxRequested <- struct{}{}
+				return nil
+			},
+		}
+
+		rrh, _ := NewResolverRequestHandler(
+			&dataRetrieverMocks.RequestersFinderStub{
+				CrossShardRequesterCalled: func(baseTopic string, crossShard uint32) (requester dataRetriever.Requester, e error) {
+					return txRequester, nil
+				},
+			},
+			&mock.RequestedItemsHandlerStub{},
+			&mock.WhiteListHandlerStub{},
+			1,
+			0,
+			time.Second,
+		)
+
+		rrh.RequestTransactionsForEpoch(0, [][]byte{[]byte("txHash")}, requestEpoch)
 
 		select {
 		case <-chTxRequested:
@@ -1099,8 +1138,41 @@ func TestResolverRequestHandler_RequestScrShouldRequestScr(t *testing.T) {
 	case <-time.After(timeoutSendRequests):
 		assert.Fail(t, "timeout while waiting to call RequestDataFromHashArray")
 	}
+}
 
-	time.Sleep(time.Second)
+func TestResolverRequestHandler_RequestScrForEpochShouldRequestScr(t *testing.T) {
+	t.Parallel()
+
+	requestEpoch := uint32(1)
+	chTxRequested := make(chan struct{})
+	txRequester := &dataRetrieverMocks.HashSliceRequesterStub{
+		RequestDataFromHashArrayCalled: func(hashes [][]byte, epoch uint32) error {
+			require.Equal(t, requestEpoch, epoch)
+			chTxRequested <- struct{}{}
+			return nil
+		},
+	}
+
+	rrh, _ := NewResolverRequestHandler(
+		&dataRetrieverMocks.RequestersFinderStub{
+			CrossShardRequesterCalled: func(baseTopic string, crossShard uint32) (requester dataRetriever.Requester, e error) {
+				return txRequester, nil
+			},
+		},
+		&mock.RequestedItemsHandlerStub{},
+		&mock.WhiteListHandlerStub{},
+		1,
+		0,
+		time.Second,
+	)
+
+	rrh.RequestUnsignedTransactionsForEpoch(0, [][]byte{[]byte("txHash")}, requestEpoch)
+
+	select {
+	case <-chTxRequested:
+	case <-time.After(timeoutSendRequests):
+		assert.Fail(t, "timeout while waiting to call RequestDataFromHashArray")
+	}
 }
 
 func TestResolverRequestHandler_RequestScrErrorsOnRequestShouldNotPanic(t *testing.T) {
@@ -1141,8 +1213,6 @@ func TestResolverRequestHandler_RequestScrErrorsOnRequestShouldNotPanic(t *testi
 	case <-time.After(timeoutSendRequests):
 		assert.Fail(t, "timeout while waiting to call RequestDataFromHashArray")
 	}
-
-	time.Sleep(time.Second)
 }
 
 func TestResolverRequestHandler_RequestRewardShouldRequestReward(t *testing.T) {
@@ -1176,8 +1246,41 @@ func TestResolverRequestHandler_RequestRewardShouldRequestReward(t *testing.T) {
 	case <-time.After(timeoutSendRequests):
 		assert.Fail(t, "timeout while waiting to call RequestDataFromHashArray")
 	}
+}
 
-	time.Sleep(time.Second)
+func TestResolverRequestHandler_RequestRewardForEpochShouldRequestReward(t *testing.T) {
+	t.Parallel()
+
+	requestEpoch := uint32(1)
+	chTxRequested := make(chan struct{})
+	txRequester := &dataRetrieverMocks.HashSliceRequesterStub{
+		RequestDataFromHashArrayCalled: func(hashes [][]byte, epoch uint32) error {
+			require.Equal(t, requestEpoch, epoch)
+			chTxRequested <- struct{}{}
+			return nil
+		},
+	}
+
+	rrh, _ := NewResolverRequestHandler(
+		&dataRetrieverMocks.RequestersFinderStub{
+			CrossShardRequesterCalled: func(baseTopic string, crossShard uint32) (requester dataRetriever.Requester, e error) {
+				return txRequester, nil
+			},
+		},
+		&mock.RequestedItemsHandlerStub{},
+		&mock.WhiteListHandlerStub{},
+		1,
+		0,
+		time.Second,
+	)
+
+	rrh.RequestRewardTransactionsForEpoch(0, [][]byte{[]byte("txHash")}, requestEpoch)
+
+	select {
+	case <-chTxRequested:
+	case <-time.After(timeoutSendRequests):
+		assert.Fail(t, "timeout while waiting to call RequestDataFromHashArray")
+	}
 }
 
 func TestRequestTrieNodes(t *testing.T) {
@@ -2308,5 +2411,220 @@ func TestResolverRequestHandler_RequestEquivalentProofByHash(t *testing.T) {
 
 		rrh.RequestEquivalentProofByHash(0, providedHash)
 		assert.True(t, wasCalled)
+	})
+}
+
+func TestResolverRequestHandler_RequestEquivalentProofByNonce(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nonce already requested should work", func(t *testing.T) {
+		t.Parallel()
+
+		nonce := uint64(10)
+		rrh, _ := NewResolverRequestHandler(
+			&dataRetrieverMocks.RequestersFinderStub{
+				MetaChainRequesterCalled: func(baseTopic string) (requester dataRetriever.Requester, e error) {
+					require.Fail(t, "should not have been called")
+					return nil, nil
+				},
+			},
+			&mock.RequestedItemsHandlerStub{
+				HasCalled: func(key string) bool {
+					return true
+				},
+			},
+			&mock.WhiteListHandlerStub{
+				AddCalled: func(keys [][]byte) {
+					require.Fail(t, "should not have been called")
+				},
+			},
+			100,
+			0,
+			time.Second,
+		)
+
+		rrh.RequestEquivalentProofByNonce(core.MetachainShardId, nonce)
+	})
+	t.Run("invalid cross-shard request should early exit", func(t *testing.T) {
+		t.Parallel()
+
+		nonce := uint64(10)
+		rrh, _ := NewResolverRequestHandler(
+			&dataRetrieverMocks.RequestersFinderStub{},
+			&mock.RequestedItemsHandlerStub{},
+			&mock.WhiteListHandlerStub{
+				AddCalled: func(keys [][]byte) {
+					require.Fail(t, "should not have been called")
+				},
+			},
+			100,
+			0,
+			time.Second,
+		)
+
+		rrh.RequestEquivalentProofByNonce(1, nonce)
+	})
+	t.Run("missing metachain requester should early exit", func(t *testing.T) {
+		t.Parallel()
+
+		nonce := uint64(10)
+		rrh, _ := NewResolverRequestHandler(
+			&dataRetrieverMocks.RequestersFinderStub{
+				MetaChainRequesterCalled: func(baseTopic string) (dataRetriever.Requester, error) {
+					return nil, errExpected
+				},
+			},
+			&mock.RequestedItemsHandlerStub{},
+			&mock.WhiteListHandlerStub{
+				AddCalled: func(keys [][]byte) {
+					require.Fail(t, "should not have been called")
+				},
+			},
+			100,
+			core.MetachainShardId,
+			time.Second,
+		)
+
+		rrh.RequestEquivalentProofByNonce(core.MetachainShardId, nonce)
+	})
+	t.Run("missing cross-shard requester should early exit", func(t *testing.T) {
+		t.Parallel()
+
+		nonce := uint64(10)
+		rrh, _ := NewResolverRequestHandler(
+			&dataRetrieverMocks.RequestersFinderStub{
+				CrossShardRequesterCalled: func(baseTopic string, crossShard uint32) (dataRetriever.Requester, error) {
+					return nil, errExpected
+				},
+			},
+			&mock.RequestedItemsHandlerStub{},
+			&mock.WhiteListHandlerStub{
+				AddCalled: func(keys [][]byte) {
+					require.Fail(t, "should not have been called")
+				},
+			},
+			100,
+			0,
+			time.Second,
+		)
+
+		rrh.RequestEquivalentProofByNonce(1, nonce)
+	})
+	t.Run("MetaChainRequester returns error", func(t *testing.T) {
+		t.Parallel()
+
+		nonce := uint64(10)
+		res := &dataRetrieverMocks.EquivalentProofRequesterStub{
+			RequestDataFromNonceCalled: func(key []byte, epoch uint32) error {
+				require.Fail(t, "should not have been called")
+
+				return nil
+			},
+		}
+
+		rrh, _ := NewResolverRequestHandler(
+			&dataRetrieverMocks.RequestersFinderStub{
+				MetaChainRequesterCalled: func(baseTopic string) (requester dataRetriever.Requester, e error) {
+					return res, errExpected
+				},
+			},
+			&mock.RequestedItemsHandlerStub{},
+			&mock.WhiteListHandlerStub{},
+			100,
+			core.MetachainShardId,
+			time.Second,
+		)
+
+		rrh.RequestEquivalentProofByNonce(core.MetachainShardId, nonce)
+	})
+	t.Run("CrossChainRequester returns error", func(t *testing.T) {
+		t.Parallel()
+
+		nonce := uint64(10)
+		res := &dataRetrieverMocks.EquivalentProofRequesterStub{
+			RequestDataFromNonceCalled: func(hash []byte, epoch uint32) error {
+				require.Fail(t, "should not have been called")
+				return nil
+			},
+		}
+
+		rrh, _ := NewResolverRequestHandler(
+			&dataRetrieverMocks.RequestersFinderStub{
+				CrossShardRequesterCalled: func(baseTopic string, crossShard uint32) (dataRetriever.Requester, error) {
+					return res, errExpected
+				},
+			},
+			&mock.RequestedItemsHandlerStub{},
+			&mock.WhiteListHandlerStub{},
+			100,
+			0,
+			time.Second,
+		)
+
+		rrh.RequestEquivalentProofByNonce(0, nonce)
+	})
+	t.Run("RequestDataFromNonce returns error", func(t *testing.T) {
+		t.Parallel()
+
+		shardID := core.MetachainShardId
+		requestNonce := uint64(10)
+		expectedRequestKey := common.GetEquivalentProofNonceShardKey(requestNonce, shardID)
+		res := &dataRetrieverMocks.EquivalentProofRequesterStub{
+			RequestDataFromNonceCalled: func(nonceShardKey []byte, epoch uint32) error {
+				require.Equal(t, []byte(expectedRequestKey), nonceShardKey)
+				return errExpected
+			},
+		}
+
+		rrh, _ := NewResolverRequestHandler(
+			&dataRetrieverMocks.RequestersFinderStub{
+				MetaChainRequesterCalled: func(baseTopic string) (requester dataRetriever.Requester, e error) {
+					return res, nil
+				},
+			},
+			&mock.RequestedItemsHandlerStub{
+				AddCalled: func(key string) error {
+					require.Fail(t, "should not have been called")
+					return nil
+				},
+			},
+			&mock.WhiteListHandlerStub{},
+			100,
+			core.MetachainShardId,
+			time.Second,
+		)
+
+		rrh.RequestEquivalentProofByNonce(shardID, requestNonce)
+	})
+	t.Run("should work shard 0 requesting from 0", func(t *testing.T) {
+		t.Parallel()
+
+		shardID := uint32(0)
+		requestNonce := uint64(10)
+		expectedRequestKey := common.GetEquivalentProofNonceShardKey(requestNonce, shardID)
+		wasCalled := false
+		res := &dataRetrieverMocks.EquivalentProofRequesterStub{
+			RequestDataFromNonceCalled: func(nonceShardKey []byte, epoch uint32) error {
+				require.Equal(t, []byte(expectedRequestKey), nonceShardKey)
+				wasCalled = true
+				return nil
+			},
+		}
+
+		rrh, _ := NewResolverRequestHandler(
+			&dataRetrieverMocks.RequestersFinderStub{
+				CrossShardRequesterCalled: func(baseTopic string, crossShard uint32) (dataRetriever.Requester, error) {
+					return res, nil
+				},
+			},
+			&mock.RequestedItemsHandlerStub{},
+			&mock.WhiteListHandlerStub{},
+			100,
+			0,
+			time.Second,
+		)
+
+		rrh.RequestEquivalentProofByNonce(shardID, requestNonce)
+		require.True(t, wasCalled)
 	})
 }

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -61,7 +61,7 @@ import (
 var log = logger.GetOrCreate("epochStart/bootstrap")
 
 // DefaultTimeToWaitForRequestedData represents the default timespan until requested data needs to be received from the connected peers
-const DefaultTimeToWaitForRequestedData = time.Minute
+const DefaultTimeToWaitForRequestedData = 2 * time.Minute
 const timeBetweenRequests = 100 * time.Millisecond
 const maxToRequest = 100
 const gracePeriodInPercentage = float64(0.25)

--- a/epochStart/bootstrap/process.go
+++ b/epochStart/bootstrap/process.go
@@ -61,7 +61,7 @@ import (
 var log = logger.GetOrCreate("epochStart/bootstrap")
 
 // DefaultTimeToWaitForRequestedData represents the default timespan until requested data needs to be received from the connected peers
-const DefaultTimeToWaitForRequestedData = 2 * time.Minute
+const DefaultTimeToWaitForRequestedData = 5 * time.Minute
 const timeBetweenRequests = 100 * time.Millisecond
 const maxToRequest = 100
 const gracePeriodInPercentage = float64(0.25)

--- a/genesis/process/disabled/disabled_test.go
+++ b/genesis/process/disabled/disabled_test.go
@@ -195,7 +195,7 @@ func TestRequestHandler(t *testing.T) {
 	handler.RequestMetaHeader([]byte{})
 	handler.RequestMetaHeaderByNonce(0)
 	handler.RequestShardHeaderByNonce(0, 0)
-	handler.RequestTransaction(0, [][]byte{})
+	handler.RequestTransactions(0, [][]byte{})
 	handler.RequestUnsignedTransactions(0, [][]byte{})
 	handler.RequestRewardTransactions(0, [][]byte{})
 	handler.RequestMiniBlock(0, []byte{})

--- a/genesis/process/disabled/requestHandler.go
+++ b/genesis/process/disabled/requestHandler.go
@@ -27,7 +27,7 @@ func (r *RequestHandler) RequestShardHeaderByNonce(_ uint32, _ uint64) {
 }
 
 // RequestTransaction does nothing
-func (r *RequestHandler) RequestTransaction(_ uint32, _ [][]byte) {
+func (r *RequestHandler) RequestTransactions(_ uint32, _ [][]byte) {
 }
 
 // RequestUnsignedTransactions does nothing

--- a/genesis/process/disabled/requestHandler.go
+++ b/genesis/process/disabled/requestHandler.go
@@ -26,7 +26,7 @@ func (r *RequestHandler) RequestMetaHeaderByNonce(_ uint64) {
 func (r *RequestHandler) RequestShardHeaderByNonce(_ uint32, _ uint64) {
 }
 
-// RequestTransaction does nothing
+// RequestTransactions does nothing
 func (r *RequestHandler) RequestTransactions(_ uint32, _ [][]byte) {
 }
 

--- a/integrationTests/resolvers/transactions/transactionsRequest_test.go
+++ b/integrationTests/resolvers/transactions/transactionsRequest_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-crypto-go/signing"
 	ed255192 "github.com/multiversx/mx-chain-crypto-go/signing/ed25519"
+
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/integrationTests"
 	"github.com/multiversx/mx-chain-go/integrationTests/resolvers"
@@ -78,7 +79,7 @@ func TestTransactionsRequestsShouldWorkForHigherMaxTxNonceDeltaAllowed(t *testin
 	_ = nRequester.AccntState.SaveAccount(account)
 	_, _ = nRequester.AccntState.Commit()
 
-	nRequester.RequestHandler.RequestTransaction(shardIdResolver, txHashes)
+	nRequester.RequestHandler.RequestTransactions(shardIdResolver, txHashes)
 
 	rm.WaitWithTimeout()
 }

--- a/process/factory/metachain/preProcessorsContainerFactory.go
+++ b/process/factory/metachain/preProcessorsContainerFactory.go
@@ -6,6 +6,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
@@ -185,7 +186,7 @@ func (ppcm *preProcessorsContainerFactory) createTxPreProcessor() (process.PrePr
 		TxProcessor:                  ppcm.txProcessor,
 		ShardCoordinator:             ppcm.shardCoordinator,
 		Accounts:                     ppcm.accounts,
-		OnRequestTransaction:         ppcm.requestHandler.RequestTransaction,
+		OnRequestTransaction:         ppcm.requestHandler.RequestTransactions,
 		EconomicsFee:                 ppcm.economicsFee,
 		GasHandler:                   ppcm.gasHandler,
 		BlockTracker:                 ppcm.blockTracker,

--- a/process/factory/shard/preProcessorsContainerFactory.go
+++ b/process/factory/shard/preProcessorsContainerFactory.go
@@ -218,7 +218,7 @@ func (ppcm *preProcessorsContainerFactory) createTxPreProcessor() (process.PrePr
 		TxProcessor:                  ppcm.txProcessor,
 		ShardCoordinator:             ppcm.shardCoordinator,
 		Accounts:                     ppcm.accounts,
-		OnRequestTransaction:         ppcm.requestHandler.RequestTransaction,
+		OnRequestTransaction:         ppcm.requestHandler.RequestTransactions,
 		EconomicsFee:                 ppcm.economicsFee,
 		GasHandler:                   ppcm.gasHandler,
 		BlockTracker:                 ppcm.blockTracker,

--- a/process/interface.go
+++ b/process/interface.go
@@ -1,9 +1,10 @@
 package process
 
 import (
-	"github.com/multiversx/mx-chain-go/ntp"
 	"math/big"
 	"time"
+
+	"github.com/multiversx/mx-chain-go/ntp"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
@@ -601,7 +602,7 @@ type RequestHandler interface {
 	RequestMetaHeader(hash []byte)
 	RequestMetaHeaderByNonce(nonce uint64)
 	RequestShardHeaderByNonce(shardID uint32, nonce uint64)
-	RequestTransaction(destShardID uint32, txHashes [][]byte)
+	RequestTransactions(destShardID uint32, txHashes [][]byte)
 	RequestUnsignedTransactions(destShardID uint32, scrHashes [][]byte)
 	RequestRewardTransactions(destShardID uint32, txHashes [][]byte)
 	RequestMiniBlock(destShardID uint32, miniblockHash []byte)

--- a/testscommon/dataRetriever/equivalentProofRequesterStub.go
+++ b/testscommon/dataRetriever/equivalentProofRequesterStub.go
@@ -1,0 +1,15 @@
+package dataRetriever
+
+// EquivalentProofRequesterStub -
+type EquivalentProofRequesterStub struct {
+	*RequesterStub
+	RequestDataFromNonceCalled func(nonceShardKey []byte, epoch uint32) error
+}
+
+// RequestDataFromNonce -
+func (stub *EquivalentProofRequesterStub) RequestDataFromNonce(nonceShardKey []byte, epoch uint32) error {
+	if stub.RequestDataFromNonceCalled != nil {
+		return stub.RequestDataFromNonceCalled(nonceShardKey, epoch)
+	}
+	return nil
+}

--- a/testscommon/requestHandlerStub.go
+++ b/testscommon/requestHandlerStub.go
@@ -94,7 +94,7 @@ func (rhs *RequestHandlerStub) RequestShardHeaderByNonce(shardID uint32, nonce u
 }
 
 // RequestTransaction -
-func (rhs *RequestHandlerStub) RequestTransaction(destShardID uint32, txHashes [][]byte) {
+func (rhs *RequestHandlerStub) RequestTransactions(destShardID uint32, txHashes [][]byte) {
 	if rhs.RequestTransactionHandlerCalled == nil {
 		return
 	}

--- a/testscommon/requestHandlerStub.go
+++ b/testscommon/requestHandlerStub.go
@@ -93,7 +93,7 @@ func (rhs *RequestHandlerStub) RequestShardHeaderByNonce(shardID uint32, nonce u
 	rhs.RequestShardHeaderByNonceCalled(shardID, nonce)
 }
 
-// RequestTransaction -
+// RequestTransactions -
 func (rhs *RequestHandlerStub) RequestTransactions(destShardID uint32, txHashes [][]byte) {
 	if rhs.RequestTransactionHandlerCalled == nil {
 		return

--- a/update/interface.go
+++ b/update/interface.go
@@ -7,6 +7,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/process"
@@ -68,7 +69,7 @@ type HistoryStorer interface {
 
 // RequestHandler defines the methods through which request to data can be made
 type RequestHandler interface {
-	RequestTransaction(shardId uint32, txHashes [][]byte)
+	RequestTransactions(shardId uint32, txHashes [][]byte)
 	RequestUnsignedTransactions(destShardID uint32, scrHashes [][]byte)
 	RequestRewardTransactions(destShardID uint32, txHashes [][]byte)
 	RequestMiniBlock(shardId uint32, miniblockHash []byte)

--- a/update/sync/syncTransactions.go
+++ b/update/sync/syncTransactions.go
@@ -13,6 +13,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/state"
@@ -200,8 +201,8 @@ func (ts *transactionsSync) requestTransactionsForNonPeerMiniBlock(miniBlock *bl
 
 	switch mbType {
 	case block.TxBlock:
-		ts.requestHandler.RequestTransaction(miniBlock.SenderShardID, missingTxs)
-		ts.requestHandler.RequestTransaction(miniBlock.ReceiverShardID, missingTxs)
+		ts.requestHandler.RequestTransactions(miniBlock.SenderShardID, missingTxs)
+		ts.requestHandler.RequestTransactions(miniBlock.ReceiverShardID, missingTxs)
 	case block.SmartContractResultBlock:
 		ts.requestHandler.RequestUnsignedTransactions(miniBlock.SenderShardID, missingTxs)
 		ts.requestHandler.RequestUnsignedTransactions(miniBlock.ReceiverShardID, missingTxs)


### PR DESCRIPTION
## Reasoning behind the pull request
- This pull request refactors the request handler interface by renaming RequestTransaction to RequestTransactions and adds new epoch-specific request methods. The main changes focus on improving method naming consistency and adding support for epoch-specific data requests.

## Proposed changes
- Renamed RequestTransaction to RequestTransactions across all implementations and interfaces
- Added new *ForEpoch variants for all request methods to support epoch-specific requests
- Updated timeout constant in bootstrap process from 2 to 5 minutes

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
