### PR TITLE
Supernova TxPool: Fixed Failing Tests

### DIFF
--- a/update/sync/syncEpochStartShardHeaders_test.go
+++ b/update/sync/syncEpochStartShardHeaders_test.go
@@ -498,7 +498,7 @@ func TestSyncEpochStartShardHeader_TwoConsecutiveProofsWithSameHeaderHash(t *tes
 		syncer.receivedProof(nonEpochStartProof)
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	err = syncer.SyncEpochStartShardHeader(shardID, epoch, startNonce, ctx)
@@ -562,7 +562,7 @@ func TestSyncEpochStartShardHeader_ProofsBeforeHeaderShouldWork(t *testing.T) {
 		syncer.receivedHeader(epochStartHeader, headerHash)
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	err = syncer.SyncEpochStartShardHeader(shardID, epoch, startNonce, ctx)
@@ -628,7 +628,7 @@ func TestSyncEpochStartShardHeader_ShouldWorkWithoutAndromedaActivated(t *testin
 		syncer.receivedHeader(epochStartHeader, headerHash)
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	err = syncer.SyncEpochStartShardHeader(shardID, epoch, startNonce, ctx)


### PR DESCRIPTION
## Reasoning behind the pull request
- Fixed **TestSyncEpochStartShardHeader_ProofsBeforeHeaderShouldWork** by increasing timeout.
  
## Proposed changes
## Testing procedure
## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
