### PR TITLE
Get timestamp for specified round

### DIFF
--- a/consensus/interface.go
+++ b/consensus/interface.go
@@ -23,6 +23,7 @@ type RoundHandler interface {
 	TimeStamp() time.Time
 	TimeDuration() time.Duration
 	RemainingTime(startTime time.Time, maxTime time.Duration) time.Duration
+	GetTimeStampForRound(round uint64) uint64
 	IsInterfaceNil() bool
 }
 

--- a/consensus/round/round_test.go
+++ b/consensus/round/round_test.go
@@ -191,3 +191,27 @@ func TestRound_BeforeGenesis(t *testing.T) {
 	rnd.UpdateRound(genesisTime, currentTime)
 	require.False(t, rnd.BeforeGenesis())
 }
+
+func TestRound_GetTimeStampForRound(t *testing.T) {
+	t.Parallel()
+
+	genesisTime := time.Now()
+
+	syncTimerMock := &consensusMocks.SyncTimerMock{}
+
+	startRound := int64(0)
+	rnd, _ := round.NewRound(genesisTime, genesisTime, roundTimeDuration, syncTimerMock, startRound)
+	require.True(t, rnd.BeforeGenesis())
+
+	roundTimeStamp := rnd.GetTimeStampForRound(0)
+	expRoundTimeStamp := genesisTime.Add(0 * roundTimeDuration)
+	require.Equal(t, uint64(expRoundTimeStamp.UnixMilli()), roundTimeStamp)
+
+	roundTimeStamp = rnd.GetTimeStampForRound(10)
+	expRoundTimeStamp = genesisTime.Add(10 * roundTimeDuration)
+	require.Equal(t, uint64(expRoundTimeStamp.UnixMilli()), roundTimeStamp)
+
+	roundTimeStamp = rnd.GetTimeStampForRound(1000)
+	expRoundTimeStamp = genesisTime.Add(1000 * roundTimeDuration)
+	require.Equal(t, uint64(expRoundTimeStamp.UnixMilli()), roundTimeStamp)
+}

--- a/factory/mock/rounderMock.go
+++ b/factory/mock/rounderMock.go
@@ -72,6 +72,11 @@ func (rndm *RoundHandlerMock) RemainingTime(_ time.Time, _ time.Duration) time.D
 	return rndm.RoundTimeDuration
 }
 
+// GetTimeStampForRound returns 0
+func (rndm *RoundHandlerMock) GetTimeStampForRound(round uint64) uint64 {
+	return 0
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (rndm *RoundHandlerMock) IsInterfaceNil() bool {
 	return rndm == nil

--- a/genesis/process/disabled/roundHandler.go
+++ b/genesis/process/disabled/roundHandler.go
@@ -39,6 +39,11 @@ func (rh *RoundHandler) RemainingTime(startTime time.Time, maxTime time.Duration
 func (rh *RoundHandler) IncrementIndex() {
 }
 
+// GetTimeStampForRound -
+func (rh *RoundHandler) GetTimeStampForRound(round uint64) uint64 {
+	return 0
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (rh *RoundHandler) IsInterfaceNil() bool {
 	return rh == nil

--- a/integrationTests/mock/roundHandlerMock.go
+++ b/integrationTests/mock/roundHandlerMock.go
@@ -53,6 +53,11 @@ func (mock *RoundHandlerMock) RemainingTime(_ time.Time, _ time.Duration) time.D
 	return mock.RemainingTimeField
 }
 
+// GetTimeStampForRound -
+func (mock *RoundHandlerMock) GetTimeStampForRound(round uint64) uint64 {
+	return 0
+}
+
 // IsInterfaceNil -
 func (mock *RoundHandlerMock) IsInterfaceNil() bool {
 	return mock == nil

--- a/node/chainSimulator/components/manualRoundHandler.go
+++ b/node/chainSimulator/components/manualRoundHandler.go
@@ -65,6 +65,13 @@ func (handler *manualRoundHandler) RemainingTime(_ time.Time, maxTime time.Durat
 	return maxTime
 }
 
+// GetTimeStampForRound -
+func (handler *manualRoundHandler) GetTimeStampForRound(round uint64) uint64 {
+	timeFromGenesis := handler.roundDuration * time.Duration(round)
+	timestamp := time.Unix(handler.genesisTimeStamp, 0).Add(timeFromGenesis)
+	return uint64(timestamp.UnixMilli())
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (handler *manualRoundHandler) IsInterfaceNil() bool {
 	return handler == nil

--- a/node/mock/rounderMock.go
+++ b/node/mock/rounderMock.go
@@ -8,12 +8,13 @@ import (
 type RoundHandlerMock struct {
 	index int64
 
-	IndexCalled         func() int64
-	TimeDurationCalled  func() time.Duration
-	TimeStampCalled     func() time.Time
-	UpdateRoundCalled   func(time.Time, time.Time)
-	RemainingTimeCalled func(startTime time.Time, maxTime time.Duration) time.Duration
-	BeforeGenesisCalled func() bool
+	IndexCalled                func() int64
+	TimeDurationCalled         func() time.Duration
+	TimeStampCalled            func() time.Time
+	UpdateRoundCalled          func(time.Time, time.Time)
+	RemainingTimeCalled        func(startTime time.Time, maxTime time.Duration) time.Duration
+	BeforeGenesisCalled        func() bool
+	GetTimeStampForRoundCalled func(round uint64) uint64
 }
 
 // BeforeGenesis -
@@ -71,6 +72,15 @@ func (rndm *RoundHandlerMock) RemainingTime(startTime time.Time, maxTime time.Du
 	}
 
 	return 4000 * time.Millisecond
+}
+
+// GetTimeStampForRound -
+func (rndm *RoundHandlerMock) GetTimeStampForRound(round uint64) uint64 {
+	if rndm.GetTimeStampForRoundCalled != nil {
+		return rndm.GetTimeStampForRoundCalled(round)
+	}
+
+	return 0
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/process/mock/rounderMock.go
+++ b/process/mock/rounderMock.go
@@ -59,6 +59,11 @@ func (rndm *RoundHandlerMock) RemainingTime(_ time.Time, _ time.Duration) time.D
 	return rndm.RoundTimeDuration
 }
 
+// GetTimeStampForRound -
+func (rndm *RoundHandlerMock) GetTimeStampForRound(round uint64) uint64 {
+	return 0
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (rndm *RoundHandlerMock) IsInterfaceNil() bool {
 	return rndm == nil

--- a/testscommon/consensus/rounderMock.go
+++ b/testscommon/consensus/rounderMock.go
@@ -8,12 +8,13 @@ import (
 type RoundHandlerMock struct {
 	RoundIndex int64
 
-	IndexCalled         func() int64
-	TimeDurationCalled  func() time.Duration
-	TimeStampCalled     func() time.Time
-	UpdateRoundCalled   func(time.Time, time.Time)
-	RemainingTimeCalled func(startTime time.Time, maxTime time.Duration) time.Duration
-	BeforeGenesisCalled func() bool
+	IndexCalled                func() int64
+	TimeDurationCalled         func() time.Duration
+	TimeStampCalled            func() time.Time
+	UpdateRoundCalled          func(time.Time, time.Time)
+	RemainingTimeCalled        func(startTime time.Time, maxTime time.Duration) time.Duration
+	GetTimeStampForRoundCalled func(round uint64) uint64
+	BeforeGenesisCalled        func() bool
 }
 
 // BeforeGenesis -
@@ -71,6 +72,15 @@ func (rndm *RoundHandlerMock) RemainingTime(startTime time.Time, maxTime time.Du
 	}
 
 	return 4000 * time.Millisecond
+}
+
+// GetTimeStampForRound -
+func (rndm *RoundHandlerMock) GetTimeStampForRound(round uint64) uint64 {
+	if rndm.GetTimeStampForRoundCalled != nil {
+		return rndm.GetTimeStampForRoundCalled(round)
+	}
+
+	return 0
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/testscommon/roundHandlerMock.go
+++ b/testscommon/roundHandlerMock.go
@@ -10,13 +10,14 @@ type RoundHandlerMock struct {
 	indexMut sync.RWMutex
 	index    int64
 
-	IndexCalled          func() int64
-	TimeDurationCalled   func() time.Duration
-	TimeStampCalled      func() time.Time
-	UpdateRoundCalled    func(time.Time, time.Time)
-	RemainingTimeCalled  func(startTime time.Time, maxTime time.Duration) time.Duration
-	BeforeGenesisCalled  func() bool
-	IncrementIndexCalled func()
+	IndexCalled                func() int64
+	TimeDurationCalled         func() time.Duration
+	TimeStampCalled            func() time.Time
+	UpdateRoundCalled          func(time.Time, time.Time)
+	RemainingTimeCalled        func(startTime time.Time, maxTime time.Duration) time.Duration
+	BeforeGenesisCalled        func() bool
+	IncrementIndexCalled       func()
+	GetTimeStampForRoundCalled func(round uint64) uint64
 }
 
 // BeforeGenesis -
@@ -86,6 +87,15 @@ func (rndm *RoundHandlerMock) IncrementIndex() {
 	if rndm.IncrementIndexCalled != nil {
 		rndm.IncrementIndexCalled()
 	}
+}
+
+// GetTimeStampForRound -
+func (rndm *RoundHandlerMock) GetTimeStampForRound(round uint64) uint64 {
+	if rndm.GetTimeStampForRoundCalled != nil {
+		return rndm.GetTimeStampForRoundCalled(round)
+	}
+
+	return 0
 }
 
 // IsInterfaceNil returns true if there is no value under the interface


### PR DESCRIPTION
## Reasoning behind the pull request
- We need to be able to determine timestamp for a specified round
  
## Proposed changes
- Extend round handler component to export timestamp as unix milliseconds for the specified round
- Adapted unit tests and mocks

## Testing procedure
- To be tested with the feature branch

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
