### PR TITLE
Fix race for TestEpochStartSubscriptionHandler_NotifyAll

### DIFF
--- a/epochStart/notifier/epochStartSubscriptionHandler_test.go
+++ b/epochStart/notifier/epochStartSubscriptionHandler_test.go
@@ -188,6 +188,8 @@ func TestEpochStartSubscriptionHandler_NotifyAll(t *testing.T) {
 
 		time.Sleep(10 * time.Millisecond)
 
+		calledHandlersLock.RLock()
+		defer calledHandlersLock.RUnlock()
 		assert.Len(t, calledHandlers, 4)
 	})
 }


### PR DESCRIPTION
## Reasoning behind the pull request
**- Race detected on TestEpochStartSubscriptionHandler_NotifyAll**
  
## Proposed changes
**- added RLock before checking the len of calledHandlers.**


## Testing procedure

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
