### PR TITLE
Supernova TxPool Part2: Check Tracked Txs Fixes

### DIFF
--- a/txcache/autoClean.go
+++ b/txcache/autoClean.go
@@ -86,7 +86,9 @@ func (cache *TxCache) RemoveSweepableTxs(accountsProvider common.AccountNoncePro
 	if len(evicted) > 0 {
 		txs := cache.txByHash.GetTxsBulk(evicted)
 		txTracker := newTransactionsTracker(cache.tracker, txs)
-		cache.txByHash.RemoveTxsBulkWithTrackingCheck(evicted, txTracker)
+
+		untrackedEvicted := txTracker.GetBulkOfUntrackedTransactions(txs)
+		cache.txByHash.RemoveTxsBulk(untrackedEvicted)
 	}
 
 	logRemove.Debug("TxCache.RemoveSweepableTxs end",

--- a/txcache/eviction.go
+++ b/txcache/eviction.go
@@ -159,12 +159,16 @@ func (cache *TxCache) evictLeastLikelyToSelectTransactions() *evictionJournal {
 		// Remove those transactions from "txByHash".
 		txs := cache.txByHash.GetTxsBulk(transactionsToEvictHashes)
 		txTracker := newTransactionsTracker(cache.tracker, txs)
-		_ = cache.txByHash.RemoveTxsBulkWithTrackingCheck(transactionsToEvictHashes, txTracker)
+
+		logRemove.Debug("evictLeastLikelyToSelectTransactions", "pass", pass, "num evicted", len(transactionsToEvict))
+
+		untrackedTransactionsToEvictHashes := txTracker.GetBulkOfUntrackedTransactions(txs)
+		_ = cache.txByHash.RemoveTxsBulk(untrackedTransactionsToEvictHashes)
 
 		journal.numEvictedByPass = append(journal.numEvictedByPass, len(transactionsToEvict))
 		journal.numEvicted += len(transactionsToEvict)
 
-		logRemove.Debug("evictLeastLikelyToSelectTransactions", "pass", pass, "num evicted", len(transactionsToEvict))
+		logRemove.Debug("evictLeastLikelyToSelectTransactions", "pass", pass, "num untracked evicted", len(untrackedTransactionsToEvictHashes))
 	}
 
 	return journal

--- a/txcache/interface.go
+++ b/txcache/interface.go
@@ -32,6 +32,6 @@ type txCacheForSelectionTracker interface {
 
 // TransactionsTracker provides the transactionsTracker methods used by other components
 type TransactionsTracker interface {
-	IsTransactionTracked(transaction *WrappedTransaction) bool
+	GetBulkOfUntrackedTransactions(transactions []*WrappedTransaction) [][]byte
 	IsInterfaceNil() bool
 }

--- a/txcache/selectionTracker.go
+++ b/txcache/selectionTracker.go
@@ -448,3 +448,15 @@ func (st *selectionTracker) getVirtualNonceOfAccountWithRootHash(
 
 	return breadcrumb.lastNonce.Value + 1, latestCommittedBlock.rootHash, nil
 }
+
+func (st *selectionTracker) getTrackedBlocks() map[string]*trackedBlock {
+	st.mutTracker.RLock()
+	defer st.mutTracker.RUnlock()
+
+	copyOfTrackedBlocks := make(map[string]*trackedBlock, len(st.blocks))
+	for key, value := range st.blocks {
+		copyOfTrackedBlocks[key] = value
+	}
+
+	return copyOfTrackedBlocks
+}

--- a/txcache/transactionsTracker.go
+++ b/txcache/transactionsTracker.go
@@ -91,7 +91,6 @@ func (txTracker *transactionsTracker) updateRangeWithBreadcrumb(rangeOfSender *a
 
 // isTransactionTracked checks if a transaction is still in the tracked blocks of the SelectionTracker
 // TODO the method ignores (at the moment) some possible forks. This should be fixed
-// TODO Analyze the next scenario: a sender sends more transactions with same nonce, but only one of them is tracked, the others aren't.
 func (txTracker *transactionsTracker) isTransactionTracked(transaction *WrappedTransaction) bool {
 	if transaction == nil || transaction.Tx == nil {
 		return false

--- a/txcache/transactionsTracker.go
+++ b/txcache/transactionsTracker.go
@@ -117,8 +117,9 @@ func (txTracker *transactionsTracker) isTransactionTracked(transaction *WrappedT
 	return true
 }
 
+// GetBulkOfUntrackedTransactions returns the txHashes of the untracked transactions
 func (txTracker *transactionsTracker) GetBulkOfUntrackedTransactions(transactions []*WrappedTransaction) [][]byte {
-	untrackedTransactions := make([][]byte, 0, len(transactions))
+	untrackedTransactions := make([][]byte, 0)
 	for _, tx := range transactions {
 		if tx == nil || tx.Tx == nil {
 			continue

--- a/txcache/transactionsTracker.go
+++ b/txcache/transactionsTracker.go
@@ -118,15 +118,14 @@ func (txTracker *transactionsTracker) isTransactionTracked(transaction *WrappedT
 }
 
 func (txTracker *transactionsTracker) GetBulkOfUntrackedTransactions(transactions []*WrappedTransaction) [][]byte {
-	untrackedTransactions := make([][]byte, 0)
+	untrackedTransactions := make([][]byte, 0, len(transactions))
 	for _, tx := range transactions {
 		if tx == nil || tx.Tx == nil {
 			continue
 		}
 
-		txHash := tx.TxHash
 		if !txTracker.isTransactionTracked(tx) {
-			untrackedTransactions = append(untrackedTransactions, txHash)
+			untrackedTransactions = append(untrackedTransactions, tx.TxHash)
 		}
 	}
 

--- a/txcache/transactionsTracker.go
+++ b/txcache/transactionsTracker.go
@@ -91,10 +91,10 @@ func (txTracker *transactionsTracker) updateRangeWithBreadcrumb(rangeOfSender *a
 	return nil
 }
 
-// IsTransactionTracked checks if a transaction is still in the tracked blocks of the SelectionTracker
+// isTransactionTracked checks if a transaction is still in the tracked blocks of the SelectionTracker
 // TODO the method ignores (at the moment) some possible forks. This should be fixed
 // TODO Analyze the next scenario: a sender sends more transactions with same nonce, but only one of them is tracked, the others aren't.
-func (txTracker *transactionsTracker) IsTransactionTracked(transaction *WrappedTransaction) bool {
+func (txTracker *transactionsTracker) isTransactionTracked(transaction *WrappedTransaction) bool {
 	if transaction == nil || transaction.Tx == nil {
 		return false
 	}
@@ -119,6 +119,22 @@ func (txTracker *transactionsTracker) IsTransactionTracked(transaction *WrappedT
 	}
 
 	return true
+}
+
+func (txTracker *transactionsTracker) GetBulkOfUntrackedTransactions(transactions []*WrappedTransaction) [][]byte {
+	untrackedTransactions := make([][]byte, 0)
+	for _, tx := range transactions {
+		if tx == nil || tx.Tx == nil {
+			continue
+		}
+
+		txHash := tx.TxHash
+		if !txTracker.isTransactionTracked(tx) {
+			untrackedTransactions = append(untrackedTransactions, txHash)
+		}
+	}
+
+	return untrackedTransactions
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/txcache/transactionsTracker.go
+++ b/txcache/transactionsTracker.go
@@ -51,10 +51,9 @@ func (txTracker *transactionsTracker) createAccountsWithDefaultRange(transaction
 
 // updateAccountsWithRange updates all the saved accounts with the range extracted from breadcrumbs
 func (txTracker *transactionsTracker) updateAccountsWithRange(tracker *selectionTracker) {
-	tracker.mutTracker.RLock()
-	defer tracker.mutTracker.RUnlock()
+	trackedBlocks := tracker.getTrackedBlocks()
 
-	for _, tb := range tracker.blocks {
+	for _, tb := range trackedBlocks {
 		txTracker.updateRangesWithBreadcrumbs(tb)
 	}
 }

--- a/txcache/transactionsTracker_test.go
+++ b/txcache/transactionsTracker_test.go
@@ -81,7 +81,8 @@ func Test_IsTransactionTracked(t *testing.T) {
 		createTx([]byte("txHash4"), "alice", 14),
 		createTx([]byte("txHash5"), "alice", 15).withRelayer([]byte("bob")).withGasLimit(100_000),
 		createTx([]byte("txHash6"), "eve", 11).withRelayer([]byte("alice")).withGasLimit(100_000),
-		// this one is not proposed. however, will be detected as "tracked", because it has the same nonce with a tracked one.
+		// This one is not proposed. However, will be detected as "tracked" because it has the same nonce with as a tracked one.
+		// This is not critical. It is ok that a sender has a specific nonce "protected".
 		createTx([]byte("txHash7"), "eve", 11).withRelayer([]byte("alice")).withGasLimit(100_000),
 	}
 

--- a/txcache/transactionsTracker_test.go
+++ b/txcache/transactionsTracker_test.go
@@ -81,6 +81,7 @@ func Test_IsTransactionTracked(t *testing.T) {
 		createTx([]byte("txHash4"), "alice", 14),
 		createTx([]byte("txHash5"), "alice", 15).withRelayer([]byte("bob")).withGasLimit(100_000),
 		createTx([]byte("txHash6"), "eve", 11).withRelayer([]byte("alice")).withGasLimit(100_000),
+		// this one is not proposed. however, will be detected as "tracked", because it has the same nonce with a tracked one.
 		createTx([]byte("txHash7"), "eve", 11).withRelayer([]byte("alice")).withGasLimit(100_000),
 	}
 
@@ -198,6 +199,17 @@ func Test_IsTransactionTracked(t *testing.T) {
 		t.Parallel()
 
 		tx1 := createTx([]byte("txHash2"), "carol", 12)
+		txTracker := newTransactionsTracker(tracker, []*WrappedTransaction{
+			tx1,
+		})
+
+		require.False(t, txTracker.isTransactionTracked(tx1))
+	})
+
+	t.Run("should return true for any transaction of sender with a tracked nonce", func(t *testing.T) {
+		t.Parallel()
+
+		tx1 := createTx([]byte("txHash7"), "eve", 12)
 		txTracker := newTransactionsTracker(tracker, []*WrappedTransaction{
 			tx1,
 		})

--- a/txcache/txByHashMap.go
+++ b/txcache/txByHashMap.go
@@ -2,7 +2,6 @@ package txcache
 
 import (
 	"github.com/multiversx/mx-chain-core-go/core/atomic"
-	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-go/txcache/maps"
 )
 
@@ -53,18 +52,6 @@ func (txMap *txByHashMap) removeTx(txHash string) (*WrappedTransaction, bool) {
 	return tx, true
 }
 
-// removeTxWithTrackingCheck removes a transaction from the map but checks if it is still tracked
-// TODO should do the check at a higher level
-func (txMap *txByHashMap) removeTxWithTrackingCheck(txHash string, txTracker TransactionsTracker) bool {
-	tx, ok := txMap.getTx(txHash)
-	if ok && txTracker.IsTransactionTracked(tx) {
-		return false
-	}
-
-	_, ok = txMap.removeTx(txHash)
-	return ok
-}
-
 // getTx gets a transaction from the map
 func (txMap *txByHashMap) getTx(txHash string) (*WrappedTransaction, bool) {
 	txUntyped, ok := txMap.backingMap.Get(txHash)
@@ -99,24 +86,6 @@ func (txMap *txByHashMap) RemoveTxsBulk(txHashes [][]byte) uint32 {
 
 	for _, txHash := range txHashes {
 		_, removed := txMap.removeTx(string(txHash))
-		if removed {
-			numRemoved++
-		}
-	}
-
-	return numRemoved
-}
-
-// RemoveTxsBulkWithTrackingCheck removes transactions, in bulk, but checks if each tx can be removed
-// TODO should do the check at a higher level
-func (txMap *txByHashMap) RemoveTxsBulkWithTrackingCheck(txHashes [][]byte, txTracker TransactionsTracker) uint32 {
-	if check.IfNil(txTracker) {
-		return 0
-	}
-
-	numRemoved := uint32(0)
-	for _, txHash := range txHashes {
-		removed := txMap.removeTxWithTrackingCheck(string(txHash), txTracker)
 		if removed {
 			numRemoved++
 		}

--- a/txcache/txCache.go
+++ b/txcache/txCache.go
@@ -94,7 +94,11 @@ func (cache *TxCache) AddTx(tx *WrappedTransaction) (ok bool, added bool) {
 		logRemove.Trace("TxCache.AddTx with eviction", "sender", tx.Tx.GetSndAddr(), "num evicted txs", len(evicted))
 		txs := cache.txByHash.GetTxsBulk(evicted)
 		txTracker := newTransactionsTracker(cache.tracker, txs)
-		_ = cache.txByHash.RemoveTxsBulkWithTrackingCheck(evicted, txTracker)
+
+		untrackedEvicted := txTracker.GetBulkOfUntrackedTransactions(txs)
+		_ = cache.txByHash.RemoveTxsBulk(untrackedEvicted)
+
+		logRemove.Trace("TxCache.AddTx with eviction and tracking check", "sender", tx.Tx.GetSndAddr(), "num evicted txs with tracking check", len(untrackedEvicted))
 	}
 
 	// The return value "added" is true even if transaction added, but then removed due to limits be sender.


### PR DESCRIPTION
## Reasoning behind the pull request
- Solved some TODOs.
  
## Proposed changes
- moved the check of the transaction **outside of txByHashMap.**
- create a method in the transactionsTracker that **returns untracked txs.** 
- added some unit tests, removed some TODO comments.
- added method for **getting all of the tracked blocks** using a copy of the map.

## Testing procedure
## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
