### PR TITLE
Supernova TxPool: Bug fix - update first nonce of fee payer breadcrumb

### DIFF
--- a/txcache/accountBreadcrumb.go
+++ b/txcache/accountBreadcrumb.go
@@ -28,13 +28,22 @@ func (breadcrumb *accountBreadcrumb) accumulateConsumedBalance(transferredValue 
 	}
 }
 
-func (breadcrumb *accountBreadcrumb) updateLastNonce(lastNonce core.OptionalUint64) error {
+func (breadcrumb *accountBreadcrumb) updateFirstNonce(initialNonce core.OptionalUint64) {
+	breadcrumb.firstNonce = initialNonce
+}
+
+func (breadcrumb *accountBreadcrumb) updateNonceRange(lastNonce core.OptionalUint64) error {
 	if !lastNonce.HasValue {
 		return errReceivedLastNonceNotSet
 	}
 	if breadcrumb.lastNonce.HasValue && breadcrumb.lastNonce.Value+1 != lastNonce.Value {
 		// validate that we have txs with sequential nonces inside the tracked block used for breadcrumbs
 		return errNonceGap
+	}
+
+	// if the account was previously a relayer, the first nonce should not remain unset
+	if !breadcrumb.firstNonce.HasValue {
+		breadcrumb.updateFirstNonce(lastNonce)
 	}
 
 	breadcrumb.lastNonce = lastNonce

--- a/txcache/accountBreadcrumb_test.go
+++ b/txcache/accountBreadcrumb_test.go
@@ -1,6 +1,7 @@
 package txcache
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core"
@@ -49,7 +50,7 @@ func Test_isRelayer(t *testing.T) {
 	})
 }
 
-func Test_updateLastNonce(t *testing.T) {
+func Test_updateNonceRange(t *testing.T) {
 	t.Parallel()
 
 	t.Run("should return receivedLastNonceNotSet the received lastNonce does not have value", func(t *testing.T) {
@@ -72,7 +73,7 @@ func Test_updateLastNonce(t *testing.T) {
 			HasValue: false,
 		}
 
-		err := breadcrumb.updateLastNonce(receivedLastNonce)
+		err := breadcrumb.updateNonceRange(receivedLastNonce)
 		require.Equal(t, errReceivedLastNonceNotSet, err)
 		require.Equal(t, uint64(1), breadcrumb.lastNonce.Value)
 	})
@@ -97,7 +98,7 @@ func Test_updateLastNonce(t *testing.T) {
 			HasValue: true,
 		}
 
-		err := breadcrumb.updateLastNonce(receivedLastNonce)
+		err := breadcrumb.updateNonceRange(receivedLastNonce)
 		require.Equal(t, errNonceGap, err)
 	})
 
@@ -121,9 +122,34 @@ func Test_updateLastNonce(t *testing.T) {
 			HasValue: true,
 		}
 
-		err := breadcrumb.updateLastNonce(receivedLastNonce)
+		err := breadcrumb.updateNonceRange(receivedLastNonce)
 		require.Nil(t, err)
 		require.Equal(t, uint64(4), breadcrumb.lastNonce.Value)
+	})
+
+	t.Run("should update the first nonce in case of relayer", func(t *testing.T) {
+		t.Parallel()
+
+		feePayerBreadcrumb := accountBreadcrumb{
+			firstNonce: core.OptionalUint64{
+				Value:    0,
+				HasValue: false,
+			},
+			lastNonce: core.OptionalUint64{
+				Value:    3,
+				HasValue: false,
+			},
+			consumedBalance: big.NewInt(10),
+		}
+
+		err := feePayerBreadcrumb.updateNonceRange(core.OptionalUint64{
+			Value:    3,
+			HasValue: true,
+		})
+		require.Nil(t, err)
+
+		require.Equal(t, uint64(3), feePayerBreadcrumb.firstNonce.Value)
+		require.Equal(t, uint64(3), feePayerBreadcrumb.lastNonce.Value)
 	})
 }
 

--- a/txcache/trackedBlock.go
+++ b/txcache/trackedBlock.go
@@ -69,7 +69,7 @@ func (tb *trackedBlock) compileBreadcrumb(tx *WrappedTransaction) error {
 	transferredValue := tx.TransferredValue
 	senderBreadcrumb.accumulateConsumedBalance(transferredValue)
 
-	err := senderBreadcrumb.updateLastNonce(core.OptionalUint64{
+	err := senderBreadcrumb.updateNonceRange(core.OptionalUint64{
 		Value:    latestNonce,
 		HasValue: true,
 	})

--- a/txcache/trackedBlock_test.go
+++ b/txcache/trackedBlock_test.go
@@ -331,6 +331,68 @@ func TestTrackedBlock_compileBreadcrumbs(t *testing.T) {
 			require.True(t, ok)
 			requireEqualBreadcrumbs(t, expectedBreadcrumbs[key], block.breadcrumbsByAddress[key])
 		}
+	})
 
+	t.Run("sender becomes fee payer, fee payer becomes sender", func(t *testing.T) {
+		t.Parallel()
+
+		block := newTrackedBlock(0, []byte("blockHash1"), []byte("blockRootHash1"), []byte("blockPrevHash1"))
+
+		txs := []*WrappedTransaction{
+			{
+				Tx: &transaction.Transaction{
+					SndAddr: []byte("alice"),
+					Nonce:   1,
+				},
+				FeePayer:         []byte("bob"),
+				Fee:              big.NewInt(2),
+				TransferredValue: big.NewInt(5),
+			},
+			{
+				Tx: &transaction.Transaction{
+					SndAddr: []byte("bob"),
+					Nonce:   4,
+				},
+				FeePayer:         []byte("alice"),
+				Fee:              big.NewInt(3),
+				TransferredValue: big.NewInt(10),
+			},
+			{
+				Tx: &transaction.Transaction{
+					SndAddr: []byte("alice"),
+					Nonce:   2,
+				},
+				TransferredValue: big.NewInt(10),
+			},
+			{
+				Tx: &transaction.Transaction{
+					SndAddr: []byte("bob"),
+					Nonce:   5,
+				},
+				TransferredValue: big.NewInt(10),
+			},
+		}
+
+		err := block.compileBreadcrumbs(txs)
+		require.NoError(t, err)
+
+		aliceBreadcrumb := newAccountBreadcrumb(core.OptionalUint64{Value: 1, HasValue: true})
+		aliceBreadcrumb.accumulateConsumedBalance(big.NewInt(18))
+		aliceBreadcrumb.lastNonce = core.OptionalUint64{Value: 2, HasValue: true}
+
+		bobBreadcrumb := newAccountBreadcrumb(core.OptionalUint64{Value: 4, HasValue: true})
+		bobBreadcrumb.accumulateConsumedBalance(big.NewInt(22))
+		bobBreadcrumb.lastNonce = core.OptionalUint64{Value: 5, HasValue: true}
+
+		expectedBreadcrumbs := map[string]*accountBreadcrumb{
+			"alice": aliceBreadcrumb,
+			"bob":   bobBreadcrumb,
+		}
+
+		for key := range expectedBreadcrumbs {
+			_, ok := block.breadcrumbsByAddress[key]
+			require.True(t, ok)
+			requireEqualBreadcrumbs(t, expectedBreadcrumbs[key], block.breadcrumbsByAddress[key])
+		}
 	})
 }


### PR DESCRIPTION
## Reasoning behind the pull request
- At the moment, an account that starts as relayer in a specific tracked block, if it has some transactions also as sender, the first nonce of the breadcrumb is not affected, only the last nonce. This leads to incorrect validation of that breadcrumb
  
## Proposed changes
- update the first nonce of the fee payer breadcrumb in this specific case
- unit tests


## Testing procedure
## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
