### PR TITLE
Fixes altered accounts

### DIFF
--- a/outport/process/alteredaccounts/alteredAccountsProvider.go
+++ b/outport/process/alteredaccounts/alteredAccountsProvider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/alteredAccount"
 	"github.com/multiversx/mx-chain-core-go/data/esdt"
 	outportcore "github.com/multiversx/mx-chain-core-go/data/outport"
+	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-go/outport/process/alteredaccounts/shared"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/sharding"
@@ -279,6 +280,28 @@ func (aap *alteredAccountsProvider) extractAddressesWithBalanceChange(
 	aap.extractAddressesFromTxsHandlers(selfShardID, scrs, markedAlteredAccounts, process.SCInvoking)
 	aap.extractAddressesFromTxsHandlers(selfShardID, rewards, markedAlteredAccounts, process.RewardTx)
 	aap.extractAddressesFromTxsHandlers(selfShardID, invalidTxs, markedAlteredAccounts, process.InvalidTransaction)
+	aap.extractAddressesFromLogs(txPool.Logs, markedAlteredAccounts)
+}
+
+func (aap *alteredAccountsProvider) extractAddressesFromLogs(
+	logs []*transaction.LogData,
+	markedAlteredAccounts map[string]*markedAlteredAccount) {
+	for _, logEvent := range logs {
+		if logEvent.Log == nil {
+			continue
+		}
+		for _, event := range logEvent.Log.Events {
+			if string(event.Identifier) != core.SCDeployIdentifier {
+				continue
+			}
+			if len(event.Topics) < 1 {
+				continue
+			}
+
+			scAddress := event.Topics[0]
+			aap.addAddressWithBalanceChangeInMap(scAddress, markedAlteredAccounts, false)
+		}
+	}
 }
 
 func txsMapToTxHandlerSlice(txs map[string]*outportcore.TxInfo) []data.TransactionHandler {

--- a/outport/process/alteredaccounts/alteredAccountsProvider.go
+++ b/outport/process/alteredaccounts/alteredAccountsProvider.go
@@ -1,6 +1,7 @@
 package alteredaccounts
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"math/big"
@@ -280,10 +281,11 @@ func (aap *alteredAccountsProvider) extractAddressesWithBalanceChange(
 	aap.extractAddressesFromTxsHandlers(selfShardID, scrs, markedAlteredAccounts, process.SCInvoking)
 	aap.extractAddressesFromTxsHandlers(selfShardID, rewards, markedAlteredAccounts, process.RewardTx)
 	aap.extractAddressesFromTxsHandlers(selfShardID, invalidTxs, markedAlteredAccounts, process.InvalidTransaction)
-	aap.extractAddressesFromLogs(txPool.Logs, markedAlteredAccounts)
+	aap.extractAddressesFromLogs(selfShardID, txPool.Logs, markedAlteredAccounts)
 }
 
 func (aap *alteredAccountsProvider) extractAddressesFromLogs(
+	selfShardID uint32,
 	logs []*transaction.LogData,
 	markedAlteredAccounts map[string]*markedAlteredAccount,
 ) {
@@ -304,6 +306,13 @@ func (aap *alteredAccountsProvider) extractAddressesFromLogs(
 			}
 
 			scAddress := event.Topics[0]
+			if !bytes.Equal(event.Address, scAddress) {
+				continue
+			}
+			if aap.shardCoordinator.ComputeId(scAddress) != selfShardID {
+				continue
+			}
+
 			aap.addAddressWithBalanceChangeInMap(scAddress, markedAlteredAccounts, false)
 		}
 	}

--- a/outport/process/alteredaccounts/alteredAccountsProvider.go
+++ b/outport/process/alteredaccounts/alteredAccountsProvider.go
@@ -285,12 +285,17 @@ func (aap *alteredAccountsProvider) extractAddressesWithBalanceChange(
 
 func (aap *alteredAccountsProvider) extractAddressesFromLogs(
 	logs []*transaction.LogData,
-	markedAlteredAccounts map[string]*markedAlteredAccount) {
+	markedAlteredAccounts map[string]*markedAlteredAccount,
+) {
 	for _, logEvent := range logs {
-		if logEvent.Log == nil {
+		if logEvent.Log == nil || check.IfNil(logEvent.Log) {
 			continue
 		}
 		for _, event := range logEvent.Log.Events {
+			if check.IfNil(event) {
+				continue
+			}
+
 			if string(event.Identifier) != core.SCDeployIdentifier {
 				continue
 			}

--- a/outport/process/alteredaccounts/alteredAccountsProvider_test.go
+++ b/outport/process/alteredaccounts/alteredAccountsProvider_test.go
@@ -1499,6 +1499,157 @@ func textExtractAlteredAccountsFromPoolTransactionValueNil(t *testing.T) {
 	}, res)
 }
 
+func TestAlteredAccountsProvider_ExtractAddressesFromLogs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil logs should work", func(t *testing.T) {
+		t.Parallel()
+
+		args := getMockArgs()
+		aap, _ := NewAlteredAccountsProvider(args)
+
+		markedAccounts := make(map[string]*markedAlteredAccount)
+		aap.extractAddressesFromLogs(nil, markedAccounts)
+		require.Empty(t, markedAccounts)
+	})
+
+	t.Run("no sc deploy events should not add addresses", func(t *testing.T) {
+		t.Parallel()
+
+		args := getMockArgs()
+		aap, _ := NewAlteredAccountsProvider(args)
+
+		markedAccounts := make(map[string]*markedAlteredAccount)
+		aap.extractAddressesFromLogs([]*transaction.LogData{
+			{
+				TxHash: "hash0",
+				Log: &transaction.Log{
+					Address: []byte("addr"),
+					Events: []*transaction.Event{
+						{
+							Address:    []byte("addr"),
+							Identifier: []byte(core.BuiltInFunctionESDTTransfer),
+							Topics: [][]byte{
+								[]byte("token0"),
+							},
+						},
+					},
+				},
+			},
+		}, markedAccounts)
+		require.Empty(t, markedAccounts)
+	})
+
+	t.Run("sc deploy event with no topics should be skipped", func(t *testing.T) {
+		t.Parallel()
+
+		args := getMockArgs()
+		aap, _ := NewAlteredAccountsProvider(args)
+
+		markedAccounts := make(map[string]*markedAlteredAccount)
+		aap.extractAddressesFromLogs([]*transaction.LogData{
+			{
+				TxHash: "hash0",
+				Log: &transaction.Log{
+					Address: []byte("addr"),
+					Events: []*transaction.Event{
+						{
+							Address:    []byte("addr"),
+							Identifier: []byte(core.SCDeployIdentifier),
+						},
+					},
+				},
+			},
+		}, markedAccounts)
+		require.Empty(t, markedAccounts)
+	})
+
+	t.Run("sc deploy events should add addresses", func(t *testing.T) {
+		t.Parallel()
+
+		args := getMockArgs()
+		args.AddressConverter = testscommon.NewPubkeyConverterMock(3)
+		aap, _ := NewAlteredAccountsProvider(args)
+
+		markedAccounts := make(map[string]*markedAlteredAccount)
+		aap.extractAddressesFromLogs([]*transaction.LogData{
+			{
+				TxHash: "hash0",
+				Log: &transaction.Log{
+					Address: []byte("addr"),
+					Events: []*transaction.Event{
+						{
+							Address:    []byte("addr"),
+							Identifier: []byte(core.SCDeployIdentifier),
+							Topics: [][]byte{
+								[]byte("sc0"),
+							},
+						},
+					},
+				},
+			},
+			{
+				TxHash: "hash1",
+				Log: &transaction.Log{
+					Address: []byte("addr"),
+					Events: []*transaction.Event{
+						{
+							Address:    []byte("addr"),
+							Identifier: []byte(core.SCDeployIdentifier),
+							Topics: [][]byte{
+								[]byte("sc1"),
+							},
+						},
+						{
+							Address:    []byte("addr"),
+							Identifier: []byte("notASCDeploy"),
+							Topics: [][]byte{
+								[]byte("sc2"),
+							},
+						},
+					},
+				},
+			},
+		}, markedAccounts)
+
+		require.Len(t, markedAccounts, 2)
+		require.Contains(t, markedAccounts, "sc0")
+		require.Contains(t, markedAccounts, "sc1")
+		require.True(t, markedAccounts["sc0"].balanceChanged)
+		require.True(t, markedAccounts["sc1"].balanceChanged)
+		require.False(t, markedAccounts["sc0"].isSender)
+		require.False(t, markedAccounts["sc1"].isSender)
+	})
+
+	t.Run("sc deploy event with an invalid address should be skipped", func(t *testing.T) {
+		t.Parallel()
+
+		args := getMockArgs()
+		args.AddressConverter = testscommon.NewPubkeyConverterMock(32)
+		aap, _ := NewAlteredAccountsProvider(args)
+
+		markedAccounts := make(map[string]*markedAlteredAccount)
+		aap.extractAddressesFromLogs([]*transaction.LogData{
+			{
+				TxHash: "hash0",
+				Log: &transaction.Log{
+					Address: []byte("addr"),
+					Events: []*transaction.Event{
+						{
+							Address:    []byte("addr"),
+							Identifier: []byte(core.SCDeployIdentifier),
+							Topics: [][]byte{
+								[]byte("invalidLenAddress"),
+							},
+						},
+					},
+				},
+			},
+		}, markedAccounts)
+		require.Empty(t, markedAccounts)
+	})
+}
+
 func getMockArgs() ArgsAlteredAccountsProvider {
 	return ArgsAlteredAccountsProvider{
 		ShardCoordinator:       &testscommon.ShardsCoordinatorMock{},

--- a/outport/process/alteredaccounts/alteredAccountsProvider_test.go
+++ b/outport/process/alteredaccounts/alteredAccountsProvider_test.go
@@ -1509,7 +1509,7 @@ func TestAlteredAccountsProvider_ExtractAddressesFromLogs(t *testing.T) {
 		aap, _ := NewAlteredAccountsProvider(args)
 
 		markedAccounts := make(map[string]*markedAlteredAccount)
-		aap.extractAddressesFromLogs(nil, markedAccounts)
+		aap.extractAddressesFromLogs(0, nil, markedAccounts)
 		require.Empty(t, markedAccounts)
 	})
 
@@ -1520,7 +1520,7 @@ func TestAlteredAccountsProvider_ExtractAddressesFromLogs(t *testing.T) {
 		aap, _ := NewAlteredAccountsProvider(args)
 
 		markedAccounts := make(map[string]*markedAlteredAccount)
-		aap.extractAddressesFromLogs([]*transaction.LogData{
+		aap.extractAddressesFromLogs(0, []*transaction.LogData{
 			{
 				TxHash: "hash0",
 				Log: &transaction.Log{
@@ -1547,7 +1547,7 @@ func TestAlteredAccountsProvider_ExtractAddressesFromLogs(t *testing.T) {
 		aap, _ := NewAlteredAccountsProvider(args)
 
 		markedAccounts := make(map[string]*markedAlteredAccount)
-		aap.extractAddressesFromLogs([]*transaction.LogData{
+		aap.extractAddressesFromLogs(0, []*transaction.LogData{
 			{
 				TxHash: "hash0",
 				Log: &transaction.Log{
@@ -1572,14 +1572,14 @@ func TestAlteredAccountsProvider_ExtractAddressesFromLogs(t *testing.T) {
 		aap, _ := NewAlteredAccountsProvider(args)
 
 		markedAccounts := make(map[string]*markedAlteredAccount)
-		aap.extractAddressesFromLogs([]*transaction.LogData{
+		aap.extractAddressesFromLogs(0, []*transaction.LogData{
 			{
 				TxHash: "hash0",
 				Log: &transaction.Log{
-					Address: []byte("addr"),
+					Address: []byte("sc0"),
 					Events: []*transaction.Event{
 						{
-							Address:    []byte("addr"),
+							Address:    []byte("sc0"),
 							Identifier: []byte(core.SCDeployIdentifier),
 							Topics: [][]byte{
 								[]byte("sc0"),
@@ -1591,17 +1591,17 @@ func TestAlteredAccountsProvider_ExtractAddressesFromLogs(t *testing.T) {
 			{
 				TxHash: "hash1",
 				Log: &transaction.Log{
-					Address: []byte("addr"),
+					Address: []byte("sc1"),
 					Events: []*transaction.Event{
 						{
-							Address:    []byte("addr"),
+							Address:    []byte("sc1"),
 							Identifier: []byte(core.SCDeployIdentifier),
 							Topics: [][]byte{
 								[]byte("sc1"),
 							},
 						},
 						{
-							Address:    []byte("addr"),
+							Address:    []byte("sc2"),
 							Identifier: []byte("notASCDeploy"),
 							Topics: [][]byte{
 								[]byte("sc2"),
@@ -1629,17 +1629,79 @@ func TestAlteredAccountsProvider_ExtractAddressesFromLogs(t *testing.T) {
 		aap, _ := NewAlteredAccountsProvider(args)
 
 		markedAccounts := make(map[string]*markedAlteredAccount)
-		aap.extractAddressesFromLogs([]*transaction.LogData{
+		aap.extractAddressesFromLogs(0, []*transaction.LogData{
 			{
 				TxHash: "hash0",
 				Log: &transaction.Log{
-					Address: []byte("addr"),
+					Address: []byte("invalidLenAddress"),
 					Events: []*transaction.Event{
 						{
-							Address:    []byte("addr"),
+							Address:    []byte("invalidLenAddress"),
 							Identifier: []byte(core.SCDeployIdentifier),
 							Topics: [][]byte{
 								[]byte("invalidLenAddress"),
+							},
+						},
+					},
+				},
+			},
+		}, markedAccounts)
+		require.Empty(t, markedAccounts)
+	})
+
+	t.Run("sc deploy event with event address different than the first topic should be skipped", func(t *testing.T) {
+		t.Parallel()
+
+		args := getMockArgs()
+		args.AddressConverter = testscommon.NewPubkeyConverterMock(3)
+		aap, _ := NewAlteredAccountsProvider(args)
+
+		markedAccounts := make(map[string]*markedAlteredAccount)
+		aap.extractAddressesFromLogs(0, []*transaction.LogData{
+			{
+				TxHash: "hash0",
+				Log: &transaction.Log{
+					Address: []byte("sc0"),
+					Events: []*transaction.Event{
+						{
+							Address:    []byte("sc0"),
+							Identifier: []byte(core.SCDeployIdentifier),
+							Topics: [][]byte{
+								[]byte("sc1"),
+							},
+						},
+					},
+				},
+			},
+		}, markedAccounts)
+		require.Empty(t, markedAccounts)
+	})
+
+	t.Run("sc deploy event with address from another shard should be skipped", func(t *testing.T) {
+		t.Parallel()
+
+		args := getMockArgs()
+		args.AddressConverter = testscommon.NewPubkeyConverterMock(3)
+		args.ShardCoordinator = &testscommon.ShardsCoordinatorMock{
+			CurrentShard: 0,
+			ComputeIdCalled: func(address []byte) uint32 {
+				return 1
+			},
+		}
+		aap, _ := NewAlteredAccountsProvider(args)
+
+		markedAccounts := make(map[string]*markedAlteredAccount)
+		aap.extractAddressesFromLogs(0, []*transaction.LogData{
+			{
+				TxHash: "hash0",
+				Log: &transaction.Log{
+					Address: []byte("sc0"),
+					Events: []*transaction.Event{
+						{
+							Address:    []byte("sc0"),
+							Identifier: []byte(core.SCDeployIdentifier),
+							Topics: [][]byte{
+								[]byte("sc0"),
 							},
 						},
 					},


### PR DESCRIPTION
## Reasoning behind the pull request
- Fixed altered accounts detection for newly deployed smart contracts
- The altered accounts provider now scans transaction logs for `SCDeploy` events and marks the deployed contract address (first topic) as altered with balance change. Previously, newly deployed SCs were missed since they don't appear in tx senders/receivers.

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
