### PR TITLE
MX-17032 Termui update - added metrics

### DIFF
--- a/cmd/termui/presenter/blockInfoGetters.go
+++ b/cmd/termui/presenter/blockInfoGetters.go
@@ -56,3 +56,11 @@ func (psh *PresenterStatusHandler) GetBlockSize() uint64 {
 func (psh *PresenterStatusHandler) GetHighestFinalBlock() uint64 {
 	return psh.getFromCacheAsUint64(common.MetricHighestFinalBlock)
 }
+
+func (psh *PresenterStatusHandler) GetBlockReceived() uint64 {
+	return psh.getFromCacheAsUint64(common.MetricReceivedProposedBlockBody)
+}
+
+func (psh *PresenterStatusHandler) GetBlockProof() uint64 {
+	return psh.getFromCacheAsUint64(common.MetricReceivedProof)
+}

--- a/cmd/termui/presenter/blockInfoGetters_test.go
+++ b/cmd/termui/presenter/blockInfoGetters_test.go
@@ -125,6 +125,28 @@ func TestPresenterStatusHandler_GetCurrentRoundTimestamp(t *testing.T) {
 	assert.Equal(t, currentRoundTimestamp, result)
 }
 
+func TestPresenterStatusHandler_GetBlockReceived(t *testing.T) {
+	t.Parallel()
+
+	proposedBlockMs := uint64(100)
+	//roundstartMs := uint64(50)
+	presenterStatusHandler := NewPresenterStatusHandler()
+	presenterStatusHandler.SetUInt64Value(common.MetricReceivedProposedBlockBody, proposedBlockMs)
+	result := presenterStatusHandler.GetBlockReceived()
+	assert.Equal(t, proposedBlockMs, result)
+}
+
+func TestPresenterStatusHandler_GetHighestFinalBlock(t *testing.T) {
+	t.Parallel()
+
+	highestFinalBlockNonce := uint64(100)
+	presenterStatusHandler := NewPresenterStatusHandler()
+	presenterStatusHandler.SetUInt64Value(common.MetricHighestFinalBlock, highestFinalBlockNonce)
+	result := presenterStatusHandler.GetHighestFinalBlock()
+
+	assert.Equal(t, highestFinalBlockNonce, result)
+}
+
 func TestPresenterStatusHandler_GetBlockSize(t *testing.T) {
 	t.Parallel()
 
@@ -137,15 +159,4 @@ func TestPresenterStatusHandler_GetBlockSize(t *testing.T) {
 
 	blockExpectedSize := miniBlocksSize + headerSize
 	assert.Equal(t, blockExpectedSize, result)
-}
-
-func TestPresenterStatusHandler_GetHighestFinalBlock(t *testing.T) {
-	t.Parallel()
-
-	highestFinalBlockNonce := uint64(100)
-	presenterStatusHandler := NewPresenterStatusHandler()
-	presenterStatusHandler.SetUInt64Value(common.MetricHighestFinalBlock, highestFinalBlockNonce)
-	result := presenterStatusHandler.GetHighestFinalBlock()
-
-	assert.Equal(t, highestFinalBlockNonce, result)
 }

--- a/cmd/termui/view/interface.go
+++ b/cmd/termui/view/interface.go
@@ -18,6 +18,8 @@ type Presenter interface {
 	GetCountConsensusAcceptedBlocks() uint64
 	GetCountLeader() uint64
 	GetCountAcceptedBlocks() uint64
+	GetBlockReceived() uint64
+	GetBlockProof() uint64
 	GetIsSyncing() uint64
 	GetTxPoolLoad() uint64
 	GetNonce() uint64

--- a/cmd/termui/view/termuic/termuiRenders/widgetsRender.go
+++ b/cmd/termui/view/termuic/termuiRenders/widgetsRender.go
@@ -295,7 +295,7 @@ func computeRedundancyStr(redundancyLevel int64, redundancyIsMainActive string) 
 
 func (wr *WidgetsRender) prepareBlockInfo() {
 	// 7 rows and one column
-	numRows := 8
+	numRows := 9
 	rows := make([][]string, numRows)
 
 	currentBlockHeight := wr.presenter.GetNonce()
@@ -338,7 +338,16 @@ func (wr *WidgetsRender) prepareBlockInfo() {
 	}
 
 	currentRoundTimestamp := wr.presenter.GetCurrentRoundTimestamp()
-	rows[7] = []string{fmt.Sprintf("Current round timestamp: %d", currentRoundTimestamp)}
+	rows[8] = []string{fmt.Sprintf("Current round timestamp: %d", currentRoundTimestamp)}
+
+	durationStartRoundToSentOrReceivedBlock := float64(wr.presenter.GetBlockReceived()) / 1e9
+	durationSentOrReceivedBlockToReceivedSignatures := float64(wr.presenter.GetBlockProof())/1e9 - durationStartRoundToSentOrReceivedBlock
+
+	rows[7] = []string{
+		fmt.Sprintf("Received proposed block: %.6f sec | Received proof: %.6f sec",
+			durationStartRoundToSentOrReceivedBlock,
+			durationSentOrReceivedBlockToReceivedSignatures),
+	}
 
 	wr.blockInfo.Title = "Block info:"
 	wr.blockInfo.RowSeparator = false

--- a/common/constants.go
+++ b/common/constants.go
@@ -315,6 +315,14 @@ const MetricNoncesPassedInCurrentEpoch = "erd_nonces_passed_in_current_epoch"
 // 100 meaning that the block has been received in the last moment of the round)
 const MetricReceivedProposedBlock = "erd_consensus_received_proposed_block"
 
+// MetricReceivedProposedBlock is the metric that specifies the moment from round start when the received block has reached the
+// current node.
+const MetricReceivedProposedBlockBody = "erd_consensus_received_sent_proposed_block_body"
+
+// MetricReceivedProof is the metric that specifies the moment from the time the block body has been sent or has reached the
+// current node until the proof was received or sent.
+const MetricReceivedProof = "erd_received_sent_proof"
+
 // MetricCreatedProposedBlock is the metric that specifies the percent of the block subround used for header and body
 // creation (0 meaning that the block was created in no-time and 100 meaning that the block creation used all the
 // subround spare duration)

--- a/consensus/spos/bls/v1/subroundBlock.go
+++ b/consensus/spos/bls/v1/subroundBlock.go
@@ -264,7 +264,9 @@ func (sr *subroundBlock) sendBlockBody(bodyHandler data.BodyHandler, marshalized
 	}
 
 	log.Debug("step 1: block body has been sent")
-
+	metricsTime := time.Since(sr.RoundHandler().TimeStamp()).Nanoseconds()
+	defer sr.AppStatusHandler().SetUInt64Value(common.MetricReceivedProposedBlockBody, uint64(metricsTime))
+	log.Debug("Sent block body", "time", metricsTime)
 	sr.SetBody(bodyHandler)
 
 	return true
@@ -484,6 +486,10 @@ func (sr *subroundBlock) receivedBlockBody(ctx context.Context, cnsDta *consensu
 	}
 
 	log.Debug("step 1: block body has been received")
+
+	metricsTime := time.Since(sr.RoundHandler().TimeStamp()).Nanoseconds()
+	defer sr.AppStatusHandler().SetUInt64Value(common.MetricReceivedProposedBlockBody, uint64(metricsTime))
+	log.Debug("Sent block body", "time (s)", metricsTime)
 
 	blockProcessedWithSuccess := sr.processReceivedBlock(ctx, cnsDta)
 

--- a/consensus/spos/bls/v2/subroundBlock.go
+++ b/consensus/spos/bls/v2/subroundBlock.go
@@ -255,6 +255,9 @@ func (sr *subroundBlock) sendBlockBody(
 
 	log.Debug("step 1: block body has been sent")
 
+	metricsTime := time.Since(sr.RoundHandler().TimeStamp()).Nanoseconds()
+	defer sr.AppStatusHandler().SetUInt64Value(common.MetricReceivedProposedBlockBody, uint64(metricsTime))
+	log.Debug("Sent block body", "time", metricsTime)
 	sr.SetBody(bodyHandler)
 
 	return true
@@ -383,6 +386,9 @@ func (sr *subroundBlock) receivedBlockBody(ctx context.Context, cnsDta *consensu
 	}
 
 	log.Debug("step 1: block body has been received")
+	metricsTime := time.Since(sr.RoundHandler().TimeStamp()).Nanoseconds()
+	defer sr.AppStatusHandler().SetUInt64Value(common.MetricReceivedProposedBlockBody, uint64(metricsTime))
+	log.Debug("Received block body", "time", metricsTime)
 
 	blockProcessedWithSuccess := sr.processReceivedBlock(ctx, cnsDta.RoundIndex, cnsDta.PubKey)
 

--- a/consensus/spos/bls/v2/subroundEndRound.go
+++ b/consensus/spos/bls/v2/subroundEndRound.go
@@ -118,7 +118,7 @@ func (sr *subroundEndRound) receivedProof(proof consensus.ProofHandler) {
 	log.Debug("step 3: block header final info has been received",
 		"PubKeysBitmap", proof.GetPubKeysBitmap(),
 		"AggregateSignature", proof.GetAggregatedSignature(),
-		"HederHash", proof.GetHeaderHash())
+		"HeaderHash", proof.GetHeaderHash())
 
 	sr.doEndRoundJobByNode()
 }
@@ -930,6 +930,10 @@ func (sr *subroundEndRound) checkReceivedSignatures() bool {
 			"signatures received", numSigs,
 			"total signatures", len(sr.ConsensusGroup()),
 			"threshold", threshold)
+
+		metricsTime := time.Since(sr.RoundHandler().TimeStamp()).Nanoseconds()
+		defer sr.AppStatusHandler().SetUInt64Value(common.MetricReceivedProof, uint64(metricsTime))
+		log.Warn("received proof", "timestamp (ns)", metricsTime)
 
 		return true
 	}


### PR DESCRIPTION

## Reasoning behind the pull request
Analyze which new Supernova metrics are useful to be displayed to show if node operation is correct (e.g execution results lagging).
  
## Proposed changes
- Added metrics for received/sent block body and received/sent proof
- Added in Termui metrics for delay between  (start round, received block) as well as  (received block, received signatures)

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
