### PR TITLE
Supernova TxPool Part2: Reset SelectionTracker

### DIFF
--- a/dataRetriever/txpool/interface.go
+++ b/dataRetriever/txpool/interface.go
@@ -24,6 +24,7 @@ type txCache interface {
 	GetTransactionsPoolForSender(sender string) []*txcache.WrappedTransaction
 	OnProposedBlock(blockHash []byte, blockBody *block.Body, blockHeader data.HeaderHandler, accountsProvider common.AccountNonceAndBalanceProvider, blockchainInfo common.BlockchainInfo) error
 	OnExecutedBlock(blockHeader data.HeaderHandler) error
+	ResetTracker()
 	Cleanup(accountsProvider common.AccountNonceProvider, randomness uint64, maxNum int, cleanupLoopMaximumDurationMs time.Duration) uint64
 }
 

--- a/txcache/globalAccountBreadcrumbsCompiler.go
+++ b/txcache/globalAccountBreadcrumbsCompiler.go
@@ -111,3 +111,14 @@ func (gabc *globalAccountBreadcrumbsCompiler) getGlobalBreadcrumbs() map[string]
 
 	return globalBreadcrumbsCopy
 }
+
+// cleanGlobalBreadcrumbs resets the global accounts breadcrumbs
+func (gabc *globalAccountBreadcrumbsCompiler) cleanGlobalBreadcrumbs() {
+	gabc.mutCompiler.Lock()
+	defer gabc.mutCompiler.Unlock()
+
+	log.Debug("globalAccountBreadcrumbsCompiler.cleanGlobalBreadcrumbs removing all breadcrumbs",
+		"len(globalAccountBreadcrumbs)", len(gabc.globalAccountBreadcrumbs))
+
+	gabc.globalAccountBreadcrumbs = make(map[string]*globalAccountBreadcrumb)
+}

--- a/txcache/globalAccountBreadcrumbsCompiler_test.go
+++ b/txcache/globalAccountBreadcrumbsCompiler_test.go
@@ -576,3 +576,18 @@ func Test_shouldWork(t *testing.T) {
 		requireEqualGlobalAccountsBreadcrumbs(t, expectedGlobalBreadcrumbs, gabc.globalAccountBreadcrumbs)
 	})
 }
+
+func Test_cleanGlobalBreadcrumbs(t *testing.T) {
+	t.Parallel()
+
+	gabc := newGlobalAccountBreadcrumbsCompiler()
+	gabc.globalAccountBreadcrumbs = map[string]*globalAccountBreadcrumb{
+		"alice": {},
+		"bob":   {},
+	}
+
+	require.Equal(t, 2, len(gabc.globalAccountBreadcrumbs))
+
+	gabc.cleanGlobalBreadcrumbs()
+	require.Equal(t, 0, len(gabc.globalAccountBreadcrumbs))
+}

--- a/txcache/selectionTracker.go
+++ b/txcache/selectionTracker.go
@@ -11,7 +11,6 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// TODO should add a reset method which cleans the tracked blocks and the global account breadcrumbs
 // TODO rename this to proposedBlocksTracker
 type selectionTracker struct {
 	mutTracker       sync.RWMutex
@@ -341,6 +340,19 @@ func (st *selectionTracker) updateLatestRootHashNoLock(receivedNonce uint64, rec
 		st.latestRootHash = receivedRootHash
 		st.latestNonce = receivedNonce
 	}
+}
+
+// ResetTracker resets the tracked blocks and the global account breadcrumbs
+func (st *selectionTracker) ResetTracker() {
+	st.mutTracker.Lock()
+	defer st.mutTracker.Unlock()
+
+	log.Debug("selectionTracker.Clean removing all tracked blocks",
+		"len(trackedBlocks)", len(st.blocks),
+	)
+
+	st.blocks = make(map[string]*trackedBlock)
+	st.gabc.cleanGlobalBreadcrumbs()
 }
 
 // deriveVirtualSelectionSession creates a virtual selection session by transforming the global accounts breadcrumbs into virtual records

--- a/txcache/selectionTracker_test.go
+++ b/txcache/selectionTracker_test.go
@@ -1151,3 +1151,31 @@ func TestSelectionTracker_GetBulkOfUntrackedTransactions(t *testing.T) {
 	bulk := tracker.GetBulkOfUntrackedTransactions(txs)
 	require.Len(t, bulk, 4)
 }
+
+func TestSelectionTracker_ResetTracker(t *testing.T) {
+	t.Parallel()
+
+	txCache := newCacheToTest(maxNumBytesPerSenderUpperBoundTest, 6)
+	tracker, err := NewSelectionTracker(txCache, maxTrackedBlocks)
+	require.Nil(t, err)
+
+	txCache.tracker = tracker
+
+	tracker.blocks = map[string]*trackedBlock{
+		"hash1": {},
+		"hash2": {},
+	}
+
+	tracker.gabc.globalAccountBreadcrumbs = map[string]*globalAccountBreadcrumb{
+		"alice": {},
+		"bob":   {},
+		"carol": {},
+	}
+
+	require.Equal(t, 2, len(tracker.blocks))
+	require.Equal(t, 3, len(tracker.gabc.globalAccountBreadcrumbs))
+
+	tracker.ResetTracker()
+	require.Equal(t, 0, len(tracker.blocks))
+	require.Equal(t, 0, len(tracker.gabc.globalAccountBreadcrumbs))
+}

--- a/txcache/txCache.go
+++ b/txcache/txCache.go
@@ -189,6 +189,10 @@ func (cache *TxCache) OnExecutedBlock(blockHeader data.HeaderHandler) error {
 	return cache.tracker.OnExecutedBlock(blockHeader)
 }
 
+func (cache *TxCache) ResetTracker() {
+	cache.tracker.ResetTracker()
+}
+
 func (cache *TxCache) getSenders() []*txListForSender {
 	return cache.txListBySender.getSenders()
 }

--- a/txcache/txCache_test.go
+++ b/txcache/txCache_test.go
@@ -4,12 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"sort"
 	"sync"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-go/common/holders"
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/testscommon/txcachemocks"
 	"github.com/multiversx/mx-chain-storage-go/common"
@@ -624,6 +627,70 @@ func TestBenchmarkTxCache_addManyTransactionsWithSameNonce(t *testing.T) {
 	// 0.000120s (TestBenchmarkTxCache_addManyTransactionsWithSameNonce/numTransactions_=_100_(worst_case))
 	// 0.002821s (TestBenchmarkTxCache_addManyTransactionsWithSameNonce/numTransactions_=_1000_(worst_case))
 	// 0.062260s (TestBenchmarkTxCache_addManyTransactionsWithSameNonce/numTransactions_=_5_000_(worst_case))
+}
+
+func Test_ResetTracker(t *testing.T) {
+	t.Parallel()
+
+	accountsProvider := &txcachemocks.AccountNonceAndBalanceProviderMock{
+		GetAccountNonceAndBalanceCalled: func(address []byte) (uint64, *big.Int, bool, error) {
+			return 11, big.NewInt(6 * 100000 * oneBillion), true, nil
+		},
+	}
+
+	config := ConfigSourceMe{
+		Name:                        "test",
+		NumChunks:                   16,
+		NumBytesThreshold:           maxNumBytesUpperBound,
+		NumBytesPerSenderThreshold:  maxNumBytesPerSenderUpperBoundTest,
+		CountThreshold:              math.MaxUint32,
+		CountPerSenderThreshold:     math.MaxUint32,
+		EvictionEnabled:             true,
+		NumItemsToPreemptivelyEvict: 1,
+		TxCacheBoundsConfig:         createMockTxBoundsConfig(),
+	}
+
+	host := txcachemocks.NewMempoolHostMock()
+
+	cache, err := NewTxCache(config, host)
+	require.Nil(t, err)
+
+	txs := []*WrappedTransaction{
+		createTx([]byte("txHash1"), "alice", 11).withRelayer([]byte("bob")).withGasLimit(100_000),
+		createTx([]byte("txHash2"), "alice", 12),
+		createTx([]byte("txHash3"), "alice", 13),
+		createTx([]byte("txHash4"), "bob", 11),
+	}
+	for _, tx := range txs {
+		cache.AddTx(tx)
+	}
+
+	err = cache.OnProposedBlock(
+		[]byte("hash1"),
+		&block.Body{
+			MiniBlocks: []*block.MiniBlock{
+				{
+					TxHashes: [][]byte{
+						[]byte("txHash1"),
+						[]byte("txHash2"),
+						[]byte("txHash3"),
+						[]byte("txHash4"),
+					},
+				},
+			},
+		},
+		&block.Header{
+			Nonce:    uint64(0),
+			PrevHash: []byte("hash0"),
+			RootHash: []byte("rootHash0"),
+		},
+		accountsProvider,
+		holders.NewBlockchainInfo([]byte("hash0"), []byte("hash0"), 0),
+	)
+	require.Nil(t, err)
+
+	require.Equal(t, 1, len(cache.tracker.blocks))
+	require.Equal(t, 2, len(cache.tracker.getGlobalAccountsBreadcrumbs()))
 }
 
 func newUnconstrainedCacheToTest(boundsConfig config.TxCacheBoundsConfig) *TxCache {

--- a/txcache/txCache_test.go
+++ b/txcache/txCache_test.go
@@ -656,10 +656,10 @@ func Test_ResetTracker(t *testing.T) {
 	require.Nil(t, err)
 
 	txs := []*WrappedTransaction{
-		createTx([]byte("txHash1"), "alice", 11).withRelayer([]byte("bob")).withGasLimit(100_000),
-		createTx([]byte("txHash2"), "alice", 12),
-		createTx([]byte("txHash3"), "alice", 13),
-		createTx([]byte("txHash4"), "bob", 11),
+		createTx([]byte("txHash1"), "bob", 11),
+		createTx([]byte("txHash2"), "alice", 11).withRelayer([]byte("bob")).withGasLimit(100_000),
+		createTx([]byte("txHash3"), "alice", 12),
+		createTx([]byte("txHash4"), "alice", 13),
 	}
 	for _, tx := range txs {
 		cache.AddTx(tx)
@@ -691,6 +691,10 @@ func Test_ResetTracker(t *testing.T) {
 
 	require.Equal(t, 1, len(cache.tracker.blocks))
 	require.Equal(t, 2, len(cache.tracker.getGlobalAccountsBreadcrumbs()))
+
+	cache.ResetTracker()
+	require.Equal(t, 0, len(cache.tracker.blocks))
+	require.Equal(t, 0, len(cache.tracker.getGlobalAccountsBreadcrumbs()))
 }
 
 func newUnconstrainedCacheToTest(boundsConfig config.TxCacheBoundsConfig) *TxCache {


### PR DESCRIPTION
## Reasoning behind the pull request
- Currently, there is no method to reset the internal state of the selection tracker - the tracked blocks and the global account breadcrumbs.
  
## Proposed changes
- added a reset method
- added unit tests

## Testing procedure
## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
